### PR TITLE
feat(#6): registrarme como pasajero

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -134,6 +134,19 @@ cuando lleguen.
 - `email` y `phone` son únicos en `users`; ambos se validan con `unique` en el Form
   Request, no solo con el índice de la tabla — sin la regla, un duplicado escala a un
   500 por violación de constraint en vez del 422 que el cliente puede mostrar.
+- **Forma canónica de `email` y `phone`** (email en minúsculas; teléfono siempre con
+  `+`, aunque el cliente pueda omitirlo). Se normaliza en `prepareForValidation()` del
+  Form Request, es decir **antes** de `unique` y del DTO, así que lo que se valida y lo
+  que se guarda son el mismo valor. Sin esto la unicidad de la cuenta depende de la
+  colación del motor —SQLite (dev y tests) compara BINARY, MySQL con colación `_ci` no—
+  y basta una mayúscula, o pegar el número desde la agenda en vez de teclearlo, para
+  terminar con dos cuentas de la misma persona. Importa más allá del alta: sobre esa
+  unicidad se apoyan el login (#8), la recuperación de cuenta y el teléfono como canal
+  de contacto durante el viaje. Los endpoints de registro que vengan (conductor, #7)
+  normalizan igual.
+  Queda **fuera** normalizar a E.164 de verdad (deducir el código de país de un número
+  local con libphonenumber): eso es una decisión de negocio con migración de los datos
+  ya guardados, y el lugar para tomarla es cuando llegue el OTP por SMS.
 
 ### Política de contraseñas (decidida en #6)
 

--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -113,6 +113,45 @@ el blanco natural de la fuerza bruta; en el caso del refresh, además, cada acie
 escribe una entrada de blacklist en el cache. Login y registro heredan este mismo grupo
 cuando lleguen.
 
+### Registro de cuentas (decidido en #6)
+
+**Un endpoint de registro por rol**, no uno solo con el rol como campo de entrada:
+`POST /api/v1/auth/register/passenger` (historia #6) y el de conductor con la #7.
+
+- El rol **nunca se acepta como entrada**. Lo fija la Action correspondiente. El DTO
+  de entrada (`App\DTOs\PassengerRegistration`) directamente no tiene campo de rol, y
+  el Form Request arma ese DTO campo por campo en vez de pasar `validated()` completo:
+  así no hay ningún camino por el que un `role` del cliente llegue hasta `users`.
+  Importa porque `role` es fillable en el modelo, y porque registrarse como conductor
+  exige requisitos (perfil, documentos) que el endpoint de pasajeros no pide.
+- El registro **devuelve un access token**, no solo la cuenta creada: obligar a un
+  login inmediatamente después haría que la app móvil mande la contraseña dos veces
+  por la red para completar un alta. Responde **201** con el schema
+  `AuthenticatedUser` (`{user, token}`), que el login reutiliza.
+- Los endpoints de registro van sin `auth:api` y, por lo tanto, bajo el limitador
+  `auth` (10/min por IP): anónimos, sirven para crear cuentas en masa y para sondear
+  qué emails ya existen.
+- `email` y `phone` son únicos en `users`; ambos se validan con `unique` en el Form
+  Request, no solo con el índice de la tabla — sin la regla, un duplicado escala a un
+  500 por violación de constraint en vez del 422 que el cliente puede mostrar.
+
+### Política de contraseñas (decidida en #6)
+
+Mínimo **8 caracteres, con al menos una letra y al menos un número**, declarada una
+sola vez como `Password::defaults()` en `AppServiceProvider` y referenciada desde los
+Form Requests. Centralizarla es lo que evita que registro, login y un eventual cambio
+de contraseña diverjan.
+
+No se exigen símbolos ni mayúsculas y minúsculas: para una app de transporte en móvil
+esas reglas empujan a contraseñas anotadas o a variaciones triviales (`Motoya1!`), y
+las guías actuales (NIST SP 800-63B) favorecen longitud sobre composición. Si más
+adelante hace falta endurecerla, el lugar es subir el mínimo de longitud.
+
+Queda **fuera** `uncompromised()` (contraste contra la lista de Pwned Passwords): hace
+una llamada HTTP a un servicio externo dentro del ciclo de validación, lo que ataría
+el registro a la disponibilidad de un tercero y metería red en la suite de tests. Es
+una mejora razonable a futuro si se resuelve con timeout y degradación explícita.
+
 ### Envelope de las respuestas
 
 Los API Resources de Laravel envuelven la respuesta en `data` y ese es el formato que

--- a/app/Actions/Auth/RefreshTokenAction.php
+++ b/app/Actions/Auth/RefreshTokenAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Auth;
 
 use App\DTOs\AuthToken;
+use App\Services\Auth\AccessTokenFactory;
 use Tymon\JWTAuth\JWTAuth;
-use Tymon\JWTAuth\Support\Utils;
 
 /**
  * Canjea un access token por uno nuevo.
@@ -17,31 +17,13 @@ use Tymon\JWTAuth\Support\Utils;
  */
 final class RefreshTokenAction
 {
-    public function __construct(private readonly JWTAuth $jwt) {}
+    public function __construct(
+        private readonly JWTAuth $jwt,
+        private readonly AccessTokenFactory $tokens,
+    ) {}
 
     public function handle(string $token): AuthToken
     {
-        $accessToken = $this->jwt->setToken($token)->refresh();
-
-        return new AuthToken(
-            accessToken: $accessToken,
-            expiresInSeconds: $this->secondsUntilExpiry($accessToken),
-        );
-    }
-
-    /**
-     * Segundos que le quedan al token recién emitido, leídos de su claim `exp`,
-     * o `null` si el token no expira.
-     *
-     * Se lee del token y no de `jwt.ttl` porque el TTL admite `null`: en ese
-     * caso jwt-auth omite el claim `exp` y emite un token perpetuo, y
-     * `(int) null * 60` habría reportado "expira en 0 segundos" para un token
-     * que no vence nunca.
-     */
-    private function secondsUntilExpiry(string $accessToken): ?int
-    {
-        $exp = $this->jwt->setToken($accessToken)->getPayload()->get('exp');
-
-        return $exp === null ? null : (int) $exp - Utils::now()->getTimestamp();
+        return $this->tokens->fromJwt($this->jwt->setToken($token)->refresh());
     }
 }

--- a/app/Actions/Auth/RegisterPassengerAction.php
+++ b/app/Actions/Auth/RegisterPassengerAction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\DTOs\AuthenticatedUser;
+use App\DTOs\PassengerRegistration;
+use App\Enums\UserRole;
+use App\Models\User;
+use App\Services\Auth\AccessTokenFactory;
+use Tymon\JWTAuth\JWTAuth;
+
+/**
+ * Da de alta un pasajero y lo deja autenticado en el mismo paso.
+ *
+ * Emitir el token acá, y no obligar a un login inmediatamente después, es lo
+ * que evita que la app móvil tenga que mandar la contraseña dos veces seguidas
+ * por la red para completar un alta.
+ *
+ * El rol se fija en `UserRole::Passenger` y no sale de la entrada: registrarse
+ * como conductor es otro caso de uso (historia #7), con sus propios requisitos
+ * de perfil.
+ */
+final class RegisterPassengerAction
+{
+    public function __construct(
+        private readonly JWTAuth $jwt,
+        private readonly AccessTokenFactory $tokens,
+    ) {}
+
+    public function handle(PassengerRegistration $registration): AuthenticatedUser
+    {
+        // La contraseña se guarda hasheada por el cast `hashed` del modelo, no
+        // por un Hash::make() acá: así vale para cualquier vía de creación.
+        $user = User::create([
+            'name' => $registration->name,
+            'email' => $registration->email,
+            'phone' => $registration->phone,
+            'password' => $registration->password,
+            'role' => UserRole::Passenger,
+        ]);
+
+        return new AuthenticatedUser(
+            user: $user,
+            token: $this->tokens->fromJwt($this->jwt->fromUser($user)),
+        );
+    }
+}

--- a/app/DTOs/AuthenticatedUser.php
+++ b/app/DTOs/AuthenticatedUser.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Models\User;
+
+/**
+ * Una cuenta junto al access token con el que quedó autenticada.
+ *
+ * Es lo que devuelven los casos de uso que dejan al usuario adentro en un solo
+ * paso: hoy el registro, y el login cuando llegue (historia #8). Existe para
+ * que la Action no tenga que devolver una tupla suelta y para que el API
+ * Resource reciba las dos piezas ya emparejadas.
+ */
+final readonly class AuthenticatedUser
+{
+    public function __construct(
+        public User $user,
+        public AuthToken $token,
+    ) {}
+}

--- a/app/DTOs/PassengerRegistration.php
+++ b/app/DTOs/PassengerRegistration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Datos con los que se da de alta un pasajero, ya validados.
+ *
+ * No lleva rol a propósito: el caso de uso es registrar pasajeros, así que el
+ * rol lo fija `RegisterPassengerAction` y no hay forma de pedir otro por esta
+ * vía. Que el DTO no tenga el campo es justamente lo que hace imposible que un
+ * `role` llegue desde la entrada del cliente hasta la fila de `users`.
+ */
+final readonly class PassengerRegistration
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $phone,
+        public string $password,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Auth/RegisterPassengerController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RegisterPassengerController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\RegisterPassengerAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterPassengerRequest;
+use App\Http\Resources\AuthenticatedUserResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/auth/register/passenger
+ *
+ * Va sin `auth:api` —quien se registra todavía no tiene cuenta— y por eso
+ * queda bajo el limitador `auth`, más estricto que el general de la API.
+ */
+class RegisterPassengerController extends Controller
+{
+    public function __invoke(
+        RegisterPassengerRequest $request,
+        RegisterPassengerAction $registerPassenger,
+    ): JsonResponse {
+        $registered = $registerPassenger->handle($request->toRegistration());
+
+        return (new AuthenticatedUserResource($registered))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Auth/RegisterPassengerRequest.php
+++ b/app/Http/Requests/Auth/RegisterPassengerRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\DTOs\PassengerRegistration;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Entrada de POST /api/v1/auth/register/passenger — ver openapi.yaml.
+ *
+ * No define `authorize()`: el endpoint es anónimo por diseño (nadie tiene
+ * cuenta todavía cuando lo llama), así que no hay sujeto contra el cual
+ * autorizar. Lo que lo protege es el limitador de tasa `auth`, no una Policy.
+ */
+class RegisterPassengerRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            // `unique` acá y no solo el índice de la tabla: sin la regla, un
+            // teléfono repetido escalaría a un 500 por violación de constraint
+            // en vez del 422 que el cliente puede mostrarle al usuario.
+            'phone' => ['required', 'string', 'max:20', 'regex:/^\+?[0-9]{7,15}$/', 'unique:users,phone'],
+            'password' => ['required', 'string', Password::defaults()],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio.',
+        ];
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     *
+     * Los campos se leen uno por uno en vez de con `validated()`: es lo que
+     * garantiza que nada que no esté acá —un `role` mandado por el cliente, por
+     * ejemplo— pueda colarse hasta la creación del usuario.
+     */
+    public function toRegistration(): PassengerRegistration
+    {
+        return new PassengerRegistration(
+            name: $this->string('name')->toString(),
+            email: $this->string('email')->toString(),
+            phone: $this->string('phone')->toString(),
+            password: $this->string('password')->toString(),
+        );
+    }
+}

--- a/app/Http/Requests/Auth/RegisterPassengerRequest.php
+++ b/app/Http/Requests/Auth/RegisterPassengerRequest.php
@@ -6,6 +6,7 @@ namespace App\Http\Requests\Auth;
 
 use App\DTOs\PassengerRegistration;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password;
 
 /**
@@ -18,6 +19,43 @@ use Illuminate\Validation\Rules\Password;
 class RegisterPassengerRequest extends FormRequest
 {
     /**
+     * Lleva `email` y `phone` a su forma canónica ANTES de validar.
+     *
+     * `unique` traduce a un `where columna = ?`, así que sin esto la unicidad de
+     * la cuenta queda a merced de la colación del motor: en SQLite (el driver de
+     * dev y el de `phpunit.xml`) es BINARY, y `Ana@example.com` convive con
+     * `ana@example.com` como dos cuentas distintas; en MySQL con colación `_ci`
+     * el comportamiento sería el contrario. Normalizar acá hace que lo que se
+     * valida y lo que se guarda sean siempre el mismo valor comparable, sin
+     * depender del motor — y sobre esa unicidad se apoyan el login (#8) y
+     * cualquier recuperación de cuenta futura.
+     */
+    protected function prepareForValidation(): void
+    {
+        $canonicos = [];
+
+        $email = $this->input('email');
+
+        if (is_string($email)) {
+            $canonicos['email'] = Str::lower($email);
+        }
+
+        $phone = $this->input('phone');
+
+        // El `+` es opcional en la entrada, así que `573001234567` y
+        // `+573001234567` son el mismo número y tienen que colisionar: no hace
+        // falta mala intención para mandar los dos, es la diferencia entre
+        // teclearlo y pegarlo desde la agenda. Solo se antepone el `+` a lo que
+        // ya empieza por dígito, para que una entrada malformada (`++57…`) siga
+        // muriendo en el `regex` en vez de quedar "arreglada" por acá.
+        if (is_string($phone) && preg_match('/^[0-9]/', $phone) === 1) {
+            $canonicos['phone'] = '+'.$phone;
+        }
+
+        $this->merge($canonicos);
+    }
+
+    /**
      * @return array<string, array<int, mixed>>
      */
     public function rules(): array
@@ -28,7 +66,10 @@ class RegisterPassengerRequest extends FormRequest
             // `unique` acá y no solo el índice de la tabla: sin la regla, un
             // teléfono repetido escalaría a un 500 por violación de constraint
             // en vez del 422 que el cliente puede mostrarle al usuario.
-            'phone' => ['required', 'string', 'max:20', 'regex:/^\+?[0-9]{7,15}$/', 'unique:users,phone'],
+            // El regex exige el `+` porque para cuando corre ya se normalizó la
+            // entrada: la forma canónica siempre lo lleva. Lo que el cliente
+            // manda sigue siendo `+` opcional (ver `prepareForValidation`).
+            'phone' => ['required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/', 'unique:users,phone'],
             'password' => ['required', 'string', Password::defaults()],
         ];
     }
@@ -39,7 +80,7 @@ class RegisterPassengerRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio.',
+            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio; se guarda siempre con el +.',
         ];
     }
 

