### PR TITLE
feat(#7): registrarme como conductor

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -148,6 +148,38 @@ cuando lleguen.
   local con libphonenumber): eso es una decisión de negocio con migración de los datos
   ya guardados, y el lugar para tomarla es cuando llegue el OTP por SMS.
 
+### Registro de conductor (decidido en #7)
+
+`POST /api/v1/auth/register/driver` sigue punto por punto lo anterior (rol fijado por
+el endpoint, 201 con `AuthenticatedUser`, limitador `auth`, email y teléfono
+canónicos) y agrega lo propio del rol:
+
+- **Cuenta y perfil se crean en una transacción.** Una cuenta con rol `driver` y sin
+  fila en `driver_profiles` no es un estado válido del dominio. El Form Request ya
+  valida que la licencia esté libre, pero entre esa consulta y el `INSERT` cabe otra
+  alta con la misma licencia, y ahí el índice único rechaza la escritura: sin la
+  transacción quedaría la cuenta a medias, y el propio conductor no podría reintentar
+  porque su email y su teléfono ya estarían tomados por ella.
+- **`license_number` también tiene forma canónica**: se recorta y se pasa a mayúsculas
+  en `prepareForValidation()`, por el mismo motivo que el email — `unique` es un
+  `where license_number = ?` sobre una columna con índice único, así que sin
+  normalizar bastaría escribirla en minúsculas para tener dos conductores con la misma
+  habilitación. No se tocan los espacios interiores: `LIC 445 566` es una licencia mal
+  escrita y corresponde un 422 explicable, no que el servidor adivine cómo debería
+  haberse escrito.
+- **La respuesta no incluye la licencia**: reutiliza el schema `AuthenticatedUser` del
+  registro de pasajero y del login, y el dato del perfil se consulta por el endpoint de
+  perfil (#10). Así el schema `User` no gana un campo que en las cuentas de pasajero
+  estaría siempre vacío.
+- La API **no verifica** que la licencia exista ni que esté vigente contra ninguna
+  entidad externa: registra lo que el conductor declara (explícitamente fuera de
+  alcance en #7). El vehículo se registra aparte (#12), porque un conductor puede dar
+  de alta su cuenta antes de tener la moto cargada.
+- Lo común a ambos registros (normalización de email/teléfono y reglas de los campos de
+  cuenta) vive en el trait `App\Http\Requests\Concerns\NormalizesAccountInput`, no
+  duplicado en cada Form Request: si las dos altas divergieran, la misma persona podría
+  terminar con una cuenta por rol usando el mismo email escrito distinto.
+
 ### Política de contraseñas (decidida en #6)
 
 Mínimo **8 caracteres, con al menos una letra y al menos un número**, declarada una

--- a/app/Actions/Auth/RegisterDriverAction.php
+++ b/app/Actions/Auth/RegisterDriverAction.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\DTOs\AuthenticatedUser;
+use App\DTOs\DriverRegistration;
+use App\Enums\UserRole;
+use App\Models\User;
+use App\Services\Auth\AccessTokenFactory;
+use Illuminate\Support\Facades\DB;
+use Tymon\JWTAuth\JWTAuth;
+
+/**
+ * Da de alta un conductor —cuenta más perfil— y lo deja autenticado en el mismo
+ * paso, igual que el registro de pasajero.
+ *
+ * El rol se fija en `UserRole::Driver` y no sale de la entrada: el DTO
+ * directamente no tiene campo de rol.
+ */
+final class RegisterDriverAction
+{
+    public function __construct(
+        private readonly JWTAuth $jwt,
+        private readonly AccessTokenFactory $tokens,
+    ) {}
+
+    public function handle(DriverRegistration $registration): AuthenticatedUser
+    {
+        $user = $this->createDriver($registration);
+
+        return new AuthenticatedUser(
+            user: $user,
+            token: $this->tokens->fromJwt($this->jwt->fromUser($user)),
+        );
+    }
+
+    /**
+     * Crea la cuenta y su perfil como una sola unidad.
+     *
+     * La transacción no es ceremonia: el Form Request ya validó que la licencia
+     * esté libre, pero entre esa consulta y esta escritura cabe otra alta con la
+     * misma licencia, y ahí el índice único de `driver_profiles` rechaza el
+     * `INSERT`. Sin transacción eso dejaría una cuenta con rol de conductor y
+     * sin licencia — un estado que el dominio no contempla, y que además
+     * bloquearía el reintento del propio conductor, porque su email y su
+     * teléfono ya estarían tomados por esa cuenta a medias.
+     */
+    private function createDriver(DriverRegistration $registration): User
+    {
+        return DB::transaction(function () use ($registration): User {
+            // La contraseña se guarda hasheada por el cast `hashed` del modelo,
+            // no por un Hash::make() acá: así vale para cualquier vía de
+            // creación.
+            $user = User::create([
+                'name' => $registration->name,
+                'email' => $registration->email,
+                'phone' => $registration->phone,
+                'password' => $registration->password,
+                'role' => UserRole::Driver,
+            ]);
+
+            $user->driverProfile()->create([
+                'license_number' => $registration->licenseNumber,
+            ]);
+
+            return $user;
+        });
+    }
+}

--- a/app/DTOs/DriverRegistration.php
+++ b/app/DTOs/DriverRegistration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Datos con los que se da de alta un conductor, ya validados.
+ *
+ * No lleva rol, por la misma razón que `PassengerRegistration`: el caso de uso
+ * es registrar conductores, así que el rol lo fija `RegisterDriverAction` y no
+ * hay forma de pedir otro por esta vía.
+ *
+ * `licenseNumber` es lo único que lo separa del alta de un pasajero. Va acá y
+ * no en un DTO aparte del perfil porque cuenta y perfil se crean en la misma
+ * operación: una cuenta de conductor sin licencia no es un estado válido.
+ */
+final readonly class DriverRegistration
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $phone,
+        public string $password,
+        public string $licenseNumber,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Auth/RegisterDriverController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RegisterDriverController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\RegisterDriverAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterDriverRequest;
+use App\Http\Resources\AuthenticatedUserResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/auth/register/driver
+ *
+ * Va sin `auth:api` —quien se registra todavía no tiene cuenta— y por eso
+ * queda bajo el limitador `auth`, más estricto que el general de la API.
+ */
+class RegisterDriverController extends Controller
+{
+    public function __invoke(
+        RegisterDriverRequest $request,
+        RegisterDriverAction $registerDriver,
+    ): JsonResponse {
+        $registered = $registerDriver->handle($request->toRegistration());
+
+        return (new AuthenticatedUserResource($registered))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Auth/RegisterDriverRequest.php
+++ b/app/Http/Requests/Auth/RegisterDriverRequest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\DTOs\DriverRegistration;
+use App\Http\Requests\Concerns\NormalizesAccountInput;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+
+/**
+ * Entrada de POST /api/v1/auth/register/driver — ver openapi.yaml.
+ *
+ * No define `authorize()`: el endpoint es anónimo por diseño (nadie tiene
+ * cuenta todavía cuando lo llama), así que no hay sujeto contra el cual
+ * autorizar. Lo que lo protege es el limitador de tasa `auth`, no una Policy.
+ */
+class RegisterDriverRequest extends FormRequest
+{
+    use NormalizesAccountInput;
+
+    /**
+     * Lleva la entrada a su forma canónica ANTES de validar.
+     *
+     * `email` y `phone` los normaliza el trait compartido con el registro de
+     * pasajero. Acá se suma `license_number`, que tiene el mismo problema por
+     * el mismo motivo: `unique` es un `where license_number = ?` sobre una
+     * columna con índice único, así que sin normalizar bastaría escribir la
+     * licencia en minúsculas para registrarla dos veces y tener dos conductores
+     * con la misma habilitación.
+     *
+     * Solo se recortan los extremos y se pasa a mayúsculas. No se tocan los
+     * espacios interiores: un `LIC 445 566` es una licencia mal escrita, y lo
+     * correcto es que muera en el `regex` con un 422 explicable, no que el
+     * servidor decida por su cuenta cómo debería haberse escrito.
+     */
+    protected function prepareForValidation(): void
+    {
+        $canonicos = $this->canonicalAccountInput();
+
+        $license = $this->input('license_number');
+
+        if (is_string($license)) {
+            $canonicos['license_number'] = Str::upper(trim($license));
+        }
+
+        $this->merge($canonicos);
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            ...$this->accountRules(),
+            // `unique` sobre `driver_profiles` y no sobre `users`: la licencia
+            // vive en el perfil. Sin la regla, la licencia repetida escalaría a
+            // un 500 por violación del índice único en vez del 422 que el
+            // conductor puede entender. La Action escribe igual dentro de una
+            // transacción, porque entre esta consulta y el INSERT cabe otra
+            // alta con la misma licencia.
+            'license_number' => [
+                'required',
+                'string',
+                'max:50',
+                'regex:/^[A-Z0-9-]{5,50}$/',
+                'unique:driver_profiles,license_number',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            ...$this->accountMessages(),
+            'license_number.regex' => 'El campo license number debe tener entre 5 y 50 caracteres, solo letras, dígitos y guiones; se guarda siempre en mayúsculas.',
+        ];
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     *
+     * Los campos se leen uno por uno en vez de con `validated()`: es lo que
+     * garantiza que nada que no esté acá —un `role` mandado por el cliente, por
+     * ejemplo— pueda colarse hasta la creación del usuario.
+     */
+    public function toRegistration(): DriverRegistration
+    {
+        return new DriverRegistration(
+            name: $this->string('name')->toString(),
+            email: $this->string('email')->toString(),
+            phone: $this->string('phone')->toString(),
+            password: $this->string('password')->toString(),
+            licenseNumber: $this->string('license_number')->toString(),
+        );
+    }
+}

--- a/app/Http/Requests/Auth/RegisterPassengerRequest.php
+++ b/app/Http/Requests/Auth/RegisterPassengerRequest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Requests\Auth;
 
 use App\DTOs\PassengerRegistration;
+use App\Http\Requests\Concerns\NormalizesAccountInput;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Password;
 
 /**
  * Entrada de POST /api/v1/auth/register/passenger — ver openapi.yaml.
@@ -18,41 +17,16 @@ use Illuminate\Validation\Rules\Password;
  */
 class RegisterPassengerRequest extends FormRequest
 {
+    use NormalizesAccountInput;
+
     /**
-     * Lleva `email` y `phone` a su forma canónica ANTES de validar.
-     *
-     * `unique` traduce a un `where columna = ?`, así que sin esto la unicidad de
-     * la cuenta queda a merced de la colación del motor: en SQLite (el driver de
-     * dev y el de `phpunit.xml`) es BINARY, y `Ana@example.com` convive con
-     * `ana@example.com` como dos cuentas distintas; en MySQL con colación `_ci`
-     * el comportamiento sería el contrario. Normalizar acá hace que lo que se
-     * valida y lo que se guarda sean siempre el mismo valor comparable, sin
-     * depender del motor — y sobre esa unicidad se apoyan el login (#8) y
-     * cualquier recuperación de cuenta futura.
+     * Lleva `email` y `phone` a su forma canónica ANTES de validar — el porqué
+     * está en `NormalizesAccountInput`, compartido con el registro de conductor
+     * para que ambas altas no puedan divergir.
      */
     protected function prepareForValidation(): void
     {
-        $canonicos = [];
-
-        $email = $this->input('email');
-
-        if (is_string($email)) {
-            $canonicos['email'] = Str::lower($email);
-        }
-
-        $phone = $this->input('phone');
-
-        // El `+` es opcional en la entrada, así que `573001234567` y
-        // `+573001234567` son el mismo número y tienen que colisionar: no hace
-        // falta mala intención para mandar los dos, es la diferencia entre
-        // teclearlo y pegarlo desde la agenda. Solo se antepone el `+` a lo que
-        // ya empieza por dígito, para que una entrada malformada (`++57…`) siga
-        // muriendo en el `regex` en vez de quedar "arreglada" por acá.
-        if (is_string($phone) && preg_match('/^[0-9]/', $phone) === 1) {
-            $canonicos['phone'] = '+'.$phone;
-        }
-
-        $this->merge($canonicos);
+        $this->merge($this->canonicalAccountInput());
     }
 
     /**
@@ -60,18 +34,7 @@ class RegisterPassengerRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
-            // `unique` acá y no solo el índice de la tabla: sin la regla, un
-            // teléfono repetido escalaría a un 500 por violación de constraint
-            // en vez del 422 que el cliente puede mostrarle al usuario.
-            // El regex exige el `+` porque para cuando corre ya se normalizó la
-            // entrada: la forma canónica siempre lo lleva. Lo que el cliente
-            // manda sigue siendo `+` opcional (ver `prepareForValidation`).
-            'phone' => ['required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/', 'unique:users,phone'],
-            'password' => ['required', 'string', Password::defaults()],
-        ];
+        return $this->accountRules();
     }
 
     /**
@@ -79,9 +42,7 @@ class RegisterPassengerRequest extends FormRequest
      */
     public function messages(): array
     {
-        return [
-            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio; se guarda siempre con el +.',
-        ];
+        return $this->accountMessages();
     }
 
     /**

--- a/app/Http/Requests/Concerns/NormalizesAccountInput.php
+++ b/app/Http/Requests/Concerns/NormalizesAccountInput.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Concerns;
+
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Forma canónica y reglas de los campos de cuenta comunes a todo registro.
+ *
+ * Vive en un solo lugar porque `.claude/STANDARDS.md` exige que los endpoints
+ * de registro normalicen igual: si el de pasajero y el de conductor
+ * divergieran, la misma persona podría quedar con dos cuentas —una por rol—
+ * usando el mismo email escrito distinto, y sobre esa unicidad se apoyan el
+ * login (#8) y la recuperación de cuenta.
+ */
+trait NormalizesAccountInput
+{
+    /**
+     * Lleva `email` y `phone` a su forma canónica, para mezclar en
+     * `prepareForValidation()` — es decir, ANTES de `unique` y del DTO.
+     *
+     * `unique` traduce a un `where columna = ?`, así que sin esto la unicidad
+     * de la cuenta queda a merced de la colación del motor: en SQLite (el
+     * driver de dev y el de `phpunit.xml`) es BINARY, y `Ana@example.com`
+     * convive con `ana@example.com` como dos cuentas distintas; en MySQL con
+     * colación `_ci` el comportamiento sería el contrario. Normalizar acá hace
+     * que lo que se valida y lo que se guarda sean siempre el mismo valor
+     * comparable, sin depender del motor.
+     *
+     * @return array<string, string>
+     */
+    protected function canonicalAccountInput(): array
+    {
+        $canonicos = [];
+
+        $email = $this->input('email');
+
+        if (is_string($email)) {
+            $canonicos['email'] = Str::lower($email);
+        }
+
+        $phone = $this->input('phone');
+
+        // El `+` es opcional en la entrada, así que `573001234567` y
+        // `+573001234567` son el mismo número y tienen que colisionar: no hace
+        // falta mala intención para mandar los dos, es la diferencia entre
+        // teclearlo y pegarlo desde la agenda. Solo se antepone el `+` a lo que
+        // ya empieza por dígito, para que una entrada malformada (`++57…`) siga
+        // muriendo en el `regex` en vez de quedar "arreglada" por acá.
+        if (is_string($phone) && preg_match('/^[0-9]/', $phone) === 1) {
+            $canonicos['phone'] = '+'.$phone;
+        }
+
+        return $canonicos;
+    }
+
+    /**
+     * Reglas de los campos que toda cuenta tiene, sin importar el rol.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function accountRules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            // `unique` acá y no solo el índice de la tabla: sin la regla, un
+            // teléfono repetido escalaría a un 500 por violación de constraint
+            // en vez del 422 que el cliente puede mostrarle al usuario.
+            // El regex exige el `+` porque para cuando corre ya se normalizó la
+            // entrada: la forma canónica siempre lo lleva. Lo que el cliente
+            // manda sigue siendo `+` opcional (ver `canonicalAccountInput`).
+            'phone' => ['required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/', 'unique:users,phone'],
+            'password' => ['required', 'string', Password::defaults()],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function accountMessages(): array
+    {
+        return [
+            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio; se guarda siempre con el +.',
+        ];
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,6 +69,95 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /auth/register/driver:
+    post:
+      tags:
+        - Auth
+      operationId: registerDriver
+      summary: Registrar una cuenta de conductor
+      description: >-
+        Crea una cuenta con rol `driver` junto a su perfil de conductor
+        (`license_number`) y devuelve, en la misma respuesta, un access token
+        válido — igual que el registro de pasajero.
+
+        La cuenta y el perfil se crean de forma atómica: si el número de
+        licencia resulta duplicado en la escritura, no queda una cuenta
+        huérfana sin perfil.
+
+        El rol **no** se acepta como entrada — lo fija el endpoint. Lo que
+        distingue a este registro del de pasajero es exactamente el
+        `license_number`; el vehículo se registra aparte (historia #12),
+        porque un conductor puede dar de alta su cuenta antes de tener la
+        moto cargada.
+
+        La respuesta reutiliza el schema `AuthenticatedUser` del registro de
+        pasajero y **no** incluye el `license_number`: el dato del perfil se
+        consulta por el endpoint de perfil (historia #10), y así el schema
+        `User` no gana un campo que para las cuentas de pasajero siempre
+        estaría vacío.
+
+        No requiere autenticación, y por eso comparte con el resto de
+        endpoints de auth el límite de 10 requests por minuto e IP.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DriverRegistrationRequest"
+            example:
+              name: Carlos Ramírez
+              email: carlos@example.com
+              phone: "+573009876543"
+              password: motoya2026
+              license_number: LIC-445566
+      responses:
+        "201":
+          description: Cuenta de conductor creada, con su perfil, y sesión iniciada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AuthenticatedUser"
+              example:
+                data:
+                  user:
+                    id: 1
+                    name: Carlos Ramírez
+                    email: carlos@example.com
+                    phone: "+573009876543"
+                    role: driver
+                  token:
+                    access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJkcml2ZXIifQ.HCJUJDXBM6BAvUcTGF6ZiHR2Wr3ubuRxKh7uBB4Umt4
+                    token_type: bearer
+                    expires_in: 900
+        "422":
+          description: >-
+            La entrada no pasó la validación: falta un campo requerido, el
+            email, el teléfono o el número de licencia ya están registrados,
+            o la contraseña no cumple la política mínima.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The license number has already been taken.
+                errors:
+                  license_number:
+                    - The license number has already been taken.
+        "429":
+          description: >-
+            Se superó el límite de requests por minuto para esta IP.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /auth/register/passenger:
     post:
       tags:
@@ -293,6 +382,67 @@ components:
           $ref: "#/components/schemas/User"
         token:
           $ref: "#/components/schemas/AuthToken"
+    DriverRegistrationRequest:
+      type: object
+      description: >-
+        Datos con los que se da de alta un conductor. El rol no se manda: lo
+        fija el endpoint.
+
+        Repite los campos de cuenta de `PassengerRegistrationRequest` en vez
+        de componerse sobre él: son dos altas distintas que hoy coinciden en
+        cuatro campos, y el registro de conductor es el que va a crecer
+        (documentos, verificación de licencia) sin arrastrar al de pasajero.
+      required:
+        - name
+        - email
+        - phone
+        - password
+        - license_number
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          example: Carlos Ramírez
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: >-
+            Único entre todas las cuentas, sin importar el rol. Se normaliza a
+            minúsculas antes de validarlo y de guardarlo.
+          example: carlos@example.com
+        phone:
+          type: string
+          maxLength: 20
+          description: >-
+            Único entre todas las cuentas, sin importar el rol. Se acepta en
+            formato E.164 (`+` y de 7 a 15 dígitos); el `+` es opcional en la
+            entrada, pero el número se guarda y se devuelve siempre con él.
+          example: "+573009876543"
+        password:
+          type: string
+          format: password
+          minLength: 8
+          description: >-
+            Mínimo 8 caracteres, con al menos una letra y al menos un número
+            (ver la política en .claude/STANDARDS.md).
+          example: motoya2026
+        license_number:
+          type: string
+          minLength: 5
+          maxLength: 50
+          description: >-
+            Número de la licencia de conducir, único entre todos los
+            conductores. Se normaliza a mayúsculas y sin espacios antes de
+            validarlo y de guardarlo, así que `lic-445566` y `LIC-445566` son
+            la misma licencia y la segunda alta responde 422. Solo se admiten
+            letras, dígitos y guiones.
+
+            La API **no** verifica que la licencia exista de verdad ni que
+            esté vigente contra ninguna entidad externa: registra el dato tal
+            como lo declara el conductor.
+          pattern: "^[A-Z0-9-]{5,50}$"
+          example: LIC-445566
     PassengerRegistrationRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
+use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
@@ -29,6 +30,7 @@ Route::prefix('v1')->group(function () {
         ->name('auth.')
         ->group(function () {
             Route::post('refresh', RefreshTokenController::class)->name('refresh');
+            Route::post('register/driver', RegisterDriverController::class)->name('register.driver');
             Route::post('register/passenger', RegisterPassengerController::class)->name('register.passenger');
         });
 });

--- a/tests/Feature/Auth/RegisterDriverTest.php
+++ b/tests/Feature/Auth/RegisterDriverTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\UserRole;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Contrato de POST /api/v1/auth/register/driver — ver openapi.yaml.
+ *
+ * Igual que el registro de pasajero, el alta deja al conductor ya autenticado.
+ * Lo que lo distingue es el perfil: la cuenta no sirve de nada sin el
+ * `license_number`, así que ambos se crean en la misma operación.
+ */
+class RegisterDriverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const REGISTER_URI = '/api/v1/auth/register/driver';
+
+    private const PROBE_URI = '/api/v1/_probe-protegida-conductor';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('auth:api')->get(self::PROBE_URI, function () {
+            return response()->json(['user_id' => auth('api')->id()]);
+        });
+    }
+
+    public function test_registra_al_conductor_y_devuelve_la_forma_del_contrato(): void
+    {
+        // `expires_in` sale de restarle "ahora" al claim `exp`; sin congelar el
+        // reloj, cruzar un segundo entre ambas lecturas daría 899.
+        $this->freezeSecond();
+
+        $response = $this->postJson(self::REGISTER_URI, $this->datosValidos());
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'data' => [
+                    'user' => ['id', 'name', 'email', 'phone', 'role'],
+                    'token' => ['access_token', 'token_type', 'expires_in'],
+                ],
+            ])
+            ->assertJsonPath('data.user.name', 'Carlos Ramírez')
+            ->assertJsonPath('data.user.email', 'carlos@example.com')
+            ->assertJsonPath('data.user.phone', '+573009876543')
+            ->assertJsonPath('data.user.role', 'driver')
+            ->assertJsonPath('data.token.token_type', 'bearer')
+            // 15 minutos de TTL expresados en segundos.
+            ->assertJsonPath('data.token.expires_in', 900);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'carlos@example.com',
+            'phone' => '+573009876543',
+            'role' => UserRole::Driver->value,
+        ]);
+    }
+
+    public function test_crea_el_perfil_de_conductor_con_la_licencia(): void
+    {
+        // Es lo único que separa este endpoint del de pasajero: sin el perfil,
+        // la cuenta tiene rol de conductor pero no la licencia que ese rol
+        // exige.
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())->assertCreated();
+
+        $conductor = User::firstWhere('email', 'carlos@example.com');
+
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $conductor->id,
+            'license_number' => 'LIC-445566',
+        ]);
+        $this->assertSame('LIC-445566', $conductor->driverProfile->license_number);
+    }
+
+    public function test_no_expone_la_licencia_en_la_respuesta_del_registro(): void
+    {
+        // La respuesta reutiliza el schema `AuthenticatedUser`, que es el mismo
+        // del registro de pasajero y del login: el dato del perfil se consulta
+        // por el endpoint de perfil (historia #10).
+        $response = $this->postJson(self::REGISTER_URI, $this->datosValidos())->assertCreated();
+
+        $this->assertArrayNotHasKey('license_number', $response->json('data.user'));
+        $this->assertSame(['user', 'token'], array_keys($response->json('data')));
+    }
+
+    public function test_el_token_devuelto_autentica_al_conductor_recien_creado(): void
+    {
+        $token = $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertCreated()
+            ->json('data.token.access_token');
+
+        $this->withToken($token)
+            ->getJson(self::PROBE_URI)
+            ->assertOk()
+            ->assertJson(['user_id' => User::firstWhere('email', 'carlos@example.com')->id]);
+    }
+
+    public function test_rechaza_una_licencia_ya_registrada(): void
+    {
+        DriverProfile::factory()->create(['license_number' => 'LIC-445566']);
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('license_number')
+            ->assertJsonStructure(['message', 'errors']);
+
+        $this->assertSame(1, DriverProfile::where('license_number', 'LIC-445566')->count());
+    }
+
+    public function test_no_deja_la_cuenta_creada_cuando_la_licencia_esta_repetida(): void
+    {
+        // El 422 tiene que dejar el sistema como estaba: si el usuario se
+        // creara igual, el conductor quedaría con cuenta y sin perfil, y el
+        // reintento con otra licencia chocaría contra su propio email.
+        DriverProfile::factory()->create(['license_number' => 'LIC-445566']);
+
+        $usuariosPrevios = User::count();
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable();
+
+        $this->assertSame($usuariosPrevios, User::count());
+        $this->assertNull(User::firstWhere('email', 'carlos@example.com'));
+    }
+
+    public function test_rechaza_una_licencia_ya_registrada_en_otra_capitalizacion(): void
+    {
+        // `unique` es un `where license_number = ?` y la colación de SQLite es
+        // BINARY: sin normalizar, cambiar una mayúscula alcanza para registrar
+        // dos veces la misma licencia.
+        DriverProfile::factory()->create(['license_number' => 'LIC-445566']);
+
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'license_number' => 'lic-445566'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('license_number');
+
+        $this->assertSame(1, DriverProfile::whereRaw('upper(license_number) = ?', ['LIC-445566'])->count());
+    }
+
+    public function test_guarda_la_licencia_en_su_forma_canonica(): void
+    {
+        // La otra mitad de la normalización: lo que se guarda tiene que ser el
+        // mismo valor que se validó, o el duplicado entra por la puerta de
+        // atrás en el registro siguiente.
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'license_number' => '  lic-445566 '])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('driver_profiles', ['license_number' => 'LIC-445566']);
+    }
+
+    public function test_rechaza_un_email_ya_registrado(): void
+    {
+        // El email es único en `users` sin importar el rol: la misma persona no
+        // puede tener una cuenta de pasajero y otra de conductor con el mismo
+        // email.
+        User::factory()->create(['email' => 'carlos@example.com']);
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+
+        $this->assertSame(1, User::where('email', 'carlos@example.com')->count());
+        $this->assertDatabaseCount('driver_profiles', 0);
+    }
+
+    public function test_rechaza_un_telefono_ya_registrado(): void
+    {
+        User::factory()->create(['phone' => '+573009876543']);
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+
+    public function test_guarda_email_y_telefono_en_su_forma_canonica(): void
+    {
+        $this->postJson(self::REGISTER_URI, [
+            ...$this->datosValidos(),
+            'email' => 'Carlos@Example.COM',
+            'phone' => '573009876543',
+        ])
+            ->assertCreated()
+            ->assertJsonPath('data.user.email', 'carlos@example.com')
+            ->assertJsonPath('data.user.phone', '+573009876543');
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'carlos@example.com',
+            'phone' => '+573009876543',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $camposEsperados
+     */
+    #[DataProvider('camposRequeridos')]
+    public function test_rechaza_la_falta_de_un_campo_requerido(string $campoFaltante, array $camposEsperados): void
+    {
+        $datos = $this->datosValidos();
+        unset($datos[$campoFaltante]);
+
+        $this->postJson(self::REGISTER_URI, $datos)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($camposEsperados);
+
+        $this->assertDatabaseCount('users', 0);
+        $this->assertDatabaseCount('driver_profiles', 0);
+    }
+
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function camposRequeridos(): array
+    {
+        return [
+            'nombre' => ['name', ['name']],
+            'email' => ['email', ['email']],
+            'teléfono' => ['phone', ['phone']],
+            'contraseña' => ['password', ['password']],
+            'licencia' => ['license_number', ['license_number']],
+        ];
+    }
+
+    public function test_informa_todos_los_campos_faltantes_en_una_sola_respuesta(): void
+    {
+        // Un 422 por campo obligaría a la app móvil a reintentar cinco veces
+        // para descubrir el formulario entero.
+        $this->postJson(self::REGISTER_URI, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'email', 'phone', 'password', 'license_number']);
+    }
+
+    #[DataProvider('licenciasInvalidas')]
+    public function test_rechaza_una_licencia_con_formato_invalido(string $licencia): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'license_number' => $licencia])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('license_number');
+
+        $this->assertDatabaseCount('users', 0);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function licenciasInvalidas(): array
+    {
+        return [
+            'demasiado corta' => ['LIC'],
+            'con símbolos' => ['LIC/445566'],
+            // La normalización recorta los extremos y pasa a mayúsculas, pero
+            // no junta lo que venga separado: un espacio en el medio no es una
+            // licencia con formato válido, no algo que haya que "arreglar".
+            'con espacios internos' => ['LIC 445 566'],
+            'vacía tras normalizar' => ['   '],
+        ];
+    }
+
+    #[DataProvider('contrasenasQueNoCumplenLaPolitica')]
+    public function test_rechaza_una_contrasena_que_no_cumple_la_politica(string $password): void
+    {
+        // La política es la misma de `Password::defaults()` que usa el registro
+        // de pasajero: no puede relajarse por ser otro rol.
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'password' => $password])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('password');
+
+        $this->assertDatabaseCount('users', 0);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function contrasenasQueNoCumplenLaPolitica(): array
+    {
+        return [
+            'demasiado corta' => ['moto26'],
+            'sin números' => ['motoyamotoya'],
+            'sin letras' => ['20262026262'],
+        ];
+    }
+
+    public function test_rechaza_un_email_con_formato_invalido(): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'email' => 'carlos-arroba-example.com'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+    }
+
+    #[DataProvider('telefonosInvalidos')]
+    public function test_rechaza_un_telefono_con_formato_invalido(string $phone): void
+    {
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'phone' => $phone])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function telefonosInvalidos(): array
+    {
+        return [
+            'no son dígitos' => ['tres-cero-cero'],
+            'prefijo duplicado' => ['++573009876543'],
+            'demasiado corto' => ['+57300'],
+        ];
+    }
+
+    public function test_ignora_el_rol_que_venga_en_la_entrada(): void
+    {
+        // El rol lo fija el endpoint, igual que en el de pasajero: mandar
+        // `role` no puede dar de alta un pasajero por esta vía ni al revés.
+        $this->postJson(self::REGISTER_URI, [...$this->datosValidos(), 'role' => UserRole::Passenger->value])
+            ->assertCreated()
+            ->assertJsonPath('data.user.role', UserRole::Driver->value);
+
+        $this->assertTrue(User::firstWhere('email', 'carlos@example.com')->isDriver());
+    }
+
+    public function test_no_expone_la_contrasena_ni_la_guarda_en_claro(): void
+    {
+        $response = $this->postJson(self::REGISTER_URI, $this->datosValidos())->assertCreated();
+
+        $this->assertArrayNotHasKey('password', $response->json('data.user'));
+        $this->assertStringNotContainsString('motoya2026', $response->getContent());
+
+        $password = User::firstWhere('email', 'carlos@example.com')->password;
+        $this->assertNotSame('motoya2026', $password);
+        $this->assertTrue(Hash::check('motoya2026', $password));
+    }
+
+    public function test_limita_la_cantidad_de_registros_por_minuto(): void
+    {
+        // El endpoint es anónimo: sin límite sirve para crear cuentas en masa
+        // y para sondear qué emails ya existen. Es el mismo limitador `auth`
+        // que cubre al refresh y al registro de pasajero.
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson(self::REGISTER_URI, [
+                ...$this->datosValidos(),
+                'email' => "carlos{$i}@example.com",
+                'phone' => '+57300987654'.$i,
+                'license_number' => "LIC-44556{$i}",
+            ])->assertCreated();
+        }
+
+        $this->postJson(self::REGISTER_URI, $this->datosValidos())
+            ->assertStatus(429)
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function datosValidos(): array
+    {
+        return [
+            'name' => 'Carlos Ramírez',
+            'email' => 'carlos@example.com',
+            'phone' => '+573009876543',
+            'password' => 'motoya2026',
+            'license_number' => 'LIC-445566',
+        ];
+    }
+}

