### PR TITLE
chore(#3): definir proveedor de mapas/geocoding y PoC de estimación de ruta

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -45,6 +45,8 @@ app/
   Policies/
   Enums/        # RideStatus, UserRole, etc. (enums nativos de PHP)
   DTOs/         # opcional, para pasar datos entre capas sin arrays
+  Services/     # clientes de proveedores externos (mapas, pagos): infraestructura,
+                # no casos de uso. Se consumen por interfaz desde las Actions.
 
 routes/
   api.php       # crear; todas las rutas de negocio van aquí, versionadas /api/v1
@@ -284,6 +286,73 @@ tabla `driver_profiles` para datos específicos del conductor.
 es el id de `User`), y `driver_profiles` mantiene la extensibilidad sin pre-optimizar
 una estructura multi-rol que todavía no existe en el producto.
 
+## Proveedor de mapas/geocoding (decidido en #3)
+
+**Decisión**: **Google Maps Platform** — Routes API v2 (`computeRoutes`) para
+distancia/duración y Geocoding API cuando haga falta resolver direcciones.
+
+> **Supuesto de región**: el backlog no declara en qué ciudades opera MotoYa. Esta
+> comparación asume ciudades intermedias de Colombia (mercado natural del moto-taxi).
+> Si la región resulta ser otra, el eje de cobertura hay que reevaluarlo; los ejes de
+> costo y de modo de dos ruedas no cambian.
+
+### Comparación
+
+| | Google Maps Platform | Mapbox | OpenRouteService / OSRM |
+|---|---|---|---|
+| Datos base | Propios | OSM + propios | OSM |
+| Modo moto | **Sí** (`TWO_WHEELER` en Routes API) | No: solo `driving`/`cycling`/`walking` | No como tal (perfiles `driving-car`/`cycling-*`) |
+| ETA con tráfico | Sí (`TRAFFIC_AWARE`) | Sí (`driving-traffic`) | No |
+| Cobertura de direcciones en ciudades intermedias de Colombia | La mejor de las tres | Buena en capitales, desigual fuera | Depende de qué tan mapeada esté la ciudad en OSM |
+| Costo por request | El más alto de los tres | Intermedio | Gratis (self-hosted: costo de infraestructura) |
+| Volumen gratuito mensual | Sí, acotado por API | Sí, más holgado | Plan gratuito con cuota diaria / ilimitado si se auto-hospeda |
+
+Las cifras exactas de precio y cuota gratuita cambian con frecuencia y no se copian
+acá para que no envejezcan mal: **confirmar en el tarifario del proveedor antes de
+contratar o de dimensionar el costo por viaje**. Lo que sí es estable —y es lo que
+sostiene la decisión— son las diferencias de la tabla que no son de precio.
+
+### Justificación
+
+1. **Modo de dos ruedas.** La Routes API tiene un modo de moto real. Es el único de
+   los tres candidatos que lo tiene, y es exactamente el vehículo del producto:
+   rutear una moto como si fuera un auto sobreestima tiempo y distancia, y eso entra
+   directo en la tarifa que ve el pasajero.
+2. **Calidad del geocoding donde opera el moto-taxi.** El moto-taxi es fuerte en
+   ciudades intermedias, que es justo donde la cobertura OSM es más despareja. Un
+   geocoding equivocado no degrada la experiencia: cancela el viaje.
+3. **Tráfico.** Parte de la tarifa es tiempo; sin ETA con tráfico, la estimación en
+   hora pico se separa sistemáticamente de la realidad.
+
+El costo es el precio a pagar por lo anterior, y es un riesgo real a volumen. Se
+mitiga así:
+
+- **Field mask mínimo** (`routes.distanceMeters,routes.duration`): en la Routes API el
+  SKU facturado depende de los campos pedidos, así que no se piden polylines ni tramos
+  mientras no se usen.
+- **La decisión es reversible por diseño**: todo el sistema depende de la interfaz
+  `App\Services\Maps\RouteEstimator`, nunca de la implementación. Cambiar de proveedor
+  es escribir otra implementación y cambiar `MAPS_PROVIDER`.
+- **Segunda opción documentada**: si el costo por viaje deja de cerrar, el reemplazo es
+  Mapbox (o un OSRM propio para el cálculo de ruta, dejando el geocoding en Google), y
+  se acepta perder el modo moto a cambio.
+
+### Integración
+
+- Configuración en [`config/maps.php`](../config/maps.php); variables en `.env.example`
+  (`MAPS_PROVIDER`, `GOOGLE_MAPS_API_KEY`, `GOOGLE_MAPS_TIMEOUT`). La API key no tiene
+  default: se restringe por API y por IP en cada entorno, y nunca se commitea.
+- Los clientes de proveedores externos viven en **`app/Services/{Dominio}/`**: son
+  infraestructura (hablan HTTP con un tercero), no casos de uso, así que no son
+  Actions. Una Action del dominio —el motor de tarifa, por ejemplo— recibe el
+  `RouteEstimator` por constructor y no sabe qué proveedor hay detrás.
+- Prueba de concepto: `php artisan maps:estimate "<lat,lng>" "<lat,lng>"` consulta al
+  proveedor real con la key configurada. Los tests cubren el contrato con `Http::fake()`;
+  el CI no llama a la API real (no tiene credenciales y gastaría cuota en cada corrida).
+
+**Fuera de alcance de #3**: el uso productivo de estas estimaciones dentro del cálculo
+de tarifa, que es el issue #4.
+
 ## Pendiente de decidir (no bloquea empezar)
 