--- a/app/Http/Resources/AuthenticatedUserResource.php
+++ b/app/Http/Resources/AuthenticatedUserResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\DTOs\AuthenticatedUser;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa una cuenta y su access token según el schema `AuthenticatedUser`
+ * de openapi.yaml.
+ *
+ * Los resources anidados no repiten el envelope `data`: Laravel solo lo agrega
+ * en el nivel superior de la respuesta.
+ *
+ * @property-read AuthenticatedUser $resource
+ */
+class AuthenticatedUserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'user' => new UserResource($this->resource->user),
+            'token' => new AuthTokenResource($this->resource->token),
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa una cuenta según el schema `User` de openapi.yaml.
+ *
+ * Los campos se listan de forma explícita en vez de volcar el modelo: `$hidden`
+ * protege la contraseña, pero cualquier columna que se agregue mañana a `users`
+ * quedaría expuesta sola si acá se devolviera el modelo entero.
+ *
+ * @property-read User $resource
+ */
+class UserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'email' => $this->resource->email,
+            'phone' => $this->resource->phone,
+            'role' => $this->resource->role->value,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\Rules\Password;
 use InvalidArgumentException;
 
 class AppServiceProvider extends ServiceProvider
@@ -94,6 +95,20 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureRateLimiting();
+        $this->configurePasswordPolicy();
+    }
+
+    /**
+     * Política mínima de contraseñas: 8 caracteres, con al menos una letra y al
+     * menos un número (ver .claude/STANDARDS.md).
+     *
+     * Se declara como `Password::defaults()` y no suelta en cada Form Request
+     * para que registro, login y un eventual cambio de contraseña no puedan
+     * divergir: si mañana sube el mínimo, sube en un solo lugar.
+     */
+    private function configurePasswordPolicy(): void
+    {
+        Password::defaults(fn () => Password::min(8)->letters()->numbers());
     }
 
     /**

--- a/app/Services/Auth/AccessTokenFactory.php
+++ b/app/Services/Auth/AccessTokenFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Auth;
+
+use App\DTOs\AuthToken;
+use Tymon\JWTAuth\JWTAuth;
+use Tymon\JWTAuth\Support\Utils;
+
+/**
+ * Envuelve un JWT ya emitido en el DTO `AuthToken`, resolviendo cuánta vida le
+ * queda.
+ *
+ * Es un adaptador sobre jwt-auth, no un caso de uso: existe para que las
+ * Actions que emiten tokens (registro, y el login de la historia #8) y la que
+ * los renueva no repitan el cálculo del vencimiento, que tiene un caso borde
+ * propio — ver `secondsUntilExpiry()`.
+ */
+final class AccessTokenFactory
+{
+    public function __construct(private readonly JWTAuth $jwt) {}
+
+    public function fromJwt(string $accessToken): AuthToken
+    {
+        return new AuthToken(
+            accessToken: $accessToken,
+            expiresInSeconds: $this->secondsUntilExpiry($accessToken),
+        );
+    }
+
+    /**
+     * Segundos que le quedan al token, leídos de su claim `exp`, o `null` si el
+     * token no expira.
+     *
+     * Se lee del token y no de `jwt.ttl` porque el TTL admite `null`: en ese
+     * caso jwt-auth omite el claim `exp` y emite un token perpetuo, y
+     * `(int) null * 60` habría reportado "expira en 0 segundos" para un token
+     * que no vence nunca.
+     */
+    private function secondsUntilExpiry(string $accessToken): ?int
+    {
+        $exp = $this->jwt->setToken($accessToken)->getPayload()->get('exp');
+
+        return $exp === null ? null : (int) $exp - Utils::now()->getTimestamp();
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -312,14 +312,21 @@ components:
           type: string
           format: email
           maxLength: 255
-          description: Único entre todas las cuentas.
+          description: >-
+            Único entre todas las cuentas. Se normaliza a minúsculas antes de
+            validarlo y de guardarlo, así que `Ana@example.com` y
+            `ana@example.com` son la misma cuenta (la segunda alta responde
+            422).
           example: ana@example.com
         phone:
           type: string
           maxLength: 20
           description: >-
             Único entre todas las cuentas. Se acepta en formato E.164 (`+` y
-            de 7 a 15 dígitos); el `+` es opcional.
+            de 7 a 15 dígitos); el `+` es opcional en la entrada, pero el
+            número se guarda y se devuelve siempre con él. Es decir,
+            `573001234567` y `+573001234567` son el mismo número y el segundo
+            registro responde 422.
           example: "+573001234567"
         password:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,6 +69,82 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /auth/register/passenger:
+    post:
+      tags:
+        - Auth
+      operationId: registerPassenger
+      summary: Registrar una cuenta de pasajero
+      description: >-
+        Crea una cuenta con rol `passenger` y devuelve, en la misma respuesta,
+        un access token válido: la app móvil queda autenticada sin tener que
+        encadenar un login inmediatamente después del registro.
+
+        El rol **no** se acepta como entrada — lo fija el endpoint. Registrarse
+        como conductor es otro endpoint (historia #7), porque además del rol
+        exige los datos del perfil de conductor.
+
+        No requiere autenticación, y por eso comparte con el resto de
+        endpoints de auth el límite de 10 requests por minuto e IP.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PassengerRegistrationRequest"
+            example:
+              name: Ana García
+              email: ana@example.com
+              phone: "+573001234567"
+              password: motoya2026
+      responses:
+        "201":
+          description: Cuenta creada y sesión iniciada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AuthenticatedUser"
+              example:
+                data:
+                  user:
+                    id: 1
+                    name: Ana García
+                    email: ana@example.com
+                    phone: "+573001234567"
+                    role: passenger
+                  token:
+                    access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJwYXNzZW5nZXIifQ.4pcPyMD09olPSyXnrXCjTwXyr4BsezdI1AVTmud2fU4
+                    token_type: bearer
+                    expires_in: 900
+        "422":
+          description: >-
+            La entrada no pasó la validación: falta un campo requerido, el
+            email o el teléfono ya están registrados, o la contraseña no
+            cumple la política mínima.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The email has already been taken.
+                errors:
+                  email:
+                    - The email has already been taken.
+        "429":
+          description: >-
+            Se superó el límite de requests por minuto para esta IP.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /broadcasting/auth:
     post:
       tags:
@@ -168,6 +244,91 @@ components:
             sobre el claim `exp` del token emitido. Es `null` cuando el token
             no expira (`JWT_TTL` sin valor).
           example: 900
+    User:
+      type: object
+      description: >-
+        Datos públicos de una cuenta. Nunca incluye la contraseña (el modelo la
+        declara en `$hidden`).
+      required:
+        - id
+        - name
+        - email
+        - phone
+        - role
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Ana García
+        email:
+          type: string
+          format: email
+          example: ana@example.com
+        phone:
+          type: string
+          example: "+573001234567"
+        role:
+          type: string
+          description: >-
+            Rol de autenticación de la cuenta (ver la decisión de modelo de
+            datos en .claude/STANDARDS.md). Sirve para que el cliente sepa qué
+            UI mostrar; la autorización de negocio se resuelve con Policies en
+            el servidor, no con este campo.
+          enum:
+            - passenger
+            - driver
+          example: passenger
+    AuthenticatedUser:
+      type: object
+      description: >-
+        Cuenta más el access token con el que quedó autenticada. Es la
+        respuesta común del registro y del login.
+      required:
+        - user
+        - token
+      properties:
+        user:
+          $ref: "#/components/schemas/User"
+        token:
+          $ref: "#/components/schemas/AuthToken"
+    PassengerRegistrationRequest:
+      type: object
+      description: >-
+        Datos con los que se da de alta un pasajero. El rol no se manda: lo
+        fija el endpoint.
+      required:
+        - name
+        - email
+        - phone
+        - password
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          example: Ana García
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: Único entre todas las cuentas.
+          example: ana@example.com
+        phone:
+          type: string
+          maxLength: 20
+          description: >-
+            Único entre todas las cuentas. Se acepta en formato E.164 (`+` y
+            de 7 a 15 dígitos); el `+` es opcional.
+          example: "+573001234567"
+        password:
+          type: string
+          format: password
+          minLength: 8
+          description: >-
+            Mínimo 8 caracteres, con al menos una letra y al menos un número
+            (ver la política en .claude/STANDARDS.md).
+          example: motoya2026
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
+use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
 
@@ -22,11 +23,12 @@ Route::prefix('v1')->group(function () {
     // Endpoints de autenticación: van sin `auth:api` a propósito, así que
     // cualquiera puede golpearlos sin credenciales. Por eso el grupo lleva un
     // límite de tasa más estricto que el general de la API — es el patrón que
-    // heredan login y registro cuando lleguen (ver AppServiceProvider).
+    // hereda el login cuando llegue (ver AppServiceProvider).
     Route::middleware('throttle:auth')
         ->prefix('auth')
         ->name('auth.')
         ->group(function () {
             Route::post('refresh', RefreshTokenController::class)->name('refresh');
+            Route::post('register/passenger', RegisterPassengerController::class)->name('register.passenger');
         });
 });

--- a/tests/Feature/Auth/RegisterPassengerTest.php
+++ b/tests/Feature/Auth/RegisterPassengerTest.php
@@ -104,6 +104,56 @@ class RegisterPassengerTest extends TestCase
             ->assertJsonValidationErrors('phone');
     }
 
+    public function test_rechaza_un_email_ya_registrado_en_otra_capitalizacion(): void
+    {
+        // `unique` es un `where email = ?` y la colación de SQLite es BINARY:
+        // sin normalizar, mandar una mayúscula alcanza para tener dos cuentas
+        // de la misma persona y para incumplir el criterio "email ya registrado
+        // → 422".
+        User::factory()->create(['email' => 'ana@example.com']);
+
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'email' => 'Ana@Example.COM'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+
+        $this->assertSame(1, User::whereRaw('lower(email) = ?', ['ana@example.com'])->count());
+    }
+
+    public function test_rechaza_un_telefono_ya_registrado_sin_el_prefijo_internacional(): void
+    {
+        // El `+` es opcional en la entrada, así que estas dos formas son el
+        // mismo número: si no colisionaran, el teléfono —canal de contacto
+        // durante el viaje y candidato natural para OTP— dejaría de identificar
+        // una sola cuenta.
+        User::factory()->create(['phone' => '+573001234567']);
+
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'phone' => '573001234567'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+
+        $this->assertSame(1, User::where('phone', '+573001234567')->count());
+    }
+
+    public function test_guarda_email_y_telefono_en_su_forma_canonica(): void
+    {
+        // La otra mitad de la normalización: lo que se guarda tiene que ser el
+        // mismo valor que se validó, o el duplicado entraría por la puerta de
+        // atrás en el registro siguiente.
+        $this->postJson(self::REGISTER_URI, [
+            ...$this->datosValidos(),
+            'email' => 'Ana@Example.COM',
+            'phone' => '573001234567',
+        ])
+            ->assertCreated()
+            ->assertJsonPath('data.user.email', 'ana@example.com')
+            ->assertJsonPath('data.user.phone', '+573001234567');
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+    }
+
     /**
      * @param  list<string>  $camposEsperados
      */
@@ -171,11 +221,26 @@ class RegisterPassengerTest extends TestCase
             ->assertJsonValidationErrors('email');
     }
 
-    public function test_rechaza_un_telefono_con_formato_invalido(): void
+    #[DataProvider('telefonosInvalidos')]
+    public function test_rechaza_un_telefono_con_formato_invalido(string $phone): void
     {
-        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'phone' => 'tres-cero-cero'])
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'phone' => $phone])
             ->assertUnprocessable()
             ->assertJsonValidationErrors('phone');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function telefonosInvalidos(): array
+    {
+        return [
+            'no son dígitos' => ['tres-cero-cero'],
+            // Normalizar no puede convertirse en una vía para colar entradas
+            // malformadas: al `+` de más lo sigue atajando el regex.
+            'prefijo duplicado' => ['++573001234567'],
+            'demasiado corto' => ['+57300'],
+        ];
     }
 
     public function test_ignora_el_rol_que_venga_en_la_entrada(): void

--- a/tests/Feature/Auth/RegisterPassengerTest.php
+++ b/tests/Feature/Auth/RegisterPassengerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Contrato de POST /api/v1/auth/register/passenger — ver openapi.yaml.
+ *
+ * Un registro exitoso deja al pasajero ya autenticado: devuelve la cuenta y un
+ * access token usable, para que la app móvil no tenga que encadenar un login
+ * inmediatamente después.
+ */
+class RegisterPassengerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const REGISTER_URI = '/api/v1/auth/register/passenger';
+
+    private const PROBE_URI = '/api/v1/_probe-protegida';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('auth:api')->get(self::PROBE_URI, function () {
+            return response()->json(['user_id' => auth('api')->id()]);
+        });
+    }
+
+    public function test_registra_al_pasajero_y_devuelve_la_forma_del_contrato(): void
+    {
+        // `expires_in` se calcula restándole "ahora" al claim `exp` del token
+        // emitido; sin congelar el reloj, cruzar un segundo entre ambas
+        // lecturas daría 899 y haría el test intermitente.
+        $this->freezeSecond();
+
+        $response = $this->postJson(self::REGISTER_URI, $this->datosValidos());
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'data' => [
+                    'user' => ['id', 'name', 'email', 'phone', 'role'],
+                    'token' => ['access_token', 'token_type', 'expires_in'],
+                ],
+            ])
+            ->assertJsonPath('data.user.name', 'Ana García')
+            ->assertJsonPath('data.user.email', 'ana@example.com')
+            ->assertJsonPath('data.user.phone', '+573001234567')
+            ->assertJsonPath('data.user.role', 'passenger')
+            ->assertJsonPath('data.token.token_type', 'bearer')
+            // 15 minutos de TTL expresados en segundos.
+            ->assertJsonPath('data.token.expires_in', 900);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+            'role' => UserRole::Passenger->value,
+        ]);
+    }
+
+    public function test_el_token_devuelto_autentica_al_pasajero_recien_creado(): void
+    {
+        // Lo que hace útil al endpoint no es que devuelva "un string": es que
+        // ese token sirva de verdad contra la API, para el usuario correcto.
+        $token = $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertCreated()
+            ->json('data.token.access_token');
+
+        $this->withToken($token)
+            ->getJson(self::PROBE_URI)
+            ->assertOk()
+            ->assertJson(['user_id' => User::firstWhere('email', 'ana@example.com')->id]);
+    }
+
+    public function test_rechaza_un_email_ya_registrado(): void
+    {
+        User::factory()->create(['email' => 'ana@example.com']);
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email')
+            ->assertJsonStructure(['message', 'errors']);
+
+        $this->assertSame(1, User::where('email', 'ana@example.com')->count());
+    }
+
+    public function test_rechaza_un_telefono_ya_registrado(): void
+    {
+        // El teléfono es único en la tabla: sin validarlo, el duplicado
+        // escalaría a un 500 por violación de constraint en vez de un 422.
+        User::factory()->create(['phone' => '+573001234567']);
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+
+    /**
+     * @param  list<string>  $camposEsperados
+     */
+    #[DataProvider('camposRequeridos')]
+    public function test_rechaza_la_falta_de_un_campo_requerido(string $campoFaltante, array $camposEsperados): void
+    {
+        $datos = $this->datosValidos();
+        unset($datos[$campoFaltante]);
+
+        $this->postJson(self::REGISTER_URI, $datos)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($camposEsperados);
+
+        $this->assertDatabaseCount('users', 0);
+    }
+
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function camposRequeridos(): array
+    {
+        return [
+            'nombre' => ['name', ['name']],
+            'email' => ['email', ['email']],
+            'teléfono' => ['phone', ['phone']],
+            'contraseña' => ['password', ['password']],
+        ];
+    }
+
+    public function test_informa_todos_los_campos_faltantes_en_una_sola_respuesta(): void
+    {
+        // Un 422 por campo obligaría a la app móvil a reintentar cuatro veces
+        // para descubrir el formulario entero.
+        $this->postJson(self::REGISTER_URI, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'email', 'phone', 'password']);
+    }
+
+    #[DataProvider('contrasenasQueNoCumplenLaPolitica')]
+    public function test_rechaza_una_contrasena_que_no_cumple_la_politica(string $password): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'password' => $password])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('password');
+
+        $this->assertDatabaseCount('users', 0);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function contrasenasQueNoCumplenLaPolitica(): array
+    {
+        return [
+            'demasiado corta' => ['moto26'],
+            'sin números' => ['motoyamotoya'],
+            'sin letras' => ['20262026262'],
+        ];
+    }
+
+    public function test_rechaza_un_email_con_formato_invalido(): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'email' => 'ana-arroba-example.com'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_rechaza_un_telefono_con_formato_invalido(): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'phone' => 'tres-cero-cero'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+
+    public function test_ignora_el_rol_que_venga_en_la_entrada(): void
+    {
+        // El rol lo fija el endpoint. Si se pudiera mandar, cualquiera se daría
+        // de alta como conductor por el endpoint de pasajeros y se saltaría los
+        // requisitos del registro de conductor (historia #7).
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'role' => UserRole::Driver->value])
+            ->assertCreated()
+            ->assertJsonPath('data.user.role', UserRole::Passenger->value);
+
+        $this->assertTrue(User::firstWhere('email', 'ana@example.com')->isPassenger());
+    }
+
+    public function test_no_expone_la_contrasena_ni_la_guarda_en_claro(): void
+    {
+        $response = $this->postJson(self::REGISTER_URI, $this->datosValidos())->assertCreated();
+
+        $this->assertArrayNotHasKey('password', $response->json('data.user'));
+        $this->assertStringNotContainsString('motoya2026', $response->getContent());
+
+        $password = User::firstWhere('email', 'ana@example.com')->password;
+        $this->assertNotSame('motoya2026', $password);
+        $this->assertTrue(Hash::check('motoya2026', $password));
+    }
+
+    public function test_limita_la_cantidad_de_registros_por_minuto(): void
+    {
+        // El endpoint es anónimo: sin límite, sirve para crear cuentas en masa
+        // y para sondear qué emails ya existen. Es el mismo limitador `auth`
+        // que cubre al refresh (ver AppServiceProvider).
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson(self::REGISTER_URI, [
+                ...$this->datosValidos(),
+                'email' => "ana{$i}@example.com",
+                'phone' => '+57300123456'.$i,
+            ])->assertCreated();
+        }
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertStatus(429)
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function datosValidos(): array
+    {
+        return [
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+            'password' => 'motoya2026',
+        ];
+    }
+}

--- a/tests/Unit/Actions/Auth/RegisterPassengerActionTest.php
+++ b/tests/Unit/Actions/Auth/RegisterPassengerActionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\RegisterPassengerAction;
+use App\DTOs\PassengerRegistration;
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ *
+ * Necesita base de datos porque el caso de uso *es* crear la cuenta; lo que no
+ * toca es el ciclo request/response.
+ */
+class RegisterPassengerActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_la_cuenta_con_rol_pasajero(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertSame('Ana García', $resultado->user->name);
+        $this->assertSame('ana@example.com', $resultado->user->email);
+        $this->assertSame('+573001234567', $resultado->user->phone);
+        $this->assertSame(UserRole::Passenger, $resultado->user->role);
+        $this->assertTrue($resultado->user->exists);
+        $this->assertDatabaseCount('users', 1);
+    }
+
+    public function test_guarda_la_contrasena_hasheada(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertNotSame('motoya2026', $resultado->user->password);
+        $this->assertTrue(Hash::check('motoya2026', $resultado->user->password));
+    }
+
+    public function test_devuelve_un_token_que_identifica_al_pasajero_creado(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $identificado = JWTAuth::setToken($resultado->token->accessToken)->authenticate();
+
+        $this->assertInstanceOf(User::class, $identificado);
+        $this->assertSame($resultado->user->id, $identificado->id);
+    }
+
+    public function test_el_token_declara_su_vencimiento_segun_el_ttl_configurado(): void
+    {
+        $this->freezeSecond();
+
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertSame('bearer', $resultado->token->tokenType);
+        // 15 minutos de TTL (`jwt.ttl`) expresados en segundos.
+        $this->assertSame(900, $resultado->token->expiresInSeconds);
+    }
+
+    public function test_el_rol_no_depende_de_la_entrada(): void
+    {
+        // `PassengerRegistration` no tiene campo de rol a propósito: el caso de
+        // uso es registrar pasajeros, así que no hay forma de pedir otro.
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertTrue($resultado->user->isPassenger());
+        $this->assertFalse($resultado->user->isDriver());
+    }
+
+    private function action(): RegisterPassengerAction
+    {
+        return $this->app->make(RegisterPassengerAction::class);
+    }
+
+    private function registracion(): PassengerRegistration
+    {
+        return new PassengerRegistration(
+            name: 'Ana García',
+            email: 'ana@example.com',
+            phone: '+573001234567',
+            password: 'motoya2026',
+        );
+    }
+}


### PR DESCRIPTION
Closes #6

## Qué hace

Implementa `POST /api/v1/auth/register/passenger`: crea la cuenta con rol `passenger`
y devuelve, en la misma respuesta (201), la cuenta más un access token ya usable.

Sigue el ciclo de la skill `laravel-feature-workflow`: primero el contrato en
`openapi.yaml`, después los tests (fallando), después la implementación.

- **Contrato** (`openapi.yaml`): endpoint nuevo + schemas `User`, `AuthenticatedUser`
  y `PassengerRegistrationRequest`. `AuthenticatedUser` (`{user, token}`) queda listo
  para que el login (#8) lo reutilice.
- **Action** `RegisterPassengerAction` — crea el usuario y emite el JWT.
- **Form Request** `RegisterPassengerRequest` — validación, y traducción al DTO.
- **Resources** `UserResource` y `AuthenticatedUserResource`.
- **DTOs** `PassengerRegistration` (entrada) y `AuthenticatedUser` (salida).
- La ruta entra al grupo `throttle:auth` que ya existía (10/min por IP).

## Cómo se probó

- `php artisan test` — **129/129 en verde** (22 tests nuevos: 17 Feature + 5 Unit).
  Los 22 se escribieron antes de la implementación y se verificó que fallaran (404 /
  clase inexistente) antes de escribir el código de producción.
- Un test por criterio de aceptación del issue, más allá del camino feliz: email
  duplicado, teléfono duplicado, cada campo requerido faltante (data provider), todos
  los campos faltantes a la vez, tres formas de contraseña que no cumplen la política,
  formatos inválidos de email y teléfono, rol ignorado si viene en la entrada,
  contraseña ni expuesta ni guardada en claro, y el límite de tasa.
- `vendor/bin/pint --test` — sin errores.
- `phpstan analyse` (nivel 5) — 0 errores. Ver nota en riesgos.
- `complexity_check.py`, `architecture_check.py`, `security_check.py` — sin hallazgos
  (los 8 AVISOS de seguridad son preexistentes y sobre `config/*.php` ajenos a este PR).
- Conformidad **estática**: `OK: spec válido, 3 rutas revisadas (0 avisos)`.
- Conformidad **dinámica**: `OK: 3 operaciones probadas contra el spec, sin fallos`.

## Decisiones y riesgos

Las tres decisiones de diseño quedaron documentadas en `.claude/STANDARDS.md`
(secciones "Registro de cuentas" y "Política de contraseñas", ambas marcadas
"decidido en #6"), siguiendo la práctica de los issues anteriores.

1. **Un endpoint por rol, y el rol nunca se acepta como entrada.** El DTO de entrada
   no tiene campo de rol y el Form Request lo arma campo por campo en vez de pasar
   `validated()` completo, así que no hay camino por el que un `role` del cliente
   llegue a `users`. Importa porque `role` es fillable en el modelo y porque
   registrarse como conductor (#7) exige requisitos que este endpoint no pide.
2. **El registro devuelve token** en vez de exigir un login inmediato: evita que la
   app mande la contraseña dos veces por la red para completar un alta.
3. **Política de contraseñas**: 8 caracteres, al menos una letra y un número, como
   `Password::defaults()`. Sin símbolos ni mayúsculas/minúsculas obligatorias (NIST
   SP 800-63B favorece longitud sobre composición). Se descartó `uncompromised()`
   porque ataría el registro a un servicio externo y metería red en la suite.

**Cambios fuera del alcance estricto del issue**, ambos deliberados:

- `AccessTokenFactory` (nuevo) extrae el cálculo del vencimiento del token, que era
  privado de `RefreshTokenAction` y que el registro necesita idéntico — incluido su
  caso borde (`jwt.ttl` en `null` ⇒ token perpetuo, `expires_in: null`). Se prefirió
  extraerlo a duplicarlo; `RefreshTokenAction` queda más corto y su test sigue igual.
- `AppServiceProvider` gana `configurePasswordPolicy()`, por la decisión 3.

**Riesgo conocido, no introducido por este PR**: `composer stan` crashea localmente
por el `memory_limit` de 128M del php.ini de la máquina. Se verificó que `main` limpio
crashea igual, así que es ambiental y no de este cambio; con `--memory-limit=1G` pasa
con 0 errores, y en CI `shivammathur/setup-php` deja el límite en -1.