### PR TITLE
feat(#4): implementar motor de cálculo de tarifa por distancia y tiempo

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -353,6 +353,81 @@ mitiga así:
 **Fuera de alcance de #3**: el uso productivo de estas estimaciones dentro del cálculo
 de tarifa, que es el issue #4.
 
+## Cálculo de tarifas (decidido en #4)
+
+**Decisión**: tarifa base + distancia + tiempo, con piso mínimo y redondeo hacia arriba.
+La implementa `App\Actions\Payments\CalculateFareAction`, que es la **única** fuente de
+verdad del monto: la tarifa estimada que se le muestra al pasajero antes de pedir el
+viaje y el cobro al terminarlo salen de la misma Action con los mismos parámetros, y lo
+único que cambia entre ambos momentos es el `RouteEstimate` que recibe (el estimado del
+proveedor de mapas primero, el trayecto realmente recorrido después).
+
+### Fórmula
+
+```
+distancia = round(metros      × per_kilometer / 1000)
+tiempo    = round(segundos    × per_minute    / 60)
+espera    = round(seg_espera  × per_waiting_minute / 60)
+
+subtotal  = base + distancia + tiempo + espera
+total     = ceil_al_múltiplo(max(subtotal, minimum), rounding_step)
+```
+
+| Parámetro | Default | Env | Qué cubre |
+|---|---|---|---|
+| `base` | 1500 | `FARE_BASE` | Cargo fijo por viaje: el desplazamiento del conductor hasta el punto de recogida. |
+| `per_kilometer` | 800 | `FARE_PER_KILOMETER` | Distancia recorrida. |
+| `per_minute` | 100 | `FARE_PER_MINUTE` | Tiempo en ruta. |
+| `per_waiting_minute` | 60 | `FARE_PER_WAITING_MINUTE` | Espera solicitada con el viaje ya aceptado. |
+| `minimum` | 3000 | `FARE_MINIMUM` | Piso del cobro. |
+| `rounding_step` | 50 | `FARE_ROUNDING_STEP` | Múltiplo al que se redondea el total. |
+| `currency` | `COP` | `FARE_CURRENCY` | Moneda (ISO 4217). |
+
+Los valores numéricos son un punto de partida a validar con el negocio, y por eso viven
+en [`config/fares.php`](../config/fares.php) y no en el código: ajustarlos no es un
+cambio de software. La **fórmula** sí es una decisión de arquitectura y cambiarla pasa
+por este documento.
+
+### Reglas que sostienen la fórmula
+
+- **Se cobra distancia y tiempo, no uno u otro.** Sin el componente de tiempo, un
+  trayecto en hora pico paga lo mismo que el mismo trayecto a medianoche ocupando al
+  conductor el triple; sin el de distancia, un viaje largo y fluido queda regalado. La
+  duración viene del proveedor de mapas con tráfico (ver la sección anterior).
+- **Las fracciones se prorratean, no se redondean a la unidad completa**: 1500 m pagan
+  kilómetro y medio, no dos. Cobrar la unidad entera produce saltos de precio que el
+  pasajero percibe como arbitrarios entre dos destinos casi iguales.
+- **El mínimo se aplica antes del redondeo, y el redondeo es hacia arriba.** El mínimo
+  es un piso: un redondeo al múltiplo más cercano podría perforarlo.
+- **El paso de redondeo existe por el efectivo.** Buena parte de estos viajes se pagan
+  en efectivo y el vuelto tiene que existir físicamente. Por eso `minimum` debería ser
+  siempre múltiplo de `rounding_step` (lo verifica un test).
+- **La espera se cobra más barato que el minuto en ruta**: el conductor está detenido,
+  sin gastar combustible.
+
+### Dinero: enteros, nunca float
+
+Todos los montos son **enteros** en la unidad mínima de la moneda configurada — para COP
+esa unidad es el peso, que no tiene subunidad en circulación. Los float no representan
+dinero de forma exacta y el error se acumula justo donde más se nota (totales, cuadres,
+comisiones). Esto aplica también a las columnas de BD cuando lleguen los pagos: entero,
+no `float`/`double`.
+
+### Estructura
+
+- `App\DTOs\FareSchedule` — los parámetros vigentes, construidos desde `config/fares.php`
+  en `AppServiceProvider`. Valida en el constructor: una tarifa negativa o un paso de
+  redondeo en 0 revientan al resolver el servicio, no al cobrarle a un pasajero real.
+- `App\DTOs\FareBreakdown` — el resultado: total **y desglose**. El desglose no es
+  decorativo; cuando el cobro final no coincide con lo estimado (trayecto distinto,
+  espera) hay que poder explicar la diferencia sin recalcular a mano.
+- La Action recibe `RouteEstimate` y los segundos de espera. **No conoce HTTP ni el
+  modelo `Ride`**, así que sirve igual desde un controller, un job o un test.
+
+**Fuera de alcance de #4**: tarifas dinámicas por demanda (surge pricing), descuentos y
+promociones; y los endpoints que consumen este cálculo, que son las historias de tarifa
+estimada (#14) y pago del viaje (#25).
+
 ## Pendiente de decidir (no bloquea empezar)
 
-- Cálculo de tarifas (por distancia/tiempo): fórmula, tarifa mínima y redondeo.
+- Nada pendiente por ahora.

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,22 @@ GOOGLE_MAPS_TIMEOUT=5
 # Solo se sobreescribe para apuntar a un mock/proxy en entornos de prueba.
 # GOOGLE_MAPS_ROUTES_ENDPOINT=https://routes.googleapis.com/directions/v2:computeRoutes
 
+# Tarifa del viaje (decidida en #4, ver .claude/STANDARDS.md). Montos enteros
+# en la unidad mínima de FARE_CURRENCY; para COP esa unidad es el peso.
+FARE_CURRENCY=COP
+# Cargo fijo por viaje, cubre el desplazamiento hasta el punto de recogida.
+FARE_BASE=1500
+FARE_PER_KILOMETER=800
+# El minuto en ruta se cobra además de la distancia (la duración viene del
+# proveedor de mapas, con tráfico).
+FARE_PER_MINUTE=100
+# Espera con el viaje ya aceptado: más barata que el minuto en ruta.
+FARE_PER_WAITING_MINUTE=60
+# Piso del cobro, para que un viaje muy corto siga compensando al conductor.
+FARE_MINIMUM=3000
+# El total se redondea hacia arriba a un múltiplo de este paso (pago en efectivo).
+FARE_ROUNDING_STEP=50
+
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database

--- a/app/Actions/Payments/CalculateFareAction.php
+++ b/app/Actions/Payments/CalculateFareAction.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Payments;
+
+use App\DTOs\FareBreakdown;
+use App\DTOs\FareSchedule;
+use App\DTOs\RouteEstimate;
+use InvalidArgumentException;
+
+/**
+ * Calcula lo que cuesta un viaje a partir de su distancia y duración.
+ *
+ * Es la única fuente de verdad de la tarifa: la estimación que se le muestra
+ * al pasajero antes de pedir el viaje y el cobro al terminarlo salen de acá
+ * con los mismos parámetros, y lo único que cambia entre ambos momentos es el
+ * `RouteEstimate` que se le pasa (estimado del proveedor de mapas primero,
+ * trayecto realmente recorrido después). Si cada lado tuviera su propia
+ * fórmula, la diferencia entre lo prometido y lo cobrado sería un bug
+ * invisible hasta que el pasajero reclama.
+ *
+ * No conoce HTTP ni el modelo `Ride`: recibe el trayecto y la espera, y
+ * devuelve el desglose. Quien la invoque —controller, job o comando— se
+ * encarga de traducir eso a su propio formato.
+ */
+final readonly class CalculateFareAction
+{
+    private const SECONDS_PER_MINUTE = 60;
+
+    private const METERS_PER_KILOMETER = 1000;
+
+    public function __construct(private FareSchedule $schedule) {}
+
+    /**
+     * @param  RouteEstimate  $route  Distancia y duración del trayecto, estimadas o reales.
+     * @param  int  $waitingSeconds  Espera solicitada por el pasajero con el viaje ya aceptado,
+     *                               fuera de la duración del trayecto.
+     *
+     * @throws InvalidArgumentException si el trayecto o la espera traen valores negativos.
+     */
+    public function handle(RouteEstimate $route, int $waitingSeconds = 0): FareBreakdown
+    {
+        $this->assertNotNegative('la distancia del trayecto', $route->distanceMeters);
+        $this->assertNotNegative('la duración del trayecto', $route->durationSeconds);
+        $this->assertNotNegative('el tiempo de espera', $waitingSeconds);
+
+        $distance = $this->prorate($route->distanceMeters, $this->schedule->perKilometer, self::METERS_PER_KILOMETER);
+        $time = $this->prorate($route->durationSeconds, $this->schedule->perMinute, self::SECONDS_PER_MINUTE);
+        $waiting = $this->prorate($waitingSeconds, $this->schedule->perWaitingMinute, self::SECONDS_PER_MINUTE);
+
+        $subtotal = $this->schedule->base + $distance + $time + $waiting;
+        $minimumApplied = $subtotal < $this->schedule->minimum;
+
+        return new FareBreakdown(
+            currency: $this->schedule->currency,
+            base: $this->schedule->base,
+            distance: $distance,
+            time: $time,
+            waiting: $waiting,
+            subtotal: $subtotal,
+            total: $this->roundUpToStep(max($subtotal, $this->schedule->minimum)),
+            minimumApplied: $minimumApplied,
+        );
+    }
+
+    /**
+     * Cobra `$rate` por cada `$unit` de `$quantity`, prorrateando las
+     * fracciones en vez de cobrar la unidad completa: 1500 m pagan kilómetro y
+     * medio, no dos.
+     */
+    private function prorate(int $quantity, int $rate, int $unit): int
+    {
+        return (int) round($quantity * $rate / $unit);
+    }
+
+    /**
+     * Redondea hacia arriba, nunca hacia el múltiplo más cercano: el mínimo es
+     * un piso y el redondeo no puede perforarlo.
+     */
+    private function roundUpToStep(int $amount): int
+    {
+        $step = $this->schedule->roundingStep;
+
+        return intdiv($amount + $step - 1, $step) * $step;
+    }
+
+    private function assertNotNegative(string $name, int $value): void
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException("Valor negativo no admitido en {$name}: {$value}.");
+        }
+    }
+}