-- Cálculo de tarifas (por distancia/tiempo) y proveedor de mapas/geocoding.
+- Cálculo de tarifas (por distancia/tiempo): fórmula, tarifa mínima y redondeo.

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,16 @@ JWT_TTL=15
 # Ventana para renovar un token ya expirado, en minutos (14 días).
 JWT_REFRESH_TTL=20160
 
+# Proveedor de mapas/geocoding (decidido en #3, ver .claude/STANDARDS.md).
+MAPS_PROVIDER=google
+# API key de Google Maps Platform con la Routes API habilitada. Se deja vacía:
+# cada entorno usa su propia key, restringida por API y por IP del servidor.
+GOOGLE_MAPS_API_KEY=
+# Timeout en segundos de la llamada al proveedor.
+GOOGLE_MAPS_TIMEOUT=5
+# Solo se sobreescribe para apuntar a un mock/proxy en entornos de prueba.
+# GOOGLE_MAPS_ROUTES_ENDPOINT=https://routes.googleapis.com/directions/v2:computeRoutes
+
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database

--- a/app/Console/Commands/EstimateRouteCommand.php
+++ b/app/Console/Commands/EstimateRouteCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\DTOs\Coordinates;
+use App\Exceptions\RouteEstimationFailed;
+use App\Services\Maps\RouteEstimator;
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+
+/**
+ * Prueba de concepto del proveedor de mapas (issue #3).
+ *
+ * Es el único punto del sistema que hoy golpea al proveedor de verdad: sirve
+ * para confirmar, con una API key real, que se obtiene distancia y tiempo
+ * entre dos coordenadas antes de que el motor de tarifa (issue #4) dependa de
+ * ello. Vive en consola y no en la API a propósito — la integración productiva
+ * queda fuera del alcance de este issue.
+ *
+ *   php artisan maps:estimate "10.3910,-75.4794" "10.4236,-75.5378"
+ */
+final class EstimateRouteCommand extends Command
+{
+    protected $signature = 'maps:estimate
+                            {origin : Coordenada de origen, formato "lat,lng"}
+                            {destination : Coordenada de destino, formato "lat,lng"}';
+
+    protected $description = 'Consulta al proveedor de mapas configurado la distancia y el tiempo estimado entre dos coordenadas.';
+
+    public function handle(RouteEstimator $estimator): int
+    {
+        try {
+            $estimate = $estimator->estimate(
+                Coordinates::fromString((string) $this->argument('origin')),
+                Coordinates::fromString((string) $this->argument('destination')),
+            );
+        } catch (InvalidArgumentException|RouteEstimationFailed $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->components->twoColumnDetail('Proveedor', (string) config('maps.provider'));
+        $this->components->twoColumnDetail('Distancia', "{$estimate->distanceMeters} m");
+        $this->components->twoColumnDetail('Duración', "{$estimate->durationSeconds} s");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/DTOs/Coordinates.php
+++ b/app/DTOs/Coordinates.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use InvalidArgumentException;
+
+/**
+ * Un punto geográfico validado.
+ *
+ * Existe para que origen y destino no viajen como dos floats sueltos que
+ * cualquier capa pueda invertir sin que nadie se entere, y para que un par de
+ * coordenadas imposible se rechace en el borde y no en la respuesta del
+ * proveedor de mapas.
+ */
+final readonly class Coordinates
+{
+    public function __construct(
+        public float $latitude,
+        public float $longitude,
+    ) {
+        if ($latitude < -90.0 || $latitude > 90.0) {
+            throw new InvalidArgumentException("Latitud fuera de rango: {$latitude} (debe estar entre -90 y 90).");
+        }
+
+        if ($longitude < -180.0 || $longitude > 180.0) {
+            throw new InvalidArgumentException("Longitud fuera de rango: {$longitude} (debe estar entre -180 y 180).");
+        }
+    }
+
+    /**
+     * Construye el par desde el formato `"lat,lng"`.
+     *
+     * Solo lo usa la entrada por consola (`maps:estimate`); los endpoints de la
+     * API reciben latitud y longitud como campos separados y validados por su
+     * Form Request.
+     *
+     * @throws InvalidArgumentException si el texto no tiene la forma esperada.
+     */
+    public static function fromString(string $value): self
+    {
+        if (preg_match('/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/', $value, $matches) !== 1) {
+            throw new InvalidArgumentException("Coordenada inválida: '{$value}'. Formato esperado: 'lat,lng'.");
+        }
+
+        return new self((float) $matches[1], (float) $matches[2]);
+    }
+}

--- a/app/DTOs/RouteEstimate.php
+++ b/app/DTOs/RouteEstimate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Distancia y duración estimadas de un trayecto, ya normalizadas a unidades
+ * del sistema internacional.
+ *
+ * Se normaliza acá y no en quien consume el dato para que el motor de tarifa
+ * (issue #4) no tenga que saber si el proveedor de turno devolvió metros,
+ * millas o una duración con formato propio.
+ */
+final readonly class RouteEstimate
+{
+    public function __construct(
+        public int $distanceMeters,
+        public int $durationSeconds,
+    ) {}
+}

--- a/app/Exceptions/RouteEstimationFailed.php
+++ b/app/Exceptions/RouteEstimationFailed.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * El proveedor de mapas no pudo entregar una estimación utilizable.
+ *
+ * Agrupa los tres modos de fallo bajo un mismo tipo para que quien consuma el
+ * estimador no tenga que distinguir entre excepciones del cliente HTTP y
+ * respuestas 200 con un cuerpo inesperado: para el negocio, en los tres casos
+ * no hay tarifa que mostrar.
+ */
+final class RouteEstimationFailed extends RuntimeException
+{
+    public static function providerRejectedRequest(string $provider, int $status): self
+    {
+        return new self("El proveedor de mapas '{$provider}' respondió con HTTP {$status}.");
+    }
+
+    public static function providerUnreachable(string $provider, string $reason): self
+    {
+        return new self("No se pudo contactar al proveedor de mapas '{$provider}': {$reason}");
+    }
+
+    public static function noRouteAvailable(string $provider): self
+    {
+        return new self("El proveedor de mapas '{$provider}' no devolvió ninguna ruta entre las coordenadas dadas.");
+    }
+
+    public static function unreadableResponse(string $provider, string $detail): self
+    {
+        return new self("Respuesta inesperada del proveedor de mapas '{$provider}': {$detail}");
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,14 @@
 
 namespace App\Providers;
 
+use App\Services\Maps\GoogleRoutesEstimator;
+use App\Services\Maps\RouteEstimator;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -14,7 +18,34 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->registerRouteEstimator();
+    }
+
+    /**
+     * Resuelve el proveedor de mapas configurado (ver config/maps.php y la
+     * decisión en .claude/STANDARDS.md).
+     *
+     * La resolución es diferida (`singleton` con closure): la API key solo se
+     * exige cuando alguien pide de verdad una estimación, así que el resto de
+     * la aplicación —y la suite de tests que no toca mapas— arranca sin
+     * necesidad de credenciales del proveedor.
+     */
+    private function registerRouteEstimator(): void
+    {
+        $this->app->singleton(RouteEstimator::class, static function (): RouteEstimator {
+            $provider = Config::string('maps.provider');
+
+            return match ($provider) {
+                'google' => new GoogleRoutesEstimator(
+                    apiKey: Config::string('maps.google.key'),
+                    endpoint: Config::string('maps.google.routes_endpoint'),
+                    timeoutSeconds: Config::integer('maps.google.timeout'),
+                ),
+                default => throw new InvalidArgumentException(
+                    "Proveedor de mapas no soportado: '{$provider}' (revisa MAPS_PROVIDER)."
+                ),
+            };
+        });
     }
 
     /**

--- a/app/Services/Maps/GoogleRoutesEstimator.php
+++ b/app/Services/Maps/GoogleRoutesEstimator.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Maps;
+
+use App\DTOs\Coordinates;
+use App\DTOs\RouteEstimate;
+use App\Exceptions\RouteEstimationFailed;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Estimador contra Google Maps Platform — Routes API v2 (`computeRoutes`).
+ *
+ * Dos detalles del request no son negociables para MotoYa:
+ *
+ * - `travelMode: TWO_WHEELER` — es el modo de moto de la Routes API. Sin él,
+ *   la ruta se calcula como si fuera un auto y las estimaciones quedan largas
+ *   en las ciudades donde el moto-taxi tiene sentido.
+ * - `X-Goog-FieldMask` — la Routes API es obligatoria en este header y además
+ *   el SKU (y por lo tanto el precio por request) depende de los campos que se
+ *   pidan. Se piden solo distancia y duración a propósito: pedir el polyline o
+ *   los tramos sube de tier sin que hoy los usemos.
+ */
+final readonly class GoogleRoutesEstimator implements RouteEstimator
+{
+    private const PROVIDER = 'google';
+
+    private const FIELD_MASK = 'routes.distanceMeters,routes.duration';
+
+    public function __construct(
+        private string $apiKey,
+        private string $endpoint,
+        private int $timeoutSeconds,
+    ) {}
+
+    public function estimate(Coordinates $origin, Coordinates $destination): RouteEstimate
+    {
+        try {
+            $response = Http::timeout($this->timeoutSeconds)
+                ->withHeaders([
+                    'X-Goog-Api-Key' => $this->apiKey,
+                    'X-Goog-FieldMask' => self::FIELD_MASK,
+                ])
+                ->post($this->endpoint, [
+                    'origin' => $this->waypoint($origin),
+                    'destination' => $this->waypoint($destination),
+                    'travelMode' => 'TWO_WHEELER',
+                    'routingPreference' => 'TRAFFIC_AWARE',
+                    'units' => 'METRIC',
+                ]);
+        } catch (ConnectionException $e) {
+            throw RouteEstimationFailed::providerUnreachable(self::PROVIDER, $e->getMessage());
+        }
+
+        if ($response->failed()) {
+            throw RouteEstimationFailed::providerRejectedRequest(self::PROVIDER, $response->status());
+        }
+
+        return $this->toEstimate($response->json('routes.0'));
+    }
+
+    /**
+     * @return array<string, array<string, array<string, float>>>
+     */
+    private function waypoint(Coordinates $point): array
+    {
+        return [
+            'location' => [
+                'latLng' => [
+                    'latitude' => $point->latitude,
+                    'longitude' => $point->longitude,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * La Routes API responde 200 con `{}` cuando no existe ruta entre ambos
+     * puntos (p. ej. una coordenada en el mar), así que la ausencia de ruta se
+     * detecta acá y no en el código de estado.
+     */
+    private function toEstimate(mixed $route): RouteEstimate
+    {
+        if (! is_array($route)) {
+            throw RouteEstimationFailed::noRouteAvailable(self::PROVIDER);
+        }
+
+        if (! isset($route['distanceMeters'], $route['duration'])) {
+            throw RouteEstimationFailed::unreadableResponse(
+                self::PROVIDER,
+                'la ruta no trae distanceMeters y/o duration.',
+            );
+        }
+
+        return new RouteEstimate(
+            distanceMeters: (int) $route['distanceMeters'],
+            durationSeconds: $this->secondsFrom($route['duration']),
+        );
+    }
+
+    /**
+     * `duration` viene como un Duration de protobuf serializado a string
+     * (`"842s"`, a veces con fracción), no como un número.
+     */
+    private function secondsFrom(mixed $duration): int
+    {
+        if (! is_string($duration) || preg_match('/^(\d+(?:\.\d+)?)s$/', $duration, $matches) !== 1) {
+            throw RouteEstimationFailed::unreadableResponse(
+                self::PROVIDER,
+                'duration no tiene el formato "<segundos>s".',
+            );
+        }
+
+        return (int) round((float) $matches[1]);
+    }
+}

--- a/app/Services/Maps/RouteEstimator.php
+++ b/app/Services/Maps/RouteEstimator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Maps;
+
+use App\DTOs\Coordinates;
+use App\DTOs\RouteEstimate;
+use App\Exceptions\RouteEstimationFailed;
+
+/**
+ * Contrato con el proveedor de mapas para estimar un trayecto.
+ *
+ * El resto de la aplicación depende de esta interfaz y nunca de una
+ * implementación concreta: la decisión de proveedor está documentada en
+ * .claude/STANDARDS.md, pero es reversible, y el costo por request es
+ * justamente el motivo por el que conviene poder cambiarla sin tocar el
+ * motor de tarifa ni los endpoints.
+ */
+interface RouteEstimator
+{
+    /**
+     * @throws RouteEstimationFailed si el proveedor falla o no hay ruta entre
+     *                               ambos puntos.
+     */
+    public function estimate(Coordinates $origin, Coordinates $destination): RouteEstimate;
+}

--- a/config/maps.php
+++ b/config/maps.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Proveedor de mapas
+    |--------------------------------------------------------------------------
+    |
+    | Proveedor externo que resuelve distancia y tiempo estimado entre dos
+    | coordenadas. La decisión vigente y su justificación están en
+    | .claude/STANDARDS.md ("Proveedor de mapas/geocoding"). El valor se lee
+    | al resolver App\Services\Maps\RouteEstimator en el contenedor, así que
+    | cambiar de proveedor no toca a quien lo consume.
+    |
+    */
+
+    'provider' => env('MAPS_PROVIDER', 'google'),
+
+    'google' => [
+
+        // Sin default a propósito: cada entorno usa su propia API key
+        // restringida. La app falla al resolver el estimador si falta, en vez
+        // de mandar requests anónimos que el proveedor rechaza.
+        'key' => env('GOOGLE_MAPS_API_KEY'),
+
+        // Routes API v2 (computeRoutes). Configurable para poder apuntar a un
+        // mock/proxy en entornos de prueba sin tocar código.
+        'routes_endpoint' => env(
+            'GOOGLE_MAPS_ROUTES_ENDPOINT',
+            'https://routes.googleapis.com/directions/v2:computeRoutes',
+        ),
+
+        // Segundos de espera antes de darse por vencido. Corto a propósito:
+        // esta llamada ocurre mientras el pasajero espera la tarifa estimada
+        // en pantalla.
+        'timeout' => (int) env('GOOGLE_MAPS_TIMEOUT', 5),
+
+    ],
+
+];

--- a/tests/Feature/Maps/EstimateRouteCommandTest.php
+++ b/tests/Feature/Maps/EstimateRouteCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Maps;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * El comando es la prueba de concepto del issue #3 y el único punto que hoy
+ * llama al proveedor, así que se cubre completo: parseo de argumentos,
+ * resolución del proveedor configurado y presentación del resultado.
+ */
+class EstimateRouteCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('maps.provider', 'google');
+        Config::set('maps.google.key', 'test-key');
+    }
+
+    public function test_prints_the_distance_and_duration_of_the_route(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response([
+                'routes' => [['distanceMeters' => 7421, 'duration' => '842s']],
+            ]),
+        ]);
+
+        $this->artisan('maps:estimate', [
+            'origin' => '10.3910,-75.4794',
+            'destination' => '10.4236,-75.5378',
+        ])
+            ->expectsOutputToContain('7421 m')
+            ->expectsOutputToContain('842 s')
+            ->assertSuccessful();
+    }
+
+    public function test_fails_with_a_readable_message_when_a_coordinate_is_malformed(): void
+    {
+        Http::fake();
+
+        $this->artisan('maps:estimate', [
+            'origin' => 'cartagena',
+            'destination' => '10.4236,-75.5378',
+        ])
+            ->expectsOutputToContain('Coordenada inválida')
+            ->assertFailed();
+
+        Http::assertNothingSent();
+    }
+
+    public function test_fails_with_a_readable_message_when_the_provider_rejects_the_request(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response(['error' => ['message' => 'API key not valid']], 403),
+        ]);
+
+        $this->artisan('maps:estimate', [
+            'origin' => '10.3910,-75.4794',
+            'destination' => '10.4236,-75.5378',
+        ])
+            ->expectsOutputToContain('HTTP 403')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/Maps/RouteEstimatorBindingTest.php
+++ b/tests/Feature/Maps/RouteEstimatorBindingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Maps;
+
+use App\Services\Maps\GoogleRoutesEstimator;
+use App\Services\Maps\RouteEstimator;
+use Illuminate\Support\Facades\Config;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * El contenedor es el único lugar que sabe qué proveedor está configurado; el
+ * resto del sistema pide la interfaz. Estos tests cubren esa resolución.
+ */
+class RouteEstimatorBindingTest extends TestCase
+{
+    public function test_resolves_the_google_implementation_when_it_is_the_configured_provider(): void
+    {
+        Config::set('maps.provider', 'google');
+        Config::set('maps.google.key', 'test-key');
+
+        $this->assertInstanceOf(GoogleRoutesEstimator::class, $this->app->make(RouteEstimator::class));
+    }
+
+    public function test_fails_loudly_when_the_configured_provider_is_unknown(): void
+    {
+        Config::set('maps.provider', 'waze');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Proveedor de mapas no soportado');
+
+        $this->app->make(RouteEstimator::class);
+    }
+
+    public function test_fails_loudly_when_the_api_key_is_missing(): void
+    {
+        Config::set('maps.provider', 'google');
+        Config::set('maps.google.key', null);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->app->make(RouteEstimator::class);
+    }
+}

--- a/tests/Unit/DTOs/CoordinatesTest.php
+++ b/tests/Unit/DTOs/CoordinatesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTOs;
+
+use App\DTOs\Coordinates;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CoordinatesTest extends TestCase
+{
+    public function test_accepts_a_valid_point(): void
+    {
+        $point = new Coordinates(10.3910, -75.4794);
+
+        $this->assertSame(10.3910, $point->latitude);
+        $this->assertSame(-75.4794, $point->longitude);
+    }
+
+    public function test_accepts_the_range_boundaries(): void
+    {
+        $point = new Coordinates(-90.0, 180.0);
+
+        $this->assertSame(-90.0, $point->latitude);
+        $this->assertSame(180.0, $point->longitude);
+    }
+
+    public function test_rejects_latitude_out_of_range(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Latitud fuera de rango');
+
+        new Coordinates(90.1, 0.0);
+    }
+
+    public function test_rejects_longitude_out_of_range(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Longitud fuera de rango');
+
+        new Coordinates(0.0, -180.1);
+    }
+
+    public function test_parses_the_lat_lng_string_format(): void
+    {
+        $point = Coordinates::fromString(' 10.3910 , -75.4794 ');
+
+        $this->assertSame(10.3910, $point->latitude);
+        $this->assertSame(-75.4794, $point->longitude);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedStrings(): array
+    {
+        return [
+            'sin coma' => ['10.3910 -75.4794'],
+            'un solo valor' => ['10.3910'],
+            'tres valores' => ['10.3910,-75.4794,5'],
+            'texto' => ['cartagena'],
+            'vacío' => [''],
+        ];
+    }
+
+    #[DataProvider('malformedStrings')]
+    public function test_rejects_a_malformed_string(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Coordenada inválida');
+
+        Coordinates::fromString($value);
+    }
+
+    public function test_rejects_a_string_whose_values_are_out_of_range(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Latitud fuera de rango');
+
+        Coordinates::fromString('100,0');
+    }
+}

--- a/tests/Unit/Services/Maps/GoogleRoutesEstimatorTest.php
+++ b/tests/Unit/Services/Maps/GoogleRoutesEstimatorTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Maps;
+
+use App\DTOs\Coordinates;
+use App\Exceptions\RouteEstimationFailed;
+use App\Services\Maps\GoogleRoutesEstimator;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Prueba de concepto del issue #3: confirma que se obtiene distancia y tiempo
+ * entre dos coordenadas con la Routes API de Google.
+ *
+ * El proveedor se simula con `Http::fake()` — la comprobación contra la API
+ * real se hace a mano con `php artisan maps:estimate` y una key válida, porque
+ * el CI no tiene credenciales ni debería gastar cuota en cada corrida. Lo que
+ * sí se verifica acá, y es lo que el CI puede proteger, es el contrato: qué se
+ * manda (modo moto, field mask, coordenadas en orden) y cómo se interpreta lo
+ * que vuelve.
+ */
+class GoogleRoutesEstimatorTest extends TestCase
+{
+    private const ENDPOINT = 'https://routes.googleapis.com/directions/v2:computeRoutes';
+
+    private function estimator(): GoogleRoutesEstimator
+    {
+        return new GoogleRoutesEstimator('test-key', self::ENDPOINT, 5);
+    }
+
+    private function origin(): Coordinates
+    {
+        return new Coordinates(10.3910, -75.4794);
+    }
+
+    private function destination(): Coordinates
+    {
+        return new Coordinates(10.4236, -75.5378);
+    }
+
+    public function test_returns_distance_and_duration_from_the_provider_response(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response([
+                'routes' => [
+                    ['distanceMeters' => 7421, 'duration' => '842s'],
+                ],
+            ]),
+        ]);
+
+        $estimate = $this->estimator()->estimate($this->origin(), $this->destination());
+
+        $this->assertSame(7421, $estimate->distanceMeters);
+        $this->assertSame(842, $estimate->durationSeconds);
+    }
+
+    public function test_sends_both_coordinates_in_two_wheeler_mode_with_a_minimal_field_mask(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response([
+                'routes' => [
+                    ['distanceMeters' => 7421, 'duration' => '842s'],
+                ],
+            ]),
+        ]);
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+
+        Http::assertSent(function (Request $request): bool {
+            $body = $request->data();
+
+            return $request->url() === self::ENDPOINT
+                && $request->hasHeader('X-Goog-Api-Key', 'test-key')
+                && $request->hasHeader('X-Goog-FieldMask', 'routes.distanceMeters,routes.duration')
+                && $body['travelMode'] === 'TWO_WHEELER'
+                && $body['origin']['location']['latLng'] === ['latitude' => 10.3910, 'longitude' => -75.4794]
+                && $body['destination']['location']['latLng'] === ['latitude' => 10.4236, 'longitude' => -75.5378];
+        });
+    }
+
+    public function test_rounds_a_fractional_duration_to_whole_seconds(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response([
+                'routes' => [
+                    ['distanceMeters' => 100, 'duration' => '842.6s'],
+                ],
+            ]),
+        ]);
+
+        $estimate = $this->estimator()->estimate($this->origin(), $this->destination());
+
+        $this->assertSame(843, $estimate->durationSeconds);
+    }
+
+    public function test_fails_when_the_provider_returns_an_error_status(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response(['error' => ['message' => 'API key not valid']], 403),
+        ]);
+
+        $this->expectException(RouteEstimationFailed::class);
+        $this->expectExceptionMessage('respondió con HTTP 403');
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+    }
+
+    public function test_fails_when_there_is_no_route_between_both_points(): void
+    {
+        // La Routes API responde 200 con un cuerpo vacío cuando no hay ruta.
+        Http::fake([self::ENDPOINT => Http::response([])]);
+
+        $this->expectException(RouteEstimationFailed::class);
+        $this->expectExceptionMessage('no devolvió ninguna ruta');
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+    }
+
+    public function test_fails_when_the_route_has_no_distance_or_duration(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response(['routes' => [['distanceMeters' => 7421]]]),
+        ]);
+
+        $this->expectException(RouteEstimationFailed::class);
+        $this->expectExceptionMessage('distanceMeters y/o duration');
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+    }
+
+    public function test_fails_when_the_duration_format_is_unexpected(): void
+    {
+        Http::fake([
+            self::ENDPOINT => Http::response([
+                'routes' => [['distanceMeters' => 7421, 'duration' => 842]],
+            ]),
+        ]);
+
+        $this->expectException(RouteEstimationFailed::class);
+        $this->expectExceptionMessage('duration no tiene el formato');
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+    }
+
+    public function test_fails_when_the_provider_is_unreachable(): void
+    {
+        Http::fake(fn () => throw new ConnectionException('cURL error 28: timeout'));
+
+        $this->expectException(RouteEstimationFailed::class);
+        $this->expectExceptionMessage('No se pudo contactar');
+
+        $this->estimator()->estimate($this->origin(), $this->destination());
+    }
+}


