### PR TITLE
chore(#5): configurar Laravel Reverb para broadcasting en tiempo real

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -183,6 +183,16 @@ cliente renueva y vuelve a suscribirse.
   en el entorno **antes** de que arranque la aplicación — los canales se registran
   contra el broadcaster configurado al bootear, así que cambiarla después con
   `Config::set` deja al nuevo broadcaster sin canales.
+- Toda variable de entorno que un test necesite se declara en `phpunit.xml`, **no** en
+  un `setUp()`. El repositorio de phpdotenv es inmutable y se llena en el primer boot
+  del proceso: una variable que no esté definida antes de ese boot queda registrada como
+  cargada desde `.env`, y en cada boot posterior el writer la repisa con el valor del
+  archivo, pisando lo que haya puesto el `setUp()`. El síntoma es un test que pasa
+  aislado (primer boot) y falla dentro de la suite, con un resultado que además depende
+  del `.env` de cada máquina — en CI, `.env` sale de `.env.example`. Fijar una variable
+  desde `setUp()` solo funciona si ya está declarada en `phpunit.xml` (ese es el caso de
+  `BROADCAST_CONNECTION`): al no entrar nunca en el conjunto *loaded*, nadie la repisa.
+  Las credenciales `REVERB_APP_*` de prueba están en `phpunit.xml` por esta razón.
 - Prueba de concepto: con `php artisan reverb:start` corriendo y un cliente suscrito a
   `private-driver.{id}`, `php artisan realtime:ping <id> "<mensaje>"` recorre la cadena
   completa (autorización del canal, publicación y entrega). El evento

--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -129,6 +129,69 @@ sigue la API (`{"data": {...}}` en éxito). Los errores no se envuelven: van com
 - Eventos (`ShouldBroadcast`) se disparan al final de la Action correspondiente,
   nunca desde el controller.
 
+### Canales y autorización (decidido en #5)
+
+**Todos los canales son privados.** No hay nada en este dominio que se pueda
+escuchar de forma anónima: por estos canales viaja la ubicación en vivo de
+personas concretas.
+
+| Canal | Quién entra | Qué lleva |
+|---|---|---|
+| `ride.{rideId}` | El pasajero del viaje y el conductor asignado | Cambios de estado y ubicación durante el viaje |
+| `driver.{driverId}` | Ese conductor, si tiene perfil creado | Solicitudes de viaje cercanas y avisos que son para él |
+
+- `{driverId}` es el id del `User`, **no** el de `driver_profiles`: la API ya
+  identifica a todo el mundo por el id de `User` (es el `sub` del JWT) y tener dos
+  numeraciones para la misma persona es una fuente de errores de autorización.
+- `routes/channels.php` solo declara qué canales existen; la regla de cada uno vive
+  en una clase de `app/Broadcasting/` (canales class-based de Laravel), que se prueba
+  sin levantar HTTP. Los canales se registran en `App\Providers\BroadcastServiceProvider`.
+- Todos los canales declaran `['guards' => ['api']]` de forma explícita: la API es
+  stateless con JWT y no existe el guard `web`.
+- El canal `ride.{id}` ya tiene su regla definitiva, pero el modelo `Ride` llega con
+  la historia #15. Hasta entonces resuelve los participantes contra
+  `App\Services\Realtime\RideParticipants`, cuya implementación registrada
+  (`PendingRideParticipants`) no conoce ningún viaje y por lo tanto **deniega todo**.
+  Fallar cerrado es la única opción aceptable acá: un canal abierto "provisionalmente"
+  expone posiciones en vivo a cualquier usuario autenticado que adivine un id. Cuando
+  exista la tabla, se cambia el binding en `AppServiceProvider` y nada más.
+
+### La ruta de autorización es una ruta de la API
+
+`POST /api/v1/broadcasting/auth` (con `auth:api`), declarada en `routes/api.php` y
+documentada en [`openapi.yaml`](../openapi.yaml) como cualquier otro endpoint. No se
+usa el helper `withBroadcasting()` de `bootstrap/app.php` porque registra la ruta con
+`GET` y `POST` y fuera del prefijo `/api/v1`, lo que rompe tanto la convención de
+versionado como la correspondencia entre spec y rutas reales que valida
+`static_conformance.py`.
+
+Acá el token expirado **no** sirve (a diferencia de `POST /api/v1/auth/refresh`): el
+cliente renueva y vuelve a suscribirse.
+
+### Configuración
+
+- `config/broadcasting.php` solo declara las conexiones que se usan (`reverb`, `log`,
+  `null`); las de Pusher y Ably del skeleton se quitaron, mismo criterio que el resto
+  del scaffolding sin usar.
+- Variables en `.env.example` (`REVERB_APP_ID`, `REVERB_APP_KEY`, `REVERB_APP_SECRET`,
+  `REVERB_HOST`, `REVERB_PORT`, `REVERB_SCHEME`, `REVERB_SERVER_HOST`,
+  `REVERB_SERVER_PORT`). Las credenciales de la aplicación Reverb no tienen default:
+  son un secreto por entorno igual que `JWT_SECRET`, y se generan con
+  `php artisan reverb:install`.
+- La suite de tests corre con `BROADCAST_CONNECTION=null` (`phpunit.xml`): ningún test
+  abre conexiones. Un test que necesite el broadcaster real tiene que fijar la conexión
+  en el entorno **antes** de que arranque la aplicación — los canales se registran
+  contra el broadcaster configurado al bootear, así que cambiarla después con
+  `Config::set` deja al nuevo broadcaster sin canales.
+- Prueba de concepto: con `php artisan reverb:start` corriendo y un cliente suscrito a
+  `private-driver.{id}`, `php artisan realtime:ping <id> "<mensaje>"` recorre la cadena
+  completa (autorización del canal, publicación y entrega). El evento
+  `App\Events\Realtime\RealtimePingSent` es `ShouldBroadcastNow` por ser una prueba;
+  los eventos de negocio usan `ShouldBroadcast` y salen por la cola.
+
+**Fuera de alcance de #5**: los eventos de negocio concretos (solicitudes cercanas,
+tracking del viaje), que llegan con sus propias historias.
+
 ## Testing: PHPUnit
 
 - Se mantiene PHPUnit (ya está en el skeleton); no se migra a Pest.

--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,31 @@ FARE_MINIMUM=3000
 # El total se redondea hacia arriba a un múltiplo de este paso (pago en efectivo).
 FARE_ROUNDING_STEP=50
 
-BROADCAST_CONNECTION=log
+# Tiempo real (decidido en #5, ver .claude/STANDARDS.md). `reverb` publica los
+# eventos ShouldBroadcast al servidor de WebSockets; `log` sirve para trabajar
+# sin levantarlo y `null` es lo que usa la suite de tests (phpunit.xml).
+BROADCAST_CONNECTION=reverb
+
+# Credenciales de la aplicación Reverb. Sin default a propósito: son un secreto
+# por entorno, igual que JWT_SECRET. Generarlas con `php artisan reverb:install`
+# (las escribe en .env) o a mano; la API firma con ellas la autorización de los
+# canales privados y el servidor las valida en cada conexión.
+REVERB_APP_ID=
+REVERB_APP_KEY=
+REVERB_APP_SECRET=
+
+# Cómo alcanza la API al servidor de Reverb para publicar. En local es el mismo
+# proceso que levanta `php artisan reverb:start`; en producción va detrás de TLS
+# (REVERB_SCHEME=https y el puerto público).
+REVERB_HOST=localhost
+REVERB_PORT=8080
+REVERB_SCHEME=http
+
+# Dónde escucha el proceso de Reverb. Se separa de REVERB_HOST porque el
+# servidor puede escuchar en 0.0.0.0 detrás de un proxy que publica otro host.
+REVERB_SERVER_HOST=0.0.0.0
+REVERB_SERVER_PORT=8080
+
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 