--- a/app/DTOs/FareBreakdown.php
+++ b/app/DTOs/FareBreakdown.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * El resultado del motor de tarifa: el monto a cobrar y de dónde sale.
+ *
+ * El desglose no es decorativo. La misma fórmula alimenta la tarifa estimada
+ * que ve el pasajero antes de pedir el viaje y el cobro al terminarlo; cuando
+ * ambos números no coinciden —porque el trayecto real no fue el estimado, o
+ * porque hubo espera— hay que poder explicar la diferencia sin recalcular nada
+ * a mano.
+ *
+ * Todos los montos son enteros en la unidad mínima de `$currency`; ver la nota
+ * sobre dinero en config/fares.php.
+ */
+final readonly class FareBreakdown
+{
+    public function __construct(
+        public string $currency,
+        public int $base,
+        public int $distance,
+        public int $time,
+        public int $waiting,
+        /** Suma de los conceptos anteriores, antes de piso y redondeo. */
+        public int $subtotal,
+        /** Lo que se cobra: el subtotal con el mínimo y el redondeo ya aplicados. */
+        public int $total,
+        /** `true` cuando el subtotal no llegaba al mínimo y el cobro lo determinó ese piso. */
+        public bool $minimumApplied,
+    ) {}
+}

--- a/app/DTOs/FareSchedule.php
+++ b/app/DTOs/FareSchedule.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use InvalidArgumentException;
+
+/**
+ * Los parámetros vigentes de la tarifa: cuánto vale arrancar, cada kilómetro,
+ * cada minuto en ruta y cada minuto de espera.
+ *
+ * Existe como objeto y no como lecturas sueltas de `config('fares.*')` dentro
+ * del motor de tarifa por dos motivos: el motor queda siendo una función pura
+ * de sus parámetros (testeable sin contenedor ni entorno), y una configuración
+ * imposible —un paso de redondeo de 0, una tarifa negativa— revienta al
+ * resolver la aplicación y no al calcular la primera tarifa de un pasajero
+ * real.
+ *
+ * Todos los montos son enteros en la unidad mínima de `$currency`; ver la nota
+ * sobre dinero en config/fares.php.
+ */
+final readonly class FareSchedule
+{
+    public function __construct(
+        public string $currency,
+        public int $base,
+        public int $perKilometer,
+        public int $perMinute,
+        public int $perWaitingMinute,
+        public int $minimum,
+        public int $roundingStep,
+    ) {
+        if (preg_match('/^[A-Z]{3}$/', $currency) !== 1) {
+            throw new InvalidArgumentException("Moneda inválida: '{$currency}'. Se espera un código ISO 4217 de tres letras mayúsculas.");
+        }
+
+        foreach ([
+            'base' => $base,
+            'per_kilometer' => $perKilometer,
+            'per_minute' => $perMinute,
+            'per_waiting_minute' => $perWaitingMinute,
+            'minimum' => $minimum,
+        ] as $name => $amount) {
+            if ($amount < 0) {
+                throw new InvalidArgumentException("La tarifa '{$name}' no puede ser negativa: {$amount}.");
+            }
+        }
+
+        if ($roundingStep < 1) {
+            throw new InvalidArgumentException("El paso de redondeo debe ser al menos 1: {$roundingStep}.");
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\DTOs\FareSchedule;
 use App\Services\Maps\GoogleRoutesEstimator;
 use App\Services\Maps\RouteEstimator;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -19,6 +20,28 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->registerRouteEstimator();
+        $this->registerFareSchedule();
+    }
+
+    /**
+     * Arma los parámetros de tarifa vigentes desde config/fares.php (ver la
+     * fórmula en .claude/STANDARDS.md).
+     *
+     * Diferido igual que el estimador: el constructor de FareSchedule rechaza
+     * una configuración imposible, y esa validación tiene que ocurrir cuando
+     * alguien va a calcular una tarifa, no en cada arranque de la aplicación.
+     */
+    private function registerFareSchedule(): void
+    {
+        $this->app->singleton(FareSchedule::class, static fn (): FareSchedule => new FareSchedule(
+            currency: Config::string('fares.currency'),
+            base: Config::integer('fares.base'),
+            perKilometer: Config::integer('fares.per_kilometer'),
+            perMinute: Config::integer('fares.per_minute'),
+            perWaitingMinute: Config::integer('fares.per_waiting_minute'),
+            minimum: Config::integer('fares.minimum'),
+            roundingStep: Config::integer('fares.rounding_step'),
+        ));
     }
 
     /**

--- a/config/fares.php
+++ b/config/fares.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tarifa del viaje
+    |--------------------------------------------------------------------------
+    |
+    | Parámetros de la fórmula que calcula el costo de un viaje. La fórmula y
+    | la justificación de cada parámetro están en .claude/STANDARDS.md
+    | ("Cálculo de tarifas"). Acá solo viven los valores, porque el negocio los
+    | ajusta con mucha más frecuencia de lo que cambia la fórmula.
+    |
+    | Todos los montos son ENTEROS en la unidad mínima de la moneda
+    | configurada. Para COP esa unidad es el peso: el peso colombiano no tiene
+    | subunidad en circulación, así que no hay centavos que representar. Nunca
+    | usar float para dinero.
+    |
+    */
+
+    'currency' => env('FARE_CURRENCY', 'COP'),
+
+    // Lo que cuesta el viaje antes de moverse: cubre el desplazamiento del
+    // conductor hasta el punto de recogida.
+    'base' => (int) env('FARE_BASE', 1500),
+
+    'per_kilometer' => (int) env('FARE_PER_KILOMETER', 800),
+
+    // El tiempo en ruta se cobra además de la distancia porque en hora pico el
+    // mismo trayecto ocupa al conductor mucho más tiempo (la duración viene
+    // del proveedor de mapas con tráfico, ver config/maps.php).
+    'per_minute' => (int) env('FARE_PER_MINUTE', 100),
+
+    // Espera solicitada por el pasajero con el viaje ya aceptado. Se cobra más
+    // barato que el minuto en ruta: el conductor está detenido, sin gastar
+    // combustible.
+    'per_waiting_minute' => (int) env('FARE_PER_WAITING_MINUTE', 60),
+
+    // Piso del cobro. Un viaje de tres cuadras igual ocupa a un conductor, y
+    // sin piso no compensa aceptarlo.
+    'minimum' => (int) env('FARE_MINIMUM', 3000),
+
+    // El total se redondea hacia arriba a un múltiplo de este paso. Buena
+    // parte de estos viajes se pagan en efectivo y el vuelto tiene que existir
+    // físicamente: nadie devuelve 13 pesos.
+    'rounding_step' => (int) env('FARE_ROUNDING_STEP', 50),
+
+];

--- a/tests/Feature/Payments/FareScheduleBindingTest.php
+++ b/tests/Feature/Payments/FareScheduleBindingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Payments;
+
+use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\FareSchedule;
+use App\DTOs\RouteEstimate;
+use Illuminate\Support\Facades\Config;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * El motor de tarifa se prueba aislado en tests/Unit; lo que se cubre acá es
+ * el cableado: que los valores de config/fares.php lleguen al Action a través
+ * del contenedor, y que una configuración imposible se detecte al resolverlo.
+ */
+class FareScheduleBindingTest extends TestCase
+{
+    public function test_builds_the_schedule_from_the_configured_values(): void
+    {
+        Config::set('fares.currency', 'COP');
+        Config::set('fares.base', 2000);
+        Config::set('fares.per_kilometer', 900);
+        Config::set('fares.per_minute', 120);
+        Config::set('fares.per_waiting_minute', 70);
+        Config::set('fares.minimum', 3500);
+        Config::set('fares.rounding_step', 100);
+
+        $schedule = $this->app->make(FareSchedule::class);
+
+        $this->assertSame('COP', $schedule->currency);
+        $this->assertSame(2000, $schedule->base);
+        $this->assertSame(900, $schedule->perKilometer);
+        $this->assertSame(120, $schedule->perMinute);
+        $this->assertSame(70, $schedule->perWaitingMinute);
+        $this->assertSame(3500, $schedule->minimum);
+        $this->assertSame(100, $schedule->roundingStep);
+    }
+
+    public function test_the_action_is_resolvable_with_its_schedule_injected(): void
+    {
+        Config::set('fares.base', 1500);
+        Config::set('fares.per_kilometer', 800);
+        Config::set('fares.per_minute', 100);
+        Config::set('fares.minimum', 0);
+        Config::set('fares.rounding_step', 50);
+
+        $fare = $this->app->make(CalculateFareAction::class)
+            ->handle(new RouteEstimate(distanceMeters: 5000, durationSeconds: 720));
+
+        $this->assertSame(6700, $fare->total);
+    }
+
+    public function test_fails_loudly_when_the_configured_schedule_is_impossible(): void
+    {
+        Config::set('fares.rounding_step', 0);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('El paso de redondeo debe ser al menos 1');
+
+        $this->app->make(FareSchedule::class);
+    }
+
+    /**
+     * Los valores por defecto de config/fares.php tienen que ser un tarifario
+     * coherente: es el que corre en cualquier entorno que no sobreescriba las
+     * variables, incluido el primer arranque local.
+     */
+    public function test_the_shipped_defaults_are_a_valid_schedule(): void
+    {
+        $schedule = $this->app->make(FareSchedule::class);
+
+        $this->assertGreaterThan(0, $schedule->minimum);
+        $this->assertGreaterThan(0, $schedule->perKilometer);
+        $this->assertGreaterThanOrEqual(1, $schedule->roundingStep);
+        $this->assertSame(0, $schedule->minimum % $schedule->roundingStep, 'El mínimo debería ser un múltiplo del paso de redondeo.');
+    }
+}

--- a/tests/Unit/Actions/Payments/CalculateFareActionTest.php
+++ b/tests/Unit/Actions/Payments/CalculateFareActionTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Payments;
+
+use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\FareSchedule;
+use App\DTOs\RouteEstimate;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * El motor de tarifa es una función pura de sus parámetros, así que estos
+ * tests fijan un tarifario propio y no leen config: si el negocio cambia el
+ * precio del kilómetro mañana, estos tests no tienen por qué ponerse rojos.
+ */
+class CalculateFareActionTest extends TestCase
+{
+    /**
+     * Tarifario de prueba con números redondos para que las cuentas de cada
+     * test se puedan verificar a mano.
+     */
+    private function schedule(int $minimum = 3000, int $roundingStep = 50): FareSchedule
+    {
+        return new FareSchedule(
+            currency: 'COP',
+            base: 1500,
+            perKilometer: 800,
+            perMinute: 100,
+            perWaitingMinute: 60,
+            minimum: $minimum,
+            roundingStep: $roundingStep,
+        );
+    }
+
+    public function test_charges_base_distance_and_time_on_a_normal_ride(): void
+    {
+        // 5 km → 4000; 12 min → 1200; + base 1500 = 6700, ya múltiplo de 50.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 5000, durationSeconds: 720));
+
+        $this->assertSame(1500, $fare->base);
+        $this->assertSame(4000, $fare->distance);
+        $this->assertSame(1200, $fare->time);
+        $this->assertSame(0, $fare->waiting);
+        $this->assertSame(6700, $fare->subtotal);
+        $this->assertSame(6700, $fare->total);
+        $this->assertFalse($fare->minimumApplied);
+        $this->assertSame('COP', $fare->currency);
+    }
+
+    public function test_applies_the_minimum_fare_on_a_very_short_ride(): void
+    {
+        // 400 m → 320; 90 s → 150; + base 1500 = 1970, por debajo del mínimo.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 400, durationSeconds: 90));
+
+        $this->assertSame(1970, $fare->subtotal);
+        $this->assertSame(3000, $fare->total);
+        $this->assertTrue($fare->minimumApplied);
+    }
+
+    public function test_does_not_apply_the_minimum_when_the_subtotal_already_reaches_it(): void
+    {
+        // 1 km → 800; 420 s → 700; + base 1500 = 3000, exactamente el mínimo.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 1000, durationSeconds: 420));
+
+        $this->assertSame(3000, $fare->subtotal);
+        $this->assertSame(3000, $fare->total);
+        $this->assertFalse($fare->minimumApplied);
+    }
+
+    public function test_scales_with_distance_on_a_long_ride(): void
+    {
+        // 42.5 km → 34000; 65 min → 6500; + base 1500 = 42000.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 42500, durationSeconds: 3900));
+
+        $this->assertSame(34000, $fare->distance);
+        $this->assertSame(6500, $fare->time);
+        $this->assertSame(42000, $fare->subtotal);
+        $this->assertSame(42000, $fare->total);
+        $this->assertFalse($fare->minimumApplied);
+    }
+
+    public function test_charges_the_requested_waiting_time_on_top_of_the_ride(): void
+    {
+        // 10 min de espera → 600, sobre el mismo viaje del primer test.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 5000, durationSeconds: 720), waitingSeconds: 600);
+
+        $this->assertSame(600, $fare->waiting);
+        $this->assertSame(7300, $fare->subtotal);
+        $this->assertSame(7300, $fare->total);
+    }
+
+    public function test_waiting_time_defaults_to_zero(): void
+    {
+        $route = new RouteEstimate(distanceMeters: 5000, durationSeconds: 720);
+        $action = new CalculateFareAction($this->schedule());
+
+        $this->assertEquals($action->handle($route, 0), $action->handle($route));
+    }
+
+    public function test_waiting_time_can_lift_a_short_ride_above_the_minimum(): void
+    {
+        // El viaje corto del test del mínimo (1970) + 30 min de espera (1800).
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 400, durationSeconds: 90), waitingSeconds: 1800);
+
+        $this->assertSame(3770, $fare->subtotal);
+        $this->assertSame(3800, $fare->total);
+        $this->assertFalse($fare->minimumApplied);
+    }
+
+    public function test_prorates_fractions_of_a_kilometer_and_of_a_minute(): void
+    {
+        // 1500 m → 1200 (km y medio, no dos km); 30 s → 50 (medio minuto).
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 1500, durationSeconds: 30));
+
+        $this->assertSame(1200, $fare->distance);
+        $this->assertSame(50, $fare->time);
+    }
+
+    public function test_rounds_the_total_up_to_the_configured_step(): void
+    {
+        // 1234 m → 987; 61 s → 102; + base 1500 = 2589 → 2600.
+        $fare = (new CalculateFareAction($this->schedule(minimum: 0)))
+            ->handle(new RouteEstimate(distanceMeters: 1234, durationSeconds: 61));
+
+        $this->assertSame(2589, $fare->subtotal);
+        $this->assertSame(2600, $fare->total);
+    }
+
+    public function test_leaves_the_total_untouched_when_it_already_lands_on_the_step(): void
+    {
+        // 1250 m → 1000; 300 s → 500; + base 1500 = 3000.
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 1250, durationSeconds: 300));
+
+        $this->assertSame(3000, $fare->total);
+    }
+
+    public function test_a_rounding_step_of_one_disables_the_rounding(): void
+    {
+        $fare = (new CalculateFareAction($this->schedule(minimum: 0, roundingStep: 1)))
+            ->handle(new RouteEstimate(distanceMeters: 1234, durationSeconds: 61));
+
+        $this->assertSame(2589, $fare->total);
+    }
+
+    public function test_a_zero_length_route_still_costs_the_minimum(): void
+    {
+        $fare = (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 0, durationSeconds: 0));
+
+        $this->assertSame(1500, $fare->subtotal);
+        $this->assertSame(3000, $fare->total);
+        $this->assertTrue($fare->minimumApplied);
+    }
+
+    public function test_rejects_a_negative_distance(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('la distancia del trayecto');
+
+        (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: -1, durationSeconds: 60));
+    }
+
+    public function test_rejects_a_negative_duration(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('la duración del trayecto');
+
+        (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 1000, durationSeconds: -1));
+    }
+
+    public function test_rejects_a_negative_waiting_time(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('el tiempo de espera');
+
+        (new CalculateFareAction($this->schedule()))
+            ->handle(new RouteEstimate(distanceMeters: 1000, durationSeconds: 60), waitingSeconds: -1);
+    }
+}