--- a/tests/Unit/Actions/Auth/RegisterDriverActionTest.php
+++ b/tests/Unit/Actions/Auth/RegisterDriverActionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\RegisterDriverAction;
+use App\DTOs\DriverRegistration;
+use App\Enums\UserRole;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ */
+class RegisterDriverActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_la_cuenta_con_rol_conductor(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertSame('Carlos Ramírez', $resultado->user->name);
+        $this->assertSame('carlos@example.com', $resultado->user->email);
+        $this->assertSame('+573009876543', $resultado->user->phone);
+        $this->assertSame(UserRole::Driver, $resultado->user->role);
+        $this->assertTrue($resultado->user->exists);
+        $this->assertDatabaseCount('users', 1);
+    }
+
+    public function test_crea_el_perfil_de_conductor_asociado_a_la_cuenta(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertDatabaseCount('driver_profiles', 1);
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $resultado->user->id,
+            'license_number' => 'LIC-445566',
+        ]);
+    }
+
+    public function test_no_deja_la_cuenta_creada_si_falla_el_perfil(): void
+    {
+        // Cuenta y perfil se crean juntos o no se crea ninguno: una cuenta de
+        // conductor sin licencia no es un estado válido del dominio, y el
+        // índice único de `license_number` puede rechazar la escritura aunque
+        // la validación del Form Request haya pasado (dos altas concurrentes
+        // con la misma licencia).
+        DriverProfile::factory()->create(['license_number' => 'LIC-445566']);
+
+        $usuariosPrevios = User::count();
+
+        try {
+            $this->action()->handle($this->registracion());
+            $this->fail('Se esperaba que la licencia duplicada abortara el alta.');
+        } catch (QueryException) {
+            // El fallo en sí es lo esperado; lo que se comprueba es que no dejó
+            // rastro.
+        }
+
+        $this->assertSame($usuariosPrevios, User::count());
+        $this->assertNull(User::firstWhere('email', 'carlos@example.com'));
+    }
+
+    public function test_guarda_la_contrasena_hasheada(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertNotSame('motoya2026', $resultado->user->password);
+        $this->assertTrue(Hash::check('motoya2026', $resultado->user->password));
+    }
+
+    public function test_devuelve_un_token_que_identifica_al_conductor_creado(): void
+    {
+        $resultado = $this->action()->handle($this->registracion());
+
+        $identificado = JWTAuth::setToken($resultado->token->accessToken)->authenticate();
+
+        $this->assertInstanceOf(User::class, $identificado);
+        $this->assertSame($resultado->user->id, $identificado->id);
+    }
+
+    public function test_el_token_declara_su_vencimiento_segun_el_ttl_configurado(): void
+    {
+        $this->freezeSecond();
+
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertSame('bearer', $resultado->token->tokenType);
+        // 15 minutos de TTL (`jwt.ttl`) expresados en segundos.
+        $this->assertSame(900, $resultado->token->expiresInSeconds);
+    }
+
+    public function test_el_rol_no_depende_de_la_entrada(): void
+    {
+        // `DriverRegistration` no tiene campo de rol a propósito: el caso de
+        // uso es registrar conductores, así que no hay forma de pedir otro.
+        $resultado = $this->action()->handle($this->registracion());
+
+        $this->assertTrue($resultado->user->isDriver());
+        $this->assertFalse($resultado->user->isPassenger());
+    }
+
+    private function action(): RegisterDriverAction
+    {
+        return $this->app->make(RegisterDriverAction::class);
+    }
+
+    private function registracion(): DriverRegistration
+    {
+        return new DriverRegistration(
+            name: 'Carlos Ramírez',
+            email: 'carlos@example.com',
+            phone: '+573009876543',
+            password: 'motoya2026',
+            licenseNumber: 'LIC-445566',
+        );
+    }
+}


### PR DESCRIPTION
Closes #7

## Qué hace

Agrega `POST /api/v1/auth/register/driver`: crea la cuenta con rol `driver`, su fila en `driver_profiles` con el `license_number`, y devuelve un access token en la misma respuesta — el conductor queda autenticado sin encadenar un login.

Sigue el flujo Issue → SDD → TDD → implementación → conformidad de la skill `laravel-feature-workflow`: primero se especificó el endpoint en `openapi.yaml`, después se escribieron los tests (38, fallando en rojo), y recién ahí el código.

| Criterio de aceptación del issue | Dónde se cubre |
|---|---|
| Alta válida → cuenta con rol conductor + JWT válido | `test_registra_al_conductor_y_devuelve_la_forma_del_contrato`, `test_el_token_devuelto_autentica_al_conductor_recien_creado` |
| Licencia ya registrada → 422 | `test_rechaza_una_licencia_ya_registrada` (+ variante en otra capitalización) |
| Campo requerido faltante → 422 por campo | `test_rechaza_la_falta_de_un_campo_requerido` (5 data sets) + `test_informa_todos_los_campos_faltantes_en_una_sola_respuesta` |

Archivos nuevos: `RegisterDriverController` → `RegisterDriverRequest` → `RegisterDriverAction` → `DriverRegistration` (DTO), respuesta vía el `AuthenticatedUserResource` que ya existía.

## Cómo se probó

Todo lo que corre el CI, en verde localmente:

- `php artisan test` — **172 pasan** (38 nuevos: 31 Feature + 7 Unit)
- `vendor/bin/pint --test` — sin errores
- `composer stan` (PHPStan/Larastan nivel 5) — 0 errores
- `complexity_check.py` / `architecture_check.py` — sin hallazgos
- `security_check.py` — sin hallazgos nuevos (los 8 AVISO de `env()` son preexistentes y ajenos a este cambio)
- `static_conformance.py` — 4 rutas, 0 avisos
- `dynamic_conformance.py --start-server` — 4 operaciones contra el spec, 0 fallos
- `composer audit` — sin CVEs

Además de los caminos del issue, los tests cubren: atomicidad cuenta/perfil, normalización de licencia, email y teléfono, unicidad de email/teléfono entre roles, política de contraseñas, rol ignorado si viene en la entrada, contraseña ni expuesta ni en claro, y el límite de tasa.

## Decisiones y riesgos

- **Cuenta y perfil en una transacción.** El Form Request valida que la licencia esté libre, pero entre esa consulta y el `INSERT` cabe otra alta con la misma licencia y el índice único rechaza la escritura. Sin transacción quedaría una cuenta con rol de conductor y sin licencia — estado que el dominio no contempla — y el propio conductor no podría reintentar, porque su email y su teléfono ya estarían tomados por esa cuenta a medias. Hay un test por cada mitad (HTTP y Action).
- **`license_number` se normaliza** (recorte + mayúsculas) antes de validar, por el mismo motivo que el email: `unique` es un `where columna = ?` y la colación de SQLite es BINARY, así que sin esto `lic-445566` y `LIC-445566` serían dos habilitaciones distintas. **No** se tocan los espacios interiores a propósito: `LIC 445 566` es una licencia mal escrita y corresponde un 422 explicable, no que el servidor adivine cómo debería haberse escrito.
- **La respuesta no incluye la licencia.** Reutiliza el schema `AuthenticatedUser` del registro de pasajero y del login; el dato del perfil se consulta por el endpoint de perfil (#10). Alternativa descartada: sumar el campo al schema `User`, que en las cuentas de pasajero quedaría siempre vacío.
- **Refactor fuera de los archivos nuevos:** la normalización de email/teléfono y las reglas de los campos de cuenta salieron de `RegisterPassengerRequest` al trait `NormalizesAccountInput`, que ahora usan ambos Form Requests. `.claude/STANDARDS.md` exige que los dos registros normalicen igual; duplicar esa lógica era la forma de que dejaran de hacerlo, y con ella la misma persona podría terminar con una cuenta por rol usando el mismo email escrito distinto. El comportamiento del endpoint de pasajero no cambia — sus tests, que ya cubrían la normalización, siguen en verde sin tocarlos.
- **Validación del formato de licencia:** `^[A-Z0-9-]{5,50}$`. Permisiva a propósito, porque el issue deja explícitamente fuera verificar la licencia contra una entidad externa; solo ataja entradas que claramente no son un número de licencia.
- `.claude/STANDARDS.md` registra estas decisiones en una sección nueva, como se hizo con #6.

## Nota aparte (no incluida en este PR)

`.claude/CLAUDE.md` sigue diciendo que el proyecto es un "esqueleto inicial de Laravel, sin dominio de negocio implementado todavía", lo cual quedó desactualizado hace varios PRs. Queda fuera del alcance de este issue.