--- a/app/Actions/Realtime/SendRealtimePingAction.php
+++ b/app/Actions/Realtime/SendRealtimePingAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Realtime;
+
+use App\Events\Realtime\RealtimePingSent;
+use App\Models\User;
+use InvalidArgumentException;
+
+/**
+ * Manda un mensaje de prueba al canal privado de un conductor (issue #5).
+ *
+ * Es la Action de prueba que exige el issue: existe para verificar la
+ * infraestructura de tiempo real, no para el negocio. Sirve igual desde el
+ * comando `realtime:ping`, un test o un tinker, porque no conoce HTTP — el
+ * mismo patrón que van a seguir las Actions que disparen eventos de verdad
+ * (ver .claude/STANDARDS.md).
+ */
+final readonly class SendRealtimePingAction
+{
+    /**
+     * @throws InvalidArgumentException si el usuario no es un conductor, porque
+     *                                  entonces nadie está autorizado a escuchar
+     *                                  ese canal y el mensaje se perdería en
+     *                                  silencio.
+     */
+    public function handle(User $driver, string $message): void
+    {
+        if (! $driver->isDriver()) {
+            throw new InvalidArgumentException(
+                "El usuario {$driver->getKey()} no es un conductor: nadie escucha su canal."
+            );
+        }
+
+        RealtimePingSent::dispatch((int) $driver->getKey(), $message);
+    }
+}

--- a/app/Broadcasting/DriverChannel.php
+++ b/app/Broadcasting/DriverChannel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+
+/**
+ * Canal privado `driver.{driverId}`: la línea directa con un conductor.
+ *
+ * Por acá le llegan las solicitudes de viaje cercanas y todo lo que es para él
+ * y no para el viaje. Es el canal más sensible del sistema —quien lo escucha
+ * ve dónde se están pidiendo viajes en tiempo real—, así que la regla es
+ * estrecha a propósito: cada conductor escucha su propio canal y nada más.
+ *
+ * El `{driverId}` es el id del `User` con rol conductor, no el de
+ * `driver_profiles`. La API ya identifica a todo el mundo por el id de `User`
+ * (es el `sub` del JWT) y tener dos numeraciones para la misma persona es una
+ * fuente de errores de autorización.
+ */
+final readonly class DriverChannel
+{
+    /**
+     * @param  string  $driverId  Llega como string desde el nombre del canal.
+     */
+    public function join(User $user, string $driverId): bool
+    {
+        if ((string) $user->getKey() !== $driverId) {
+            return false;
+        }
+
+        // El perfil es lo que habilita a recibir viajes (ver la decisión de #1
+        // en .claude/STANDARDS.md): un usuario con rol conductor pero sin
+        // perfil creado todavía no es un conductor operativo, así que tampoco
+        // tiene por qué escuchar solicitudes.
+        return $user->isDriver() && $user->driverProfile()->exists();
+    }
+}

--- a/app/Broadcasting/RideChannel.php
+++ b/app/Broadcasting/RideChannel.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+use App\Services\Realtime\RideParticipants;
+
+/**
+ * Canal privado `ride.{rideId}`: todo lo que pasa dentro de un viaje.
+ *
+ * Cambios de estado y ubicación del conductor en curso viajan por acá, así que
+ * lo escuchan exactamente las dos personas que están en ese viaje: el pasajero
+ * que lo pidió y el conductor asignado.
+ *
+ * De dónde salen esos dos ids es problema de {@see RideParticipants}, no de
+ * este canal — el modelo `Ride` llega con la historia #15 y hasta entonces la
+ * implementación registrada no reconoce ningún viaje, con lo que este canal
+ * deniega todo. La regla de autorización, en cambio, ya es la definitiva.
+ */
+final readonly class RideChannel
+{
+    public function __construct(private RideParticipants $participants) {}
+
+    /**
+     * @param  string  $rideId  Llega como string desde el nombre del canal.
+     */
+    public function join(User $user, string $rideId): bool
+    {
+        // El id viene del nombre del canal, que lo elige el cliente: cualquier
+        // cosa que no sea un entero positivo se rechaza antes de convertirla,
+        // en vez de dejar que un "12abc" se transforme en el viaje 12.
+        if (! ctype_digit($rideId)) {
+            return false;
+        }
+
+        return in_array(
+            (int) $user->getKey(),
+            $this->participants->forRide((int) $rideId),
+            strict: true,
+        );
+    }
+}