--- a/tests/Unit/DTOs/FareScheduleTest.php
+++ b/tests/Unit/DTOs/FareScheduleTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTOs;
+
+use App\DTOs\FareSchedule;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FareScheduleTest extends TestCase
+{
+    private static function make(
+        string $currency = 'COP',
+        int $base = 1500,
+        int $perKilometer = 800,
+        int $perMinute = 100,
+        int $perWaitingMinute = 60,
+        int $minimum = 3000,
+        int $roundingStep = 50,
+    ): FareSchedule {
+        return new FareSchedule(
+            currency: $currency,
+            base: $base,
+            perKilometer: $perKilometer,
+            perMinute: $perMinute,
+            perWaitingMinute: $perWaitingMinute,
+            minimum: $minimum,
+            roundingStep: $roundingStep,
+        );
+    }
+
+    public function test_accepts_a_valid_schedule(): void
+    {
+        $schedule = self::make();
+
+        $this->assertSame('COP', $schedule->currency);
+        $this->assertSame(1500, $schedule->base);
+        $this->assertSame(800, $schedule->perKilometer);
+        $this->assertSame(50, $schedule->roundingStep);
+    }
+
+    /**
+     * Una tarifa en cero es una decisión de negocio válida (una promoción sin
+     * cargo base, por ejemplo); lo que no puede es ser negativa.
+     */
+    public function test_accepts_rates_of_zero(): void
+    {
+        $schedule = self::make(base: 0, perMinute: 0, minimum: 0);
+
+        $this->assertSame(0, $schedule->base);
+        $this->assertSame(0, $schedule->perMinute);
+        $this->assertSame(0, $schedule->minimum);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidCurrencies(): array
+    {
+        return [
+            'minúsculas' => ['cop'],
+            'demasiado corta' => ['CO'],
+            'demasiado larga' => ['COPS'],
+            'con símbolo' => ['CO$'],
+            'vacía' => [''],
+        ];
+    }
+
+    #[DataProvider('invalidCurrencies')]
+    public function test_rejects_an_invalid_currency(string $currency): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Moneda inválida');
+
+        self::make(currency: $currency);
+    }
+
+    /**
+     * Cada caso pone en -1 una sola tarifa y deja el resto válida, para
+     * comprobar que el mensaje señala exactamente la clave de configuración
+     * que hay que corregir.
+     *
+     * @return array<string, array{string, int, int, int, int, int}>
+     */
+    public static function negativeRates(): array
+    {
+        return [
+            'base' => ['base', -1, 800, 100, 60, 3000],
+            'por kilómetro' => ['per_kilometer', 1500, -1, 100, 60, 3000],
+            'por minuto' => ['per_minute', 1500, 800, -1, 60, 3000],
+            'por minuto de espera' => ['per_waiting_minute', 1500, 800, 100, -1, 3000],
+            'mínimo' => ['minimum', 1500, 800, 100, 60, -1],
+        ];
+    }
+
+    #[DataProvider('negativeRates')]
+    public function test_rejects_a_negative_rate(
+        string $configKey,
+        int $base,
+        int $perKilometer,
+        int $perMinute,
+        int $perWaitingMinute,
+        int $minimum,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("La tarifa '{$configKey}' no puede ser negativa");
+
+        self::make(
+            base: $base,
+            perKilometer: $perKilometer,
+            perMinute: $perMinute,
+            perWaitingMinute: $perWaitingMinute,
+            minimum: $minimum,
+        );
+    }
+
+    public function test_rejects_a_rounding_step_below_one(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('El paso de redondeo debe ser al menos 1');
+
+        self::make(roundingStep: 0);
+    }
+}


### PR DESCRIPTION
Closes #4

## Qué hace

Implementa el motor de tarifa como una Action reutilizable, única fuente de verdad del
monto: la tarifa estimada que ve el pasajero antes de pedir el viaje y el cobro al
terminarlo salen de la misma clase con los mismos parámetros. Lo único que cambia entre
ambos momentos es el `RouteEstimate` que recibe (estimado del proveedor de mapas
primero, trayecto real después).

- `App\Actions\Payments\CalculateFareAction` — recibe `RouteEstimate` y los segundos de
  espera, devuelve el desglose. No conoce HTTP ni el modelo `Ride`.
- `App\DTOs\FareSchedule` — los parámetros vigentes, construidos desde `config/fares.php`
  en `AppServiceProvider` (binding diferido). Valida en el constructor: una tarifa
  negativa o un paso de redondeo en 0 revientan al resolver el servicio, no al cobrarle
  a un pasajero real.
- `App\DTOs\FareBreakdown` — total **y** desglose por concepto, para poder explicar la
  diferencia entre lo estimado y lo cobrado sin recalcular a mano.
- `config/fares.php` + variables `FARE_*` en `.env.example`.
- Fórmula, tabla de parámetros y las reglas que la sostienen documentadas en
  `.claude/STANDARDS.md` → "Cálculo de tarifas".

Fórmula:

```
distancia = round(metros     × per_kilometer      / 1000)
tiempo    = round(segundos   × per_minute         / 60)
espera    = round(seg_espera × per_waiting_minute / 60)

subtotal  = base + distancia + tiempo + espera
total     = ceil_al_múltiplo(max(subtotal, minimum), rounding_step)
```

## Cómo se probó

15 tests unitarios sobre la Action, cubriendo los criterios de aceptación y no solo el
camino feliz: viaje normal, viaje muy corto donde manda el mínimo, viaje largo, espera
adicional (incluida la que levanta un viaje corto por encima del mínimo), prorrateo de
fracciones de km y de minuto, redondeo hacia arriba, ruta de longitud cero y rechazo de
distancia/duración/espera negativas. Más tests de validación de `FareSchedule` y un test
de integración del binding en el contenedor.

Local, todo en verde: `php artisan test` (85 tests), `pint --test`, `composer stan`,
`composer audit`, y los checks de complejidad, arquitectura, seguridad y conformidad
estática/dinámica que corre el CI.

## Decisiones y riesgos

- **Dinero en enteros, nunca float.** Todos los montos son enteros en la unidad mínima
  de la moneda; para COP esa unidad es el peso, que no tiene subunidad en circulación.
  Queda anotado en STANDARDS que esto aplica también a las columnas de BD cuando lleguen
  los pagos.
- **Se cobra distancia y tiempo, no uno u otro.** Sin componente de tiempo, un trayecto
  en hora pico paga igual que el mismo trayecto a medianoche ocupando al conductor el
  triple; sin distancia, un viaje largo y fluido queda regalado.
- **Las fracciones se prorratean.** 1500 m pagan kilómetro y medio, no dos: cobrar la
  unidad entera produce saltos de precio que el pasajero percibe como arbitrarios entre
  dos destinos casi iguales.
- **El mínimo se aplica antes del redondeo, y el redondeo es hacia arriba**, porque el
  mínimo es un piso y un redondeo al múltiplo más cercano podría perforarlo.
- **El paso de redondeo existe por el efectivo**: el vuelto tiene que existir
  físicamente. De ahí que `minimum` deba ser múltiplo de `rounding_step`, lo verifica un
  test.
- **Los valores numéricos son un punto de partida a validar con el negocio.** Por eso
  viven en config y no en el código: ajustarlos no es un cambio de software. La fórmula
  sí es decisión de arquitectura y cambiarla pasa por STANDARDS.
- Fuera de alcance, como dice el issue: surge pricing, descuentos/promociones, y los
  endpoints que consumen este cálculo (#14 y #25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)