### PR DESCRIPTION
Closes #3

## Qué hace

Cierra la decisión pendiente de proveedor de mapas y deja una prueba de concepto
funcionando, sin integrarla todavía en el cálculo de tarifa (eso es #4, y está
explícitamente fuera del alcance del issue).

**Decisión: Google Maps Platform — Routes API v2 (`computeRoutes`).** La comparación
con Mapbox y OpenRouteService (datos base, modo moto, tráfico, cobertura, costo) y la
justificación quedan en `.claude/STANDARDS.md`. Los tres argumentos que la sostienen:

1. Es el único de los tres con **modo de dos ruedas real** (`TWO_WHEELER`). Rutear una
   moto como auto sobreestima distancia y tiempo, y eso entra directo en la tarifa.
2. Mejor **geocoding en ciudades intermedias**, que es donde el moto-taxi opera y donde
   la cobertura OSM es más despareja.
3. **ETA con tráfico**, necesario porque parte de la tarifa es tiempo.

El costo —que es el punto débil de Google— se mitiga con un field mask mínimo (el SKU
facturado depende de los campos pedidos) y, sobre todo, haciendo la decisión reversible:
todo depende de la interfaz `App\Services\Maps\RouteEstimator`, nunca de la
implementación concreta. Cambiar de proveedor es otra implementación + `MAPS_PROVIDER`.

Archivos:

- `config/maps.php` + variables en `.env.example` (`MAPS_PROVIDER`,
  `GOOGLE_MAPS_API_KEY` sin valor, `GOOGLE_MAPS_TIMEOUT`).
- `App\Services\Maps\RouteEstimator` (interfaz) y `GoogleRoutesEstimator`
  (implementación); binding diferido en `AppServiceProvider`.
- DTOs `Coordinates` (valida rangos) y `RouteEstimate` (metros + segundos).
- `App\Exceptions\RouteEstimationFailed` para los cuatro modos de fallo del proveedor.
- `php artisan maps:estimate "<lat,lng>" "<lat,lng>"` — la PoC, en consola y no en la
  API, porque la integración productiva está fuera de alcance.

## Cómo se probó

- `php artisan test` — 53 tests, 117 assertions, en verde.
- `./vendor/bin/pint --test` — sin errores.
- `composer stan` (PHPStan/Larastan nivel 5) — 0 errores. *Nota*: localmente crashea con
  el `memory_limit` de 128M por defecto de PHP; se corrió con `--memory-limit=1G`. En CI
  `setup-php` no impone ese límite.
- `complexity_check.py`, `architecture_check.py`, `security_check.py` — sin hallazgos
  (7 avisos preexistentes de `.env.example`, ninguno de este cambio).
- Conformidad OpenAPI estática y dinámica — OK; este PR no agrega rutas.

Los tests cubren el contrato con el proveedor vía `Http::fake()`: qué se manda (modo
moto, field mask, coordenadas en orden) y cómo se interpreta lo que vuelve, incluyendo
los caminos de error — HTTP 4xx/5xx, 200 sin ruta (lo que devuelve la Routes API cuando
no hay trayecto), ruta sin `distanceMeters`/`duration`, `duration` con formato
inesperado, y proveedor inalcanzable.

**Lo que los tests no prueban**: que la API real responda. Eso requiere una key válida y
se verifica a mano con `maps:estimate`; el CI no tiene credenciales y no debería gastar
cuota en cada corrida. Es la limitación conocida de esta PoC.

## Decisiones y riesgos

- **Supuesto de región**: el issue pide comparar cobertura "en la región de operación de
  MotoYa", pero el backlog no dice cuál es. Se asumió **ciudades intermedias de
  Colombia** y el supuesto quedó escrito en `STANDARDS.md`. Si la región es otra, hay que
  reevaluar el eje de cobertura; los ejes de modo moto y costo no cambian.
- **Precios fuera del documento a propósito.** Las cifras exactas de tarifa y cuota
  gratuita cambian seguido; documentarlas habría envejecido mal y dado falsa precisión.
  Se documentan las diferencias estables y se deja anotado que hay que confirmar el
  tarifario antes de contratar.
- **Carpeta nueva `app/Services/`**, no contemplada antes en `STANDARDS.md`. Un cliente
  de un proveedor externo es infraestructura, no un caso de uso, así que no encaja como
  Action; la estructura y el criterio quedaron documentados.
- **`TRAFFIC_AWARE` con `TWO_WHEELER`**: elegido por la precisión del ETA. Si el costo o
  la latencia del tier con tráfico no cierran, bajar a `TRAFFIC_UNAWARE` es un cambio de
  una línea.
- **El binding es diferido**: la key solo se exige cuando alguien pide una estimación de
  verdad, así que la app y la suite de tests arrancan sin credenciales del proveedor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)