--- a/app/Console/Commands/SendRealtimePingCommand.php
+++ b/app/Console/Commands/SendRealtimePingCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Actions\Realtime\SendRealtimePingAction;
+use App\Models\User;
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+
+/**
+ * Prueba de concepto del tiempo real (issue #5), en el mismo espíritu que
+ * `maps:estimate` para el proveedor de mapas.
+ *
+ * Con `php artisan reverb:start` corriendo y un cliente suscrito a
+ * `private-driver.{id}`, esto confirma la cadena completa: autorización del
+ * canal, publicación al servidor y entrega al suscriptor.
+ *
+ *   php artisan realtime:ping 7 "hola desde el backend"
+ */
+final class SendRealtimePingCommand extends Command
+{
+    protected $signature = 'realtime:ping
+                            {driver : Id del usuario conductor dueño del canal}
+                            {message=Ping de prueba desde MotoYa : Texto a enviar}';
+
+    protected $description = 'Envía un mensaje de prueba al canal privado de un conductor para verificar el broadcasting.';
+
+    public function handle(SendRealtimePingAction $action): int
+    {
+        $driver = User::query()->find($this->argument('driver'));
+
+        if ($driver === null) {
+            $this->components->error("No existe un usuario con id {$this->argument('driver')}.");
+
+            return self::FAILURE;
+        }
+
+        try {
+            $action->handle($driver, (string) $this->argument('message'));
+        } catch (InvalidArgumentException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->components->twoColumnDetail('Conexión', (string) config('broadcasting.default'));
+        $this->components->twoColumnDetail('Canal', "private-driver.{$driver->getKey()}");
+        $this->components->twoColumnDetail('Evento', 'realtime.ping');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Events/Realtime/RealtimePingSent.php
+++ b/app/Events/Realtime/RealtimePingSent.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Realtime;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Evento de prueba del tiempo real (issue #5).
+ *
+ * No es un evento de negocio: existe para confirmar de punta a punta que la
+ * infraestructura funciona —un cliente se autoriza en el canal privado, se
+ * suscribe y recibe el mensaje— antes de que las historias de tracking y
+ * solicitudes cercanas dependan de ella. Los eventos reales llegan con esas
+ * historias y se disparan al final de su Action (ver .claude/STANDARDS.md).
+ *
+ * Es `ShouldBroadcastNow` y no `ShouldBroadcast` porque una prueba de concepto
+ * que queda esperando a que alguien levante un worker de colas no prueba nada.
+ * Los eventos de negocio sí usarán la cola: publicar es una llamada HTTP al
+ * servidor de Reverb y no tiene por qué retrasar la respuesta al cliente.
+ */
+final class RealtimePingSent implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets;
+
+    public function __construct(
+        public readonly int $driverId,
+        public readonly string $message,
+    ) {}
+
+    /**
+     * Va al canal del conductor —y no a uno de prueba— para que la prueba de
+     * concepto ejercite la autorización real de `driver.{id}`.
+     */
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel("driver.{$this->driverId}");
+    }
+
+    /**
+     * Nombre con el que el cliente escucha el evento. Explícito para no atar
+     * la app móvil al FQCN de una clase de PHP.
+     */
+    public function broadcastAs(): string
+    {
+        return 'realtime.ping';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function broadcastWith(): array
+    {
+        return ['message' => $this->message];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 use App\DTOs\FareSchedule;
 use App\Services\Maps\GoogleRoutesEstimator;
 use App\Services\Maps\RouteEstimator;
+use App\Services\Realtime\PendingRideParticipants;
+use App\Services\Realtime\RideParticipants;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
@@ -21,6 +23,21 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->registerRouteEstimator();
         $this->registerFareSchedule();
+        $this->registerRideParticipants();
+    }
+
+    /**
+     * Fuente de los participantes de un viaje, que es lo que autoriza el canal
+     * privado `ride.{id}` (ver App\Broadcasting\RideChannel).
+     *
+     * Hoy no existe el modelo `Ride`, así que la implementación registrada no
+     * reconoce ningún viaje y el canal deniega todo. Cuando la historia #15
+     * cree la tabla, esto pasa a apuntar a una implementación con Eloquent y
+     * ni el canal ni routes/channels.php se tocan.
+     */
+    private function registerRideParticipants(): void
+    {
+        $this->app->bind(RideParticipants::class, PendingRideParticipants::class);
     }
 
     /**

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Registra los canales de broadcasting de la aplicación.
+ *
+ * Carga routes/channels.php a mano en vez de usar `withBroadcasting()` en
+ * bootstrap/app.php porque ese helper, además de los canales, registra la ruta
+ * de autorización con GET y POST y fuera de cualquier convención de esta API.
+ * Acá la ruta se declara como una más en routes/api.php: versionada bajo
+ * /api/v1, solo POST y documentada en openapi.yaml como el resto (ver
+ * .claude/STANDARDS.md).
+ */
+final class BroadcastServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        require base_path('routes/channels.php');
+    }
+}

--- a/app/Services/Realtime/PendingRideParticipants.php
+++ b/app/Services/Realtime/PendingRideParticipants.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+/**
+ * Implementación vigente de {@see RideParticipants} mientras no exista el
+ * modelo `Ride` (historia #15).
+ *
+ * No conoce ningún viaje, así que el canal `ride.{id}` deniega todas las
+ * suscripciones. Es deliberado: la infraestructura de tiempo real queda
+ * completa y probada, y lo único que falta —la tabla de viajes— llega con la
+ * historia que la crea. Fallar cerrado es lo correcto acá; abrir el canal
+ * "provisionalmente" expondría la ubicación en vivo de conductores y
+ * pasajeros a cualquier usuario autenticado que adivine un id.
+ */
+final class PendingRideParticipants implements RideParticipants
+{
+    /**
+     * @return list<int>
+     */
+    public function forRide(int $rideId): array
+    {
+        return [];
+    }
+}

--- a/app/Services/Realtime/RideParticipants.php
+++ b/app/Services/Realtime/RideParticipants.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+/**
+ * Quiénes son los usuarios que participan de un viaje.
+ *
+ * Es lo único que necesita saber la autorización del canal `ride.{id}` para
+ * decidir: la regla —solo el pasajero y el conductor asignado escuchan el
+ * viaje— vive en App\Broadcasting\RideChannel, y de dónde salen esos ids vive
+ * detrás de esta interfaz.
+ *
+ * Existe como interfaz porque el modelo `Ride` todavía no está implementado
+ * (llega con la historia #15, "Solicitar un viaje"). Mientras tanto la
+ * implementación registrada es {@see PendingRideParticipants}, que no conoce
+ * ningún viaje y por lo tanto no deja entrar a nadie. Cuando exista la tabla,
+ * cambia el binding en AppServiceProvider y el canal empieza a autorizar sin
+ * tocar routes/channels.php ni el canal.
+ */
+interface RideParticipants
+{
+    /**
+     * Ids de los usuarios que participan del viaje: el pasajero que lo pidió y
+     * el conductor asignado, si ya lo hay.
+     *
+     * Devuelve un arreglo vacío si el viaje no existe — un viaje inexistente y
+     * uno del que nadie participa se autorizan igual (denegando), y así el
+     * canal no filtra qué ids de viaje existen.
+     *
+     * @return list<int>
+     */
+    public function forRide(int $rideId): array;
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\BroadcastServiceProvider;
 
 return [
     AppServiceProvider::class,
+    BroadcastServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
+        "laravel/reverb": "^1.11",
         "laravel/tinker": "^3.0",
         "tymon/jwt-auth": "^2.3"
     },
@@ -43,7 +44,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" --names=server,queue,logs --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"php artisan reverb:start\" --names=server,queue,logs,reverb --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi @no_additional_args",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bde852f3a73c5d33d1febe21aa21716c",
+    "content-hash": "69ab700b7aa4ae14538b2acd90e28a6e",
     "packages": [
         {
             "name": "brick/math",
@@ -133,6 +133,136 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "clue/redis-protocol",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/redis-protocol.git",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\Redis\\Protocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A streaming Redis protocol (RESP) parser and serializer written in pure PHP.",
+            "homepage": "https://github.com/clue/redis-protocol",
+            "keywords": [
+                "parser",
+                "protocol",
+                "redis",
+                "resp",
+                "serializer",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/redis-protocol/issues",
+                "source": "https://github.com/clue/redis-protocol/tree/v0.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-07T11:06:28+00:00"
+        },
+        {
+            "name": "clue/redis-react",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-redis.git",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-redis/zipball/84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-protocol": "^0.3.2",
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.0 || ^1.1",
+                "react/promise-timer": "^1.11",
+                "react/socket": "^1.16"
+            },
+            "require-dev": {
+                "clue/block-react": "^1.5",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Redis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Async Redis client implementation, built on top of ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-redis",
+            "keywords": [
+                "async",
+                "client",
+                "database",
+                "reactphp",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-redis/issues",
+                "source": "https://github.com/clue/reactphp-redis/tree/v2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-03T16:18:33+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -506,6 +636,53 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -1342,6 +1519,85 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
             "time": "2026-06-26T00:11:25+00:00"
+        },
+        {
+            "name": "laravel/reverb",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/reverb.git",
+                "reference": "dca414f38e0f7acc237890ca18edfb5f3d535f86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/dca414f38e0f7acc237890ca18edfb5f3d535f86",
+                "reference": "dca414f38e0f7acc237890ca18edfb5f3d535f86",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-react": "^2.6",
+                "guzzlehttp/psr7": "^2.6",
+                "illuminate/console": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.47|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.15|^0.2.0|^0.3.0",
+                "php": "^8.2",
+                "pusher/pusher-php-server": "^7.2",
+                "ratchet/rfc6455": "^0.4",
+                "react/promise-timer": "^1.10",
+                "react/socket": "^1.14",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.3|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "phpstan/phpstan": "^1.10",
+                "ratchet/pawl": "^0.4.1",
+                "react/async": "^4.2",
+                "react/http": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Reverb\\ApplicationManagerServiceProvider",
+                        "Laravel\\Reverb\\ReverbServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Reverb\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Joe Dixon",
+                    "email": "joe@laravel.com"
+                }
+            ],
+            "description": "Laravel Reverb provides a real-time WebSocket communication backend for Laravel applications.",
+            "keywords": [
+                "WebSockets",
+                "laravel",
+                "real-time",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/reverb/issues",
+                "source": "https://github.com/laravel/reverb/tree/v1.11.0"
+            },
+            "time": "2026-06-25T02:41:17+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -3182,6 +3438,66 @@
             "time": "2026-06-29T15:41:09+00:00"
         },
         {
+            "name": "pusher/pusher-php-server",
+            "version": "7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pusher/pusher-http-php.git",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.2",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "overtrue/phplint": "^2.3",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pusher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for interacting with the Pusher REST API",
+            "keywords": [
+                "events",
+                "messaging",
+                "php-pusher-server",
+                "publish",
+                "push",
+                "pusher",
+                "real time",
+                "real-time",
+                "realtime",
+                "rest",
+                "trigger"
+            ],
+            "support": {
+                "issues": "https://github.com/pusher/pusher-http-php/issues",
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
+            },
+            "time": "2026-05-18T13:11:36+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -3378,6 +3694,595 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
             "time": "2026-06-18T03:57:49+00:00"
+        },
+        {
+            "name": "ratchet/rfc6455",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ratchetphp/RFC6455.git",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/9b05f371219cbaf9748b505f139617dd0715592b",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^2.7",
+                "phpunit/phpunit": "^9.5",
+                "react/socket": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ratchet\\RFC6455\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Bonneau",
+                    "role": "Developer"
+                }
+            ],
+            "description": "RFC6455 WebSocket protocol handler",
+            "homepage": "http://socketo.me",
+            "keywords": [
+                "WebSockets",
+                "rfc6455",
+                "websocket"
+            ],
+            "support": {
+                "chat": "https://gitter.im/reactphp/reactphp",
+                "issues": "https://github.com/ratchetphp/RFC6455/issues",
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.1"
+            },
+            "time": "2026-06-06T14:34:23+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/promise-timer",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4f70306ed66b8b44768941ca7f142092600fafc1",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:27:45+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,0 +1,68 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Conexión de broadcasting por defecto
+    |--------------------------------------------------------------------------
+    |
+    | Servidor al que se publican los eventos que implementan ShouldBroadcast.
+    | En cualquier entorno donde el tiempo real importe esto es "reverb" (ver
+    | .claude/STANDARDS.md, "Tiempo real: Laravel Reverb"); "log" y "null"
+    | quedan para desarrollo sin servidor de WebSockets y para la suite de
+    | tests, que no debe abrir conexiones.
+    |
+    */
+
+    'default' => env('BROADCAST_CONNECTION', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Conexiones
+    |--------------------------------------------------------------------------
+    |
+    | Solo están las conexiones que este proyecto usa. Las de Pusher y Ably que
+    | trae el framework por defecto se omiten a propósito: el proveedor está
+    | decidido y dejarlas acá solo agrega variables de entorno que nadie
+    | configura (mismo criterio que la limpieza de scaffolding en
+    | .claude/STANDARDS.md). Reverb habla el protocolo de Pusher, así que si
+    | alguna vez se migra a Pusher u otro proveedor compatible, es agregar la
+    | conexión acá y cambiar BROADCAST_CONNECTION.
+    |
+    */
+
+    'connections' => [
+
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                // Host/puerto/esquema con los que la aplicación alcanza al
+                // servidor de Reverb para publicar. No son necesariamente los
+                // mismos que ve la app móvil: en producción el cliente entra
+                // por el dominio público con TLS y la API puede publicar
+                // contra el host interno.
+                'host' => env('REVERB_HOST'),
+                'port' => env('REVERB_PORT', 443),
+                'scheme' => env('REVERB_SCHEME', 'https'),
+                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+            ],
+            'client_options' => [
+                // Opciones de Guzzle: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
+        'log' => [
+            'driver' => 'log',
+        ],
+
+        'null' => [
+            'driver' => 'null',
+        ],
+
+    ],
+
+];

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,0 +1,102 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Reverb Server
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default server used by Reverb to handle
+    | incoming messages as well as broadcasting message to all your
+    | connected clients. At this time only "reverb" is supported.
+    |
+    */
+
+    'default' => env('REVERB_SERVER', 'reverb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Servers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define details for each of the supported Reverb servers.
+    | Each server has its own configuration options that are defined in
+    | the array below. You should ensure all the options are present.
+    |
+    */
+
+    'servers' => [
+
+        'reverb' => [
+            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
+            'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
+            'hostname' => env('REVERB_HOST'),
+            'options' => [
+                'tls' => [],
+            ],
+            'max_request_size' => env('REVERB_MAX_REQUEST_SIZE', 10_000),
+            'scaling' => [
+                'enabled' => env('REVERB_SCALING_ENABLED', false),
+                'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'database' => env('REDIS_DB', '0'),
+                    'timeout' => env('REDIS_TIMEOUT', 60),
+                ],
+            ],
+            'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Applications
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how Reverb applications are managed. If you choose
+    | to use the "config" provider, you may define an array of apps which
+    | your server will support, including their connection credentials.
+    |
+    */
+
+    'apps' => [
+
+        'provider' => 'config',
+
+        'apps' => [
+            [
+                'key' => env('REVERB_APP_KEY'),
+                'secret' => env('REVERB_APP_SECRET'),
+                'app_id' => env('REVERB_APP_ID'),
+                'options' => [
+                    'host' => env('REVERB_HOST'),
+                    'port' => env('REVERB_PORT', 443),
+                    'scheme' => env('REVERB_SCHEME', 'https'),
+                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                ],
+                'allowed_origins' => ['*'],
+                'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
+                'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
+            ],
+        ],
+
+    ],
+
+];

--- a/database/factories/DriverProfileFactory.php
+++ b/database/factories/DriverProfileFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DriverProfile>
+ */
+class DriverProfileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->driver(),
+            'license_number' => fake()->unique()->bothify('LIC-######'),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
+use App\Enums\UserRole;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * @extends Factory<User>
@@ -20,6 +22,10 @@ class UserFactory extends Factory
     /**
      * Define the model's default state.
      *
+     * Por defecto un pasajero: es el rol con el que se registra la mayoría y
+     * el único que no necesita nada más para existir. Para un conductor está
+     * el estado `driver()`, y su perfil lo crea DriverProfileFactory.
+     *
      * @return array<string, mixed>
      */
     public function definition(): array
@@ -27,19 +33,16 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
+            'phone' => fake()->unique()->numerify('+57300#######'),
             'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'role' => UserRole::Passenger,
         ];
     }
 
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
+    public function driver(): static
     {
         return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
+            'role' => UserRole::Driver,
         ]);
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,6 +69,73 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /broadcasting/auth:
+    post:
+      tags:
+        - Realtime
+      operationId: authorizeBroadcastChannel
+      summary: Autorizar la suscripción a un canal privado
+      description: >-
+        Firma la suscripción del cliente a un canal privado de Reverb. El SDK
+        del cliente (Laravel Echo / pusher-js) llama a este endpoint por su
+        cuenta cada vez que se suscribe a un canal `private-*`, mandando el
+        `socket_id` de su conexión con el servidor de WebSockets y el nombre
+        del canal.
+
+        La autorización de cada canal está en `routes/channels.php`
+        (`ride.{rideId}` y `driver.{driverId}`): responde 403 si el usuario
+        autenticado no participa de esa entidad. Requiere un access token
+        vigente — a diferencia del refresh, acá el token expirado no sirve.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BroadcastAuthRequest"
+            example:
+              socket_id: "123456.789012"
+              channel_name: private-driver.1
+      responses:
+        "200":
+          description: >-
+            Suscripción autorizada. La firma se devuelve tal cual la espera el
+            cliente (formato del protocolo Pusher que habla Reverb), sin el
+            envelope `data` del resto de la API.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BroadcastAuthResponse"
+              example:
+                auth: "motoya-local:8f3c1a2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7081920a1b2c3d4e5f"
+        "401":
+          description: Falta el access token o ya no es válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El usuario autenticado no tiene permiso sobre la entidad del canal
+            (no es el conductor de `driver.{id}`, o no participa del viaje de
+            `ride.{id}`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -101,6 +168,37 @@ components:
             sobre el claim `exp` del token emitido. Es `null` cuando el token
             no expira (`JWT_TTL` sin valor).
           example: 900
+    BroadcastAuthRequest:
+      type: object
+      description: >-
+        Cuerpo que manda el SDK del cliente al suscribirse a un canal privado.
+        Los nombres de los campos los fija el protocolo Pusher que habla
+        Reverb, no esta API.
+      required:
+        - socket_id
+        - channel_name
+      properties:
+        socket_id:
+          type: string
+          description: Identificador de la conexión WebSocket que asignó Reverb.
+          example: "123456.789012"
+        channel_name:
+          type: string
+          description: >-
+            Nombre del canal en el cable, con el prefijo `private-` que agrega
+            el cliente. Canales definidos hoy: `private-ride.{rideId}` y
+            `private-driver.{driverId}`.
+          example: private-driver.1
+    BroadcastAuthResponse:
+      type: object
+      description: >-
+        Firma que el cliente reenvía a Reverb para completar la suscripción.
+      required:
+        - auth
+      properties:
+        auth:
+          type: string
+          description: "Firma HMAC del par `socket_id:channel_name`, en formato `<app_key>:<hmac>`."
     Error:
       type: object
       description: Formato de error de la API (exception handler de Laravel).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,20 @@
         <env name="JWT_SECRET" value="testing-only-not-a-real-secret-000000000000"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <!-- Credenciales de Reverb solo para la suite: no son secretos reales.
+             Van acá y no en el setUp() de un test porque el repositorio de
+             phpdotenv es inmutable y se llena en el primer boot del proceso:
+             una variable que no esté definida antes de ese boot queda marcada
+             como cargada desde .env y se repisa con el valor del archivo en
+             cada boot posterior (en CI, .env sale de .env.example y trae las
+             REVERB_APP_* vacías). Declaradas acá, PHPUnit las fija antes del
+             primer boot y phpdotenv nunca las toca. -->
+        <env name="REVERB_APP_ID" value="motoya-testing"/>
+        <env name="REVERB_APP_KEY" value="motoya-testing-key"/>
+        <env name="REVERB_APP_SECRET" value="motoya-testing-secret"/>
+        <env name="REVERB_HOST" value="127.0.0.1"/>
+        <env name="REVERB_PORT" value="8080"/>
+        <env name="REVERB_SCHEME" value="http"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,24 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
+use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
+    // Autorización de los canales privados de Reverb. La llama el SDK del
+    // cliente (Echo/pusher-js) por su cuenta al suscribirse, no la app móvil a
+    // mano. Se declara acá, y no con `withBroadcasting()` en bootstrap/app.php,
+    // para que quede versionada bajo /api/v1 y solo con POST: ese helper la
+    // registra con GET y POST fuera del prefijo de la API (ver
+    // App\Providers\BroadcastServiceProvider).
+    //
+    // Lleva `auth:api` como cualquier ruta protegida: acá el token expirado no
+    // sirve —a diferencia del refresh— y quién es el usuario es exactamente lo
+    // que las reglas de routes/channels.php necesitan resolver.
+    Route::middleware('auth:api')
+        ->post('broadcasting/auth', [BroadcastController::class, 'authenticate'])
+        ->name('broadcasting.auth');
+
     // Endpoints de autenticación: van sin `auth:api` a propósito, así que
     // cualquiera puede golpearlos sin credenciales. Por eso el grupo lleva un
     // límite de tasa más estricto que el general de la API — es el patrón que

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Broadcasting\DriverChannel;
+use App\Broadcasting\RideChannel;
+use Illuminate\Support\Facades\Broadcast;
+
+/*
+|--------------------------------------------------------------------------
+| Canales de broadcasting
+|--------------------------------------------------------------------------
+|
+| Convención de canales privados por entidad (ver .claude/STANDARDS.md,
+| "Tiempo real: Laravel Reverb"). Este archivo solo declara qué canales
+| existen; la regla de quién entra a cada uno vive en su clase de
+| App\Broadcasting, que es donde se puede probar sin levantar HTTP.
+|
+| Todos los canales son privados: no hay nada en este dominio que se pueda
+| escuchar de forma anónima. El cliente los pide con el prefijo `private-`
+| (`private-ride.7`) y la autorización pasa por POST /api/v1/broadcasting/auth.
+|
+| `guards: ['api']` es explícito a propósito: la API es stateless con JWT y no
+| tiene guard `web`. Sin esto, la resolución del usuario dependería de qué
+| guard dejó por defecto el middleware de la ruta.
+|
+*/
+
+Broadcast::channel('ride.{rideId}', RideChannel::class, ['guards' => ['api']]);
+
+Broadcast::channel('driver.{driverId}', DriverChannel::class, ['guards' => ['api']]);

--- a/tests/Feature/Realtime/BroadcastAuthEndpointTest.php
+++ b/tests/Feature/Realtime/BroadcastAuthEndpointTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * POST /api/v1/broadcasting/auth — la puerta de entrada a los canales privados
+ * (issue #5).
+ *
+ * Los tests de los canales prueban la regla; este prueba que esa regla se
+ * aplique de verdad cuando el cliente se suscribe: con el JWT del usuario, por
+ * el guard `api`, y devolviendo la firma que el cliente le reenvía a Reverb.
+ *
+ * La suite corre con BROADCAST_CONNECTION=null (phpunit.xml), y el broadcaster
+ * nulo autoriza cualquier cosa sin preguntar. Acá se fuerza `reverb` con
+ * credenciales de prueba: la firma es un HMAC local, así que no hace falta
+ * ningún servidor corriendo.
+ *
+ * La conexión se fija en el entorno *antes* de que arranque la aplicación, no
+ * con `Config::set` después: los canales de routes/channels.php se registran
+ * contra el broadcaster que esté configurado al bootear, así que cambiar la
+ * conexión más tarde deja al nuevo broadcaster sin ningún canal declarado.
+ */
+class BroadcastAuthEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/broadcasting/auth';
+
+    private const SOCKET_ID = '123456.789012';
+
+    private const APP_KEY = 'motoya-testing-key';
+
+    /** @var array<string, string> */
+    private const ENTORNO_REVERB = [
+        'BROADCAST_CONNECTION' => 'reverb',
+        'REVERB_APP_ID' => 'motoya-testing',
+        'REVERB_APP_KEY' => self::APP_KEY,
+        'REVERB_APP_SECRET' => 'motoya-testing-secret',
+        'REVERB_HOST' => '127.0.0.1',
+        'REVERB_PORT' => '8080',
+        'REVERB_SCHEME' => 'http',
+    ];
+
+    /** @var array<string, string|false> */
+    private array $entornoOriginal = [];
+
+    protected function setUp(): void
+    {
+        foreach (self::ENTORNO_REVERB as $clave => $valor) {
+            $this->entornoOriginal[$clave] = $_SERVER[$clave] ?? false;
+            $_SERVER[$clave] = $_ENV[$clave] = $valor;
+            putenv("{$clave}={$valor}");
+        }
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        foreach ($this->entornoOriginal as $clave => $valor) {
+            if ($valor === false) {
+                unset($_SERVER[$clave], $_ENV[$clave]);
+                putenv($clave);
+
+                continue;
+            }
+
+            $_SERVER[$clave] = $_ENV[$clave] = $valor;
+            putenv("{$clave}={$valor}");
+        }
+    }
+
+    public function test_sin_token_no_se_autoriza_ningun_canal(): void
+    {
+        $conductor = $this->conductorOperativo();
+
+        $this->postJson(self::URI, [
+            'socket_id' => self::SOCKET_ID,
+            'channel_name' => "private-driver.{$conductor->getKey()}",
+        ])->assertUnauthorized();
+    }
+
+    public function test_un_conductor_recibe_la_firma_de_su_propio_canal(): void
+    {
+        $conductor = $this->conductorOperativo();
+
+        $response = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'socket_id' => self::SOCKET_ID,
+                'channel_name' => "private-driver.{$conductor->getKey()}",
+            ]);
+
+        $response->assertOk()->assertJsonStructure(['auth']);
+
+        $this->assertStringStartsWith(self::APP_KEY.':', $response->json('auth'));
+    }
+
+    public function test_un_conductor_no_recibe_la_firma_del_canal_de_otro(): void
+    {
+        $conductor = $this->conductorOperativo();
+        $otro = $this->conductorOperativo();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'socket_id' => self::SOCKET_ID,
+                'channel_name' => "private-driver.{$otro->getKey()}",
+            ])
+            ->assertForbidden();
+    }
+
+    /**
+     * Mientras no exista el modelo `Ride` (historia #15) nadie participa de
+     * ningún viaje, así que el canal deniega — que es lo que tiene que pasar
+     * antes que abrirlo "por ahora".
+     */
+    public function test_el_canal_de_viaje_deniega_mientras_no_existan_viajes(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, [
+                'socket_id' => self::SOCKET_ID,
+                'channel_name' => 'private-ride.1',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_un_canal_que_no_esta_declarado_se_rechaza(): void
+    {
+        $conductor = $this->conductorOperativo();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'socket_id' => self::SOCKET_ID,
+                'channel_name' => 'private-admin.1',
+            ])
+            ->assertForbidden();
+    }
+
+    private function conductorOperativo(): User
+    {
+        $conductor = User::factory()->driver()->create();
+
+        DriverProfile::factory()->for($conductor)->create();
+
+        return $conductor;
+    }
+}

--- a/tests/Feature/Realtime/BroadcastAuthEndpointTest.php
+++ b/tests/Feature/Realtime/BroadcastAuthEndpointTest.php
@@ -19,14 +19,21 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  * el guard `api`, y devolviendo la firma que el cliente le reenvía a Reverb.
  *
  * La suite corre con BROADCAST_CONNECTION=null (phpunit.xml), y el broadcaster
- * nulo autoriza cualquier cosa sin preguntar. Acá se fuerza `reverb` con
- * credenciales de prueba: la firma es un HMAC local, así que no hace falta
- * ningún servidor corriendo.
+ * nulo autoriza cualquier cosa sin preguntar. Acá se fuerza `reverb`, que firma
+ * con las credenciales `REVERB_APP_*` de phpunit.xml: la firma es un HMAC
+ * local, así que no hace falta ningún servidor corriendo.
  *
  * La conexión se fija en el entorno *antes* de que arranque la aplicación, no
  * con `Config::set` después: los canales de routes/channels.php se registran
  * contra el broadcaster que esté configurado al bootear, así que cambiar la
  * conexión más tarde deja al nuevo broadcaster sin ningún canal declarado.
+ *
+ * Que funcione fijándola desde acá es un caso particular, no el mecanismo
+ * general: `BROADCAST_CONNECTION` está declarada en phpunit.xml, así que
+ * phpdotenv nunca la considera cargada desde `.env` y nunca la repisa. Una
+ * variable que *no* esté en phpunit.xml no se puede fijar así — el writer
+ * inmutable de phpdotenv la sobrescribe con el valor de `.env` en cada boot
+ * posterior al primero. Por eso las credenciales viven en phpunit.xml.
  */
 class BroadcastAuthEndpointTest extends TestCase
 {
@@ -36,29 +43,26 @@ class BroadcastAuthEndpointTest extends TestCase
 
     private const SOCKET_ID = '123456.789012';
 
+    /**
+     * Espejo de `REVERB_APP_KEY` en phpunit.xml: Reverb antepone la clave de la
+     * aplicación a la firma que devuelve.
+     */
     private const APP_KEY = 'motoya-testing-key';
 
-    /** @var array<string, string> */
-    private const ENTORNO_REVERB = [
-        'BROADCAST_CONNECTION' => 'reverb',
-        'REVERB_APP_ID' => 'motoya-testing',
-        'REVERB_APP_KEY' => self::APP_KEY,
-        'REVERB_APP_SECRET' => 'motoya-testing-secret',
-        'REVERB_HOST' => '127.0.0.1',
-        'REVERB_PORT' => '8080',
-        'REVERB_SCHEME' => 'http',
-    ];
+    /** Espejo de `REVERB_APP_SECRET` en phpunit.xml: con él se firma el HMAC. */
+    private const APP_SECRET = 'motoya-testing-secret';
 
-    /** @var array<string, string|false> */
-    private array $entornoOriginal = [];
+    private const CONEXION = 'BROADCAST_CONNECTION';
+
+    private string|false $conexionOriginal = false;
 
     protected function setUp(): void
     {
-        foreach (self::ENTORNO_REVERB as $clave => $valor) {
-            $this->entornoOriginal[$clave] = $_SERVER[$clave] ?? false;
-            $_SERVER[$clave] = $_ENV[$clave] = $valor;
-            putenv("{$clave}={$valor}");
-        }
+        $original = $_SERVER[self::CONEXION] ?? false;
+        $this->conexionOriginal = is_string($original) ? $original : false;
+
+        $_SERVER[self::CONEXION] = $_ENV[self::CONEXION] = 'reverb';
+        putenv(self::CONEXION.'=reverb');
 
         parent::setUp();
     }
@@ -67,17 +71,15 @@ class BroadcastAuthEndpointTest extends TestCase
     {
         parent::tearDown();
 
-        foreach ($this->entornoOriginal as $clave => $valor) {
-            if ($valor === false) {
-                unset($_SERVER[$clave], $_ENV[$clave]);
-                putenv($clave);
+        if ($this->conexionOriginal === false) {
+            unset($_SERVER[self::CONEXION], $_ENV[self::CONEXION]);
+            putenv(self::CONEXION);
 
-                continue;
-            }
-
-            $_SERVER[$clave] = $_ENV[$clave] = $valor;
-            putenv("{$clave}={$valor}");
+            return;
         }
+
+        $_SERVER[self::CONEXION] = $_ENV[self::CONEXION] = $this->conexionOriginal;
+        putenv(self::CONEXION.'='.$this->conexionOriginal);
     }
 
     public function test_sin_token_no_se_autoriza_ningun_canal(): void
@@ -93,16 +95,27 @@ class BroadcastAuthEndpointTest extends TestCase
     public function test_un_conductor_recibe_la_firma_de_su_propio_canal(): void
     {
         $conductor = $this->conductorOperativo();
+        $canal = "private-driver.{$conductor->getKey()}";
 
         $response = $this->withToken(JWTAuth::fromUser($conductor))
             ->postJson(self::URI, [
                 'socket_id' => self::SOCKET_ID,
-                'channel_name' => "private-driver.{$conductor->getKey()}",
+                'channel_name' => $canal,
             ]);
 
         $response->assertOk()->assertJsonStructure(['auth']);
 
-        $this->assertStringStartsWith(self::APP_KEY.':', $response->json('auth'));
+        // Se compara la firma completa, no solo el prefijo: con el prefijo
+        // bastaba que `REVERB_APP_KEY` fuera la esperada, y una credencial de
+        // firma vacía o distinta pasaba igual. El HMAC obliga a que las dos
+        // credenciales sean las que este test dice estar ejercitando.
+        $esperada = self::APP_KEY.':'.hash_hmac(
+            'sha256',
+            self::SOCKET_ID.':'.$canal,
+            self::APP_SECRET
+        );
+
+        $this->assertSame($esperada, $response->json('auth'));
     }
 
     public function test_un_conductor_no_recibe_la_firma_del_canal_de_otro(): void

--- a/tests/Feature/Realtime/DriverChannelTest.php
+++ b/tests/Feature/Realtime/DriverChannelTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Broadcasting\DriverChannel;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Autorización del canal privado `driver.{driverId}` (issue #5).
+ *
+ * Por este canal viajan las solicitudes de viaje cercanas: quien lo escucha ve
+ * en vivo dónde se está pidiendo transporte. Cada caso de acá es una forma de
+ * colarse en él.
+ */
+class DriverChannelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DriverChannel $channel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->channel = new DriverChannel;
+    }
+
+    public function test_un_conductor_operativo_entra_a_su_propio_canal(): void
+    {
+        $conductor = $this->conductorOperativo();
+
+        $this->assertTrue($this->channel->join($conductor, (string) $conductor->getKey()));
+    }
+
+    public function test_un_conductor_no_entra_al_canal_de_otro_conductor(): void
+    {
+        $conductor = $this->conductorOperativo();
+        $otro = $this->conductorOperativo();
+
+        $this->assertFalse($this->channel->join($conductor, (string) $otro->getKey()));
+    }
+
+    /**
+     * Un conductor sin perfil todavía no puede recibir viajes (decisión de #1
+     * en .claude/STANDARDS.md), así que tampoco tiene por qué ver las
+     * solicitudes que circulan.
+     */
+    public function test_un_conductor_sin_perfil_no_entra_a_su_canal(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->assertFalse($this->channel->join($conductor, (string) $conductor->getKey()));
+    }
+
+    public function test_un_pasajero_no_entra_al_canal_de_conductor_con_su_propio_id(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->assertFalse($this->channel->join($pasajero, (string) $pasajero->getKey()));
+    }
+
+    /**
+     * El nombre del canal lo elige el cliente, así que no basta con que el id
+     * se parezca al propio: tiene que ser idéntico.
+     */
+    public function test_un_id_de_canal_que_no_es_exactamente_el_propio_no_entra(): void
+    {
+        $conductor = $this->conductorOperativo();
+
+        $this->assertFalse($this->channel->join($conductor, $conductor->getKey().'abc'));
+        $this->assertFalse($this->channel->join($conductor, '0'.$conductor->getKey()));
+        $this->assertFalse($this->channel->join($conductor, ''));
+    }
+
+    private function conductorOperativo(): User
+    {
+        $conductor = User::factory()->driver()->create();
+
+        DriverProfile::factory()->for($conductor)->create();
+
+        return $conductor;
+    }
+}

--- a/tests/Feature/Realtime/RealtimePingTest.php
+++ b/tests/Feature/Realtime/RealtimePingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Actions\Realtime\SendRealtimePingAction;
+use App\Events\Realtime\RealtimePingSent;
+use App\Models\User;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\Config;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * Prueba de concepto del tiempo real de punta a punta (issue #5): la Action
+ * dispara el evento, el evento llega al broadcaster con el canal, el nombre y
+ * el payload que espera el cliente suscrito.
+ *
+ * El broadcaster real se reemplaza por uno que anota lo que recibiría el
+ * servidor de Reverb. Es el último punto del backend antes de la red: si el
+ * evento llega bien hasta acá, lo que sigue es Reverb entregándolo a quien se
+ * autorizó en el canal (ver BroadcastAuthEndpointTest).
+ */
+class RealtimePingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_ping_llega_al_broadcaster_en_el_canal_privado_del_conductor(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $conductor = User::factory()->driver()->create();
+
+        app(SendRealtimePingAction::class)->handle($conductor, 'hola conductor');
+
+        $this->assertCount(1, $grabador->emitidos);
+        [$canales, $evento, $payload] = $grabador->emitidos[0];
+
+        $this->assertSame(["private-driver.{$conductor->getKey()}"], $canales);
+        $this->assertSame('realtime.ping', $evento);
+        $this->assertSame('hola conductor', $payload['message']);
+    }
+
+    public function test_no_se_manda_un_ping_a_un_pasajero_porque_nadie_lo_escucharia(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $pasajero = User::factory()->create();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        try {
+            app(SendRealtimePingAction::class)->handle($pasajero, 'hola');
+        } finally {
+            $this->assertSame([], $grabador->emitidos);
+        }
+    }
+
+    public function test_el_evento_declara_el_canal_y_el_nombre_que_escucha_el_cliente(): void
+    {
+        $evento = new RealtimePingSent(driverId: 42, message: 'hola');
+
+        $this->assertSame('private-driver.42', $evento->broadcastOn()->name);
+        $this->assertSame('realtime.ping', $evento->broadcastAs());
+        $this->assertSame(['message' => 'hola'], $evento->broadcastWith());
+    }
+
+    public function test_el_comando_de_prueba_reporta_el_canal_al_que_publico(): void
+    {
+        $this->grabarBroadcasts();
+        $conductor = User::factory()->driver()->create();
+
+        $this->artisan('realtime:ping', ['driver' => $conductor->getKey(), 'message' => 'hola'])
+            ->assertSuccessful();
+    }
+
+    public function test_el_comando_falla_si_el_usuario_no_existe(): void
+    {
+        $this->artisan('realtime:ping', ['driver' => 999])->assertFailed();
+    }
+
+    public function test_el_comando_falla_si_el_usuario_no_es_conductor(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->artisan('realtime:ping', ['driver' => $pasajero->getKey()])->assertFailed();
+    }
+
+    /**
+     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
+     * anota lo que se le pidió publicar.
+     */
+    private function grabarBroadcasts(): object
+    {
+        $grabador = new class implements Broadcaster
+        {
+            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
+            public array $emitidos = [];
+
+            public function auth($request) {}
+
+            public function validAuthenticationResponse($request, $result) {}
+
+            public function broadcast(array $channels, $event, array $payload = []): void
+            {
+                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
+            }
+        };
+
+        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
+        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
+        Config::set('broadcasting.default', 'recording');
+
+        return $grabador;
+    }
+}

--- a/tests/Feature/Realtime/RideChannelTest.php
+++ b/tests/Feature/Realtime/RideChannelTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Broadcasting\RideChannel;
+use App\Models\User;
+use App\Services\Realtime\PendingRideParticipants;
+use App\Services\Realtime\RideParticipants;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Autorización del canal privado `ride.{rideId}` (issue #5).
+ *
+ * La regla que se prueba acá es la definitiva —solo el pasajero y el conductor
+ * del viaje lo escuchan— aunque el modelo `Ride` todavía no exista: de dónde
+ * salen esos ids está detrás de RideParticipants, y acá se reemplaza por una
+ * implementación de prueba.
+ */
+class RideChannelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const RIDE_ID = 7;
+
+    public function test_el_pasajero_del_viaje_entra_al_canal(): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create();
+
+        $channel = $this->channelConParticipantes([(int) $pasajero->getKey(), (int) $conductor->getKey()]);
+
+        $this->assertTrue($channel->join($pasajero, (string) self::RIDE_ID));
+    }
+
+    public function test_el_conductor_asignado_entra_al_canal(): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create();
+
+        $channel = $this->channelConParticipantes([(int) $pasajero->getKey(), (int) $conductor->getKey()]);
+
+        $this->assertTrue($channel->join($conductor, (string) self::RIDE_ID));
+    }
+
+    public function test_un_tercero_no_entra_al_canal_del_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $curioso = User::factory()->create();
+
+        $channel = $this->channelConParticipantes([(int) $pasajero->getKey()]);
+
+        $this->assertFalse($channel->join($curioso, (string) self::RIDE_ID));
+    }
+
+    public function test_un_viaje_que_no_existe_no_deja_entrar_a_nadie(): void
+    {
+        $usuario = User::factory()->create();
+
+        $channel = $this->channelConParticipantes([(int) $usuario->getKey()]);
+
+        $this->assertFalse($channel->join($usuario, '999'));
+    }
+
+    /**
+     * El id llega del nombre del canal, que lo escribe el cliente: nada que no
+     * sea un entero se convierte silenciosamente a uno.
+     */
+    public function test_un_id_de_viaje_que_no_es_un_entero_no_entra(): void
+    {
+        $usuario = User::factory()->create();
+
+        $channel = $this->channelConParticipantes([(int) $usuario->getKey()]);
+
+        foreach ([self::RIDE_ID.'abc', ' '.self::RIDE_ID, '-'.self::RIDE_ID, ''] as $idInvalido) {
+            $this->assertFalse(
+                $channel->join($usuario, (string) $idInvalido),
+                "El id de canal '{$idInvalido}' no debería autorizar."
+            );
+        }
+    }
+
+    /**
+     * Mientras no exista el modelo `Ride` (historia #15) el canal tiene que
+     * fallar cerrado: sin esto, un canal "provisionalmente abierto" expondría
+     * la ubicación en vivo de conductores y pasajeros.
+     */
+    public function test_la_implementacion_registrada_hoy_deniega_todo(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->assertInstanceOf(PendingRideParticipants::class, app(RideParticipants::class));
+
+        $this->assertFalse(
+            app(RideChannel::class)->join($usuario, (string) self::RIDE_ID),
+        );
+    }
+
+    /**
+     * @param  list<int>  $participantes
+     */
+    private function channelConParticipantes(array $participantes): RideChannel
+    {
+        return new RideChannel(new class(self::RIDE_ID, $participantes) implements RideParticipants
+        {
+            /**
+             * @param  list<int>  $participantes
+             */
+            public function __construct(
+                private readonly int $viaje,
+                private readonly array $participantes,
+            ) {}
+
+            /**
+             * @return list<int>
+             */
+            public function forRide(int $rideId): array
+            {
+                return $rideId === $this->viaje ? $this->participantes : [];
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #5

## Qué hace

Deja lista la infraestructura de tiempo real que bloquea las historias de tracking del viaje y de solicitudes cercanas a conductores. Los eventos de negocio concretos quedan fuera de alcance, como pide el issue.

**Reverb instalado y configurado**
- `laravel/reverb ^1.11`, `config/reverb.php` publicado y `config/broadcasting.php` recortado a las conexiones que este proyecto usa (`reverb`, `log`, `null`). Las de Pusher y Ably del skeleton se omiten: el proveedor está decidido y dejarlas solo agrega variables que nadie configura.
- `REVERB_*` documentadas en `.env.example`. Las credenciales de la app van sin default —son un secreto por entorno, igual que `JWT_SECRET`— y se generan con `php artisan reverb:install`.
- `composer dev` levanta también `reverb:start`.

**Canales privados y su autorización**
- `routes/channels.php` declara `ride.{rideId}` y `driver.{driverId}`, ambos con `['guards' => ['api']]` explícito (la API es stateless con JWT, no hay guard `web`).
- La regla de cada canal vive en `app/Broadcasting/` (canales class-based), que es donde se puede probar sin levantar HTTP:
  - `driver.{driverId}`: solo ese conductor, y solo si tiene perfil creado — un conductor sin perfil no recibe viajes (decisión de #1), así que tampoco tiene por qué ver las solicitudes que circulan. El `{driverId}` es el id de `User`, no el de `driver_profiles`: la API ya identifica a todos por el id de `User` y dos numeraciones para la misma persona son una fuente de errores de autorización.
  - `ride.{rideId}`: el pasajero del viaje y el conductor asignado.

**Evento y Action de prueba**
- `App\Events\Realtime\RealtimePingSent` (`ShouldBroadcastNow`) disparado por `App\Actions\Realtime\SendRealtimePingAction`, con `php artisan realtime:ping <id> "<mensaje>"` como prueba de concepto — el mismo patrón que `maps:estimate` para el proveedor de mapas.

## Cómo se probó

Todo en verde localmente, con el entorno que usa el CI (`cp .env.example .env`):

- `php artisan test` — 107 tests, 238 aserciones. 22 nuevos en `tests/Feature/Realtime/`.
- `vendor/bin/pint --test`, `composer stan` (PHPStan nivel 5), `composer audit`.
- `complexity_check.py`, `architecture_check.py`, `security_check.py` — sin errores (avisos: `REVERB_APP_MAX_CONNECTIONS` es opcional, mismo caso que `REDIS_URL`).
- `static_conformance.py` y `dynamic_conformance.py --start-server` — OK.
- `php artisan reverb:start` arranca y escucha con la configuración de `.env.example` (verificado; el `:8080` del ejemplo puede chocar con otro proceso local, `--port` lo resuelve).

Los tests cubren los criterios de aceptación, no solo el camino feliz: canal de otro conductor, conductor sin perfil, pasajero pidiendo un canal de conductor, ids que se *parecen* al propio (`7abc`, `07`, vacío), canal no declarado, request sin token, y la entrega del evento al broadcaster con canal, nombre y payload.

## Decisiones y riesgos

**1. `ride.{id}` falla cerrado hasta la historia #15.** El modelo `Ride` no existe todavía y crearlo acá invadiría esa historia. La regla de autorización sí es la definitiva; lo que está detrás de una interfaz es de dónde salen los participantes (`App\Services\Realtime\RideParticipants`, mismo patrón que `RouteEstimator`). La implementación registrada hoy no conoce ningún viaje, así que el canal **deniega todo** — un canal abierto "provisionalmente" expondría la ubicación en vivo de conductores y pasajeros a cualquier usuario autenticado que adivine un id. Cuando #15 cree la tabla, se cambia el binding en `AppServiceProvider` y ni el canal ni `routes/channels.php` se tocan.

**2. La ruta de autorización se declara a mano, no con `withBroadcasting()`.** Ese helper registra `/broadcasting/auth` con `GET` y `POST` fuera del prefijo de la API, lo que rompe el versionado y la correspondencia spec ↔ rutas reales que valida `static_conformance.py`. Acá es `POST /api/v1/broadcasting/auth` con `auth:api`, documentada en `openapi.yaml` como cualquier endpoint. Los canales los carga `App\Providers\BroadcastServiceProvider`.

**3. `BROADCAST_CONNECTION` pasa de `log` a `reverb` en `.env.example`.** Es la conexión real del proyecto; quien no quiera levantar el servidor pone `log`. La suite sigue en `null` por `phpunit.xml`.

**4. Fuera del alcance estricto: `database/factories/UserFactory.php`.** Estaba roto —no ponía `phone` ni `role` (ambos `NOT NULL`) y sí `email_verified_at` y `remember_token`, columnas que la migración de `users` no tiene—, así que cualquier uso reventaba y por eso los tests existentes crean usuarios a mano. Se corrigió al mínimo y se agregó el estado `driver()` más `DriverProfileFactory`, que es lo que necesitan los tests de canales. De paso, `DatabaseSeeder` vuelve a funcionar.

**5. Un detalle a tener presente al escribir tests futuros**, documentado en STANDARDS.md: los canales se registran contra el broadcaster que esté configurado al bootear la aplicación. Cambiar `broadcasting.default` con `Config::set` dentro de un test deja al broadcaster nuevo sin canales; hay que fijarlo en el entorno antes de que arranque la app (es lo que hace `BroadcastAuthEndpointTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)