### PR TITLE
feat(#8): iniciar sesión

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -180,6 +180,59 @@ canónicos) y agrega lo propio del rol:
   duplicado en cada Form Request: si las dos altas divergieran, la misma persona podría
   terminar con una cuenta por rol usando el mismo email escrito distinto.
 
+### Inicio de sesión (decidido en #8)
+
+`POST /api/v1/auth/login` es **un solo endpoint para ambos roles**: el rol no se manda
+ni se elige, sale de la cuenta encontrada y viaja de vuelta en `user.role` solo para
+que el cliente sepa qué UI mostrar. Responde **200** con el mismo schema
+`AuthenticatedUser` (`{user, token}`) que los dos registros, así que la app móvil
+procesa igual el alta y el login.
+
+- **Los dos fallos posibles son indistinguibles, y eso es el requisito, no un
+  detalle**: contraseña que no coincide y email sin cuenta responden 401 con el mismo
+  cuerpo palabra por palabra. Cualquier diferencia —código, mensaje, un `errors` de
+  más— convierte al endpoint en un oráculo para averiguar qué emails tienen cuenta,
+  que es el primer paso de un relleno de credenciales. Lo sostienen tres decisiones
+  concretas:
+  - Una sola excepción de dominio (`App\Exceptions\Auth\InvalidCredentialsException`)
+    para ambos motivos, **sin ningún dato que permita distinguirlos**. Si el motivo
+    llegara hasta el controller, tarde o temprano alguien lo renderizaría.
+  - El mensaje se define en un único lugar y la traducción a 401 vive en
+    `bootstrap/app.php`, junto al resto de fallos de autenticación — no en el
+    controller, que no captura nada.
+  - **La Action gasta un hash contra nada cuando el email no existe.** Sin eso, el
+    email sin cuenta responde sin haber ejecutado bcrypt y el email real responde
+    después de ejecutarlo: la diferencia de tiempo es medible y reconstruye el mismo
+    oráculo que el mensaje genérico evita. Laravel no lo hace por su cuenta
+    (`EloquentUserProvider::retrieveByCredentials()` devuelve `null` y nadie llega a
+    comparar nada), así que corresponde a la Action.
+- **El login NO valida la contraseña contra `Password::defaults()`.** Es la única
+  excepción a la política de la sección siguiente, y es deliberada: aplicarla haría
+  que una contraseña corta respondiera 422 y una bien formada 401, y esa diferencia de
+  código de estado delata cuál de los dos campos falló. Una contraseña que no cumple
+  la política simplemente no coincide con ninguna cuenta. Tampoco hay
+  `exists:users,email`, por el mismo motivo. Del `email` se valida la forma y nada
+  más: una cadena que no es un email no puede corresponder a ninguna cuenta, así que
+  su 422 no depende de qué haya en la base.
+- **El `email` se normaliza con el mismo trait `NormalizesAccountInput` que los
+  registros.** No es una comodidad: el alta guardó el email en minúsculas, así que un
+  login que normalizara distinto —o que no normalizara— dejaría a quien tecleó
+  `Ana@Example.COM` afuera de su propia cuenta, y encima con un mensaje que le dice
+  que su contraseña está mal.
+- Va sin `auth:api` y por lo tanto bajo el limitador `auth` (10/min por IP), que acá
+  es además la contención principal contra la fuerza bruta sobre contraseñas.
+- La contraseña en claro viaja en `App\DTOs\LoginCredentials` marcada con
+  `#[\SensitiveParameter]`, igual que hace Laravel en
+  `EloquentUserProvider::validateCredentials()`: sin eso queda como argumento en el
+  stack trace de cualquier excepción lanzada más abajo, y los reporters que vuelcan
+  los argumentos de cada frame la escribirían en el log.
+
+Queda **fuera** de #8: recuperación de contraseña, login con proveedores externos
+(Google/Apple), bloqueo de cuenta tras N intentos fallidos y rehash de la contraseña
+al iniciar sesión. El bloqueo por cuenta, en particular, es una decisión de producto
+con su propio costo (permite que un tercero deje sin servicio a un usuario conocido
+solo con fallar sus intentos) y merece su propia historia.
+
 ### Política de contraseñas (decidida en #6)
 
 Mínimo **8 caracteres, con al menos una letra y al menos un número**, declarada una

--- a/app/Actions/Auth/LoginAction.php
+++ b/app/Actions/Auth/LoginAction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\DTOs\AuthenticatedUser;
+use App\DTOs\LoginCredentials;
+use App\Exceptions\Auth\InvalidCredentialsException;
+use App\Models\User;
+use App\Services\Auth\AccessTokenFactory;
+use Illuminate\Support\Facades\Hash;
+use Tymon\JWTAuth\JWTAuth;
+
+/**
+ * Autentica una cuenta ya registrada y emite su access token.
+ *
+ * Un solo caso de uso para ambos roles: el rol no participa de la decisión, se
+ * lee de la cuenta encontrada y viaja de vuelta para que el cliente sepa qué UI
+ * mostrar.
+ *
+ * Devuelve el mismo `AuthenticatedUser` que los registros, así que la respuesta
+ * del login y la del alta tienen exactamente la misma forma.
+ */
+final class LoginAction
+{
+    public function __construct(
+        private readonly JWTAuth $jwt,
+        private readonly AccessTokenFactory $tokens,
+    ) {}
+
+    /**
+     * @throws InvalidCredentialsException si el email no tiene cuenta o la
+     *                                     contraseña no coincide — el mismo
+     *                                     fallo para ambos casos.
+     */
+    public function handle(#[\SensitiveParameter] LoginCredentials $credentials): AuthenticatedUser
+    {
+        $user = User::firstWhere('email', $credentials->email);
+
+        if ($user === null) {
+            // Se gasta un hash contra nada. Sin esto, el email sin cuenta
+            // responde sin haber ejecutado bcrypt y el email real responde
+            // después de ejecutarlo: la diferencia de tiempo es medible y
+            // reconstruye exactamente el oráculo que el mensaje genérico
+            // evita. Laravel tampoco lo hace por su cuenta —
+            // `EloquentUserProvider::retrieveByCredentials()` devuelve `null`
+            // y nadie llega a comparar nada—, así que corresponde acá.
+            Hash::make($credentials->password);
+
+            throw new InvalidCredentialsException;
+        }
+
+        if (! Hash::check($credentials->password, $user->getAuthPassword())) {
+            throw new InvalidCredentialsException;
+        }
+
+        return new AuthenticatedUser(
+            user: $user,
+            token: $this->tokens->fromJwt($this->jwt->fromUser($user)),
+        );
+    }
+}

--- a/app/Actions/Auth/LoginAction.php
+++ b/app/Actions/Auth/LoginAction.php
@@ -36,6 +36,23 @@ final class LoginAction
      */
     public function handle(#[\SensitiveParameter] LoginCredentials $credentials): AuthenticatedUser
     {
+        // Antes de mirar la base, y por lo tanto igual para cualquier email:
+        // `Hash::make()` no acepta un byte nulo —`password_hash()` lanza un
+        // `ValueError` que `BcryptHasher::make()` re-lanza como
+        // `RuntimeException`—, así que el hash de descarte de más abajo salía
+        // por una excepción ajena al dominio en vez de por el 401. Un byte nulo
+        // no puede ser la contraseña de ninguna cuenta: el alta habría fallado
+        // igual al hashearla. Se comprueba en vez de capturar la
+        // `RuntimeException` para no confundir esta entrada con un bcrypt
+        // realmente inutilizable, que sí tiene que romper fuerte.
+        //
+        // El Form Request ya lo rechaza con un 422 antes de llegar acá; esto es
+        // lo que sostiene el `@throws` para quien invoque el caso de uso sin
+        // pasar por HTTP, desde un comando o un job.
+        if (str_contains($credentials->password, "\0")) {
+            throw new InvalidCredentialsException;
+        }
+
         $user = User::firstWhere('email', $credentials->email);
 
         if ($user === null) {

--- a/app/DTOs/LoginCredentials.php
+++ b/app/DTOs/LoginCredentials.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Credenciales con las que una cuenta ya registrada inicia sesión.
+ *
+ * No lleva rol: el mismo caso de uso sirve a pasajeros y conductores, y el rol
+ * sale de la cuenta encontrada, nunca de la entrada.
+ *
+ * El `email` llega ya en su forma canónica (minúsculas). Quien construye el DTO
+ * es responsable de normalizarlo — desde HTTP lo hace `LoginRequest` con el
+ * mismo trait que usan los registros, para que la forma canónica siga viviendo
+ * en un solo lugar (ver .claude/STANDARDS.md).
+ */
+final readonly class LoginCredentials
+{
+    /**
+     * `#[\SensitiveParameter]` por el mismo motivo por el que Laravel lo pone
+     * en `EloquentUserProvider::validateCredentials()`: sin él, la contraseña
+     * en claro queda como argumento en el stack trace de cualquier excepción
+     * que se lance más abajo, y los reporters que vuelcan los argumentos de
+     * cada frame la escribirían en el log.
+     */
+    public function __construct(
+        public string $email,
+        #[\SensitiveParameter]
+        public string $password,
+    ) {}
+}

--- a/app/Exceptions/Auth/InvalidCredentialsException.php
+++ b/app/Exceptions/Auth/InvalidCredentialsException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Auth;
+
+use RuntimeException;
+
+/**
+ * Las credenciales de inicio de sesión no corresponden a ninguna cuenta.
+ *
+ * Es **una sola** excepción para los dos motivos posibles —contraseña que no
+ * coincide y email sin cuenta— y a propósito no lleva ningún dato que permita
+ * distinguirlos: si el motivo viajara hasta acá, tarde o temprano alguien lo
+ * renderizaría y el endpoint pasaría a contestar qué emails tienen cuenta.
+ *
+ * No conoce HTTP: no trae código de estado ni sabe que existe un 401. La
+ * traducción a respuesta ocurre en bootstrap/app.php, junto al resto de fallos
+ * de autenticación, para que las Actions sigan siendo invocables desde un
+ * comando o un job (ver .claude/STANDARDS.md).
+ */
+final class InvalidCredentialsException extends RuntimeException
+{
+    /**
+     * Mensaje genérico, y el único que el cliente llega a ver.
+     */
+    public const MESSAGE = 'El email o la contraseña no son correctos.';
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LoginController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\LoginAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Resources\AuthenticatedUserResource;
+
+/**
+ * POST /api/v1/auth/login
+ *
+ * Va sin `auth:api` —quien inicia sesión todavía no tiene token— y por eso
+ * queda bajo el limitador `auth`, que acá es además la contención principal
+ * contra la fuerza bruta sobre contraseñas.
+ *
+ * No captura nada: el fallo de credenciales sale de la Action como
+ * `InvalidCredentialsException` y se traduce a 401 en bootstrap/app.php, junto
+ * al resto de fallos de autenticación. Así el mensaje genérico está definido en
+ * un solo lugar y no depende de que cada controller lo repita igual.
+ */
+class LoginController extends Controller
+{
+    public function __invoke(LoginRequest $request, LoginAction $login): AuthenticatedUserResource
+    {
+        return new AuthenticatedUserResource($login->handle($request->toCredentials()));
+    }
+}

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -44,13 +44,42 @@ class LoginRequest extends FormRequest
      * campos falló. Una contraseña que no cumple la política simplemente no
      * coincide con ninguna cuenta.
      *
+     * El `regex` de la contraseña no es una excepción a esa regla, es la misma:
+     * rechaza el byte nulo, que es forma y no existencia. `password_hash()` no
+     * lo acepta —lanza un `ValueError` que `BcryptHasher::make()` re-lanza como
+     * `RuntimeException`—, así que sin esta regla la contraseña `"a\0b"` salía
+     * 500 contra un email sin cuenta (por el hash de descarte de la Action) y
+     * 401 contra uno registrado (`password_verify()` no lanza, devuelve
+     * `false`): el estado pasaba a depender de si el email existía. Un byte nulo
+     * tampoco puede ser la contraseña de ninguna cuenta —el alta habría fallado
+     * igual al hashearla—, así que su 422 no depende de qué haya en la base, el
+     * mismo argumento que el del `email` mal formado.
+     *
+     * Deliberadamente NO hay un `max` sobre la contraseña: `Password::defaults()`
+     * no le pone techo a la del registro, así que acotarla solo acá dejaría
+     * afuera de su propia cuenta a quien se registró con una más larga. Y no
+     * hace falta para el 500: bcrypt trunca a 72 bytes sin lanzar nada.
+     *
      * @return array<string, array<int, mixed>>
      */
     public function rules(): array
     {
         return [
             'email' => ['required', 'string', 'email', 'max:255'],
-            'password' => ['required', 'string'],
+            'password' => ['required', 'string', 'regex:/^[^\x00]*$/u'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        // El mensaje por defecto de `regex` ("el formato es inválido") invita a
+        // creer que hay una política de formato que cumplir, que es justo lo que
+        // el login no tiene.
+        return [
+            'password.regex' => 'El campo password no puede contener un byte nulo.',
         ];
     }
 

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\DTOs\LoginCredentials;
+use App\Http\Requests\Concerns\NormalizesAccountInput;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/auth/login — ver openapi.yaml.
+ *
+ * No define `authorize()`: el endpoint es anónimo por diseño —autenticarse es
+ * justamente lo que viene a hacer quien lo llama—, así que no hay sujeto contra
+ * el cual autorizar. Lo que lo protege es el limitador de tasa `auth`.
+ */
+class LoginRequest extends FormRequest
+{
+    use NormalizesAccountInput;
+
+    /**
+     * Lleva el `email` a su forma canónica ANTES de buscar la cuenta.
+     *
+     * Usa el mismo trait que los registros a propósito: el email se guardó en
+     * minúsculas al darse de alta, así que si el login normalizara distinto —o
+     * no normalizara— quien tecleó `Ana@Example.COM` quedaría afuera de su
+     * propia cuenta, y encima con un mensaje que le dice que su contraseña está
+     * mal. Que la forma canónica viva en un solo lugar es lo que impide que
+     * alta y login puedan divergir (ver .claude/STANDARDS.md).
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge($this->canonicalAccountInput());
+    }
+
+    /**
+     * Solo forma, nunca existencia.
+     *
+     * No hay `exists:users,email` —sería el oráculo que el 401 genérico existe
+     * para evitar— ni `Password::defaults()` sobre la contraseña: aplicar la
+     * política del registro haría que una contraseña corta respondiera 422 y
+     * una bien formada 401, y esa diferencia de estado delata cuál de los dos
+     * campos falló. Una contraseña que no cumple la política simplemente no
+     * coincide con ninguna cuenta.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     */
+    public function toCredentials(): LoginCredentials
+    {
+        return new LoginCredentials(
+            email: $this->string('email')->toString(),
+            password: $this->string('password')->toString(),
+        );
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\Auth\InvalidCredentialsException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -51,6 +52,21 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(
             fn (TokenExpiredException|TokenInvalidException|UserNotDefinedException $e) => new JsonResponse(
                 ['message' => 'Token inválido o expirado. Inicia sesión de nuevo.'],
+                JsonResponse::HTTP_UNAUTHORIZED,
+            ),
+        );
+
+        // Credenciales que no corresponden a ninguna cuenta (login, historia
+        // #8). Se traduce acá y no en el controller por el mismo motivo que lo
+        // anterior, y además porque el cuerpo tiene que ser palabra por palabra
+        // el mismo para los dos motivos posibles —contraseña incorrecta y email
+        // sin cuenta—: definirlo en un solo lugar es lo que garantiza que no
+        // puedan separarse. `$e->getMessage()` ya es ese mensaje genérico (ver
+        // InvalidCredentialsException); la excepción no lleva ningún dato del
+        // motivo, así que no hay nada que se pueda filtrar por acá.
+        $exceptions->render(
+            fn (InvalidCredentialsException $e) => new JsonResponse(
+                ['message' => $e->getMessage()],
                 JsonResponse::HTTP_UNAUTHORIZED,
             ),
         );

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -502,6 +502,14 @@ components:
             esa diferencia de código de estado delataría cuál de los dos campos
             falló. Una contraseña que no cumple la política simplemente no
             coincide con ninguna cuenta.
+
+
+            La única forma que sí se rechaza con 422 es el byte nulo
+            (`U+0000`), que bcrypt no puede hashear y que por lo tanto tampoco
+            puede ser la contraseña de ninguna cuenta: ese 422 no depende de qué
+            haya en la base. Tampoco hay `maxLength`, para no dejar afuera a una
+            cuenta registrada con una contraseña más larga que el tope.
+          pattern: "^[^\\u0000]*$"
           example: motoya2026
     DriverRegistrationRequest:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,6 +13,98 @@ servers:
 security:
   - bearerAuth: []
 paths:
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      operationId: login
+      summary: Iniciar sesión con email y contraseña
+      description: >-
+        Autentica una cuenta ya registrada y devuelve un access token. Es el
+        mismo endpoint para pasajeros y conductores: el rol no se manda ni se
+        elige, viaja de vuelta en `user.role` para que el cliente sepa qué UI
+        mostrar.
+
+        El `email` se normaliza a minúsculas antes de buscarlo, igual que en el
+        registro (ver .claude/STANDARDS.md): quien se registró como
+        `ana@example.com` entra escribiendo `Ana@Example.COM`.
+
+        **Credenciales incorrectas y email no registrado responden exactamente
+        lo mismo**: 401 con un mensaje genérico, sin `errors`. Distinguir ambos
+        casos convertiría al endpoint en un oráculo para averiguar qué emails
+        tienen cuenta, que es el primer paso de un relleno de credenciales.
+
+        No requiere autenticación, y por eso comparte con el resto de endpoints
+        de auth el límite de 10 requests por minuto e IP — que acá es además la
+        contención principal contra la fuerza bruta sobre contraseñas.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+            example:
+              email: ana@example.com
+              password: motoya2026
+      responses:
+        "200":
+          description: Credenciales correctas; sesión iniciada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AuthenticatedUser"
+              example:
+                data:
+                  user:
+                    id: 1
+                    name: Ana García
+                    email: ana@example.com
+                    phone: "+573001234567"
+                    role: passenger
+                  token:
+                    access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJwYXNzZW5nZXIifQ.4pcPyMD09olPSyXnrXCjTwXyr4BsezdI1AVTmud2fU4
+                    token_type: bearer
+                    expires_in: 900
+        "401":
+          description: >-
+            La contraseña no coincide, o el email no corresponde a ninguna
+            cuenta. Ambos casos devuelven este mismo cuerpo, palabra por
+            palabra.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: El email o la contraseña no son correctos.
+        "422":
+          description: >-
+            La entrada está incompleta o malformada: falta `email` o
+            `password`, o el email no tiene forma de email. **No** se usa para
+            credenciales incorrectas — eso es 401.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The email field is required.
+                errors:
+                  email:
+                    - The email field is required.
+        "429":
+          description: >-
+            Se superó el límite de intentos por minuto para esta IP.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /auth/refresh:
     post:
       tags:
@@ -382,6 +474,35 @@ components:
           $ref: "#/components/schemas/User"
         token:
           $ref: "#/components/schemas/AuthToken"
+    LoginRequest:
+      type: object
+      description: >-
+        Credenciales con las que una cuenta ya registrada inicia sesión. No
+        lleva rol: el mismo endpoint sirve a pasajeros y conductores.
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: >-
+            Email de la cuenta. Se normaliza a minúsculas antes de buscarla,
+            igual que en el registro, así que la capitalización con la que se
+            escriba es indiferente.
+          example: ana@example.com
+        password:
+          type: string
+          format: password
+          description: >-
+            Contraseña en claro. A diferencia del registro, acá **no** se
+            valida contra la política mínima de contraseñas: hacerlo
+            respondería 422 en vez de 401 a una contraseña que no la cumple, y
+            esa diferencia de código de estado delataría cuál de los dos campos
+            falló. Una contraseña que no cumple la política simplemente no
+            coincide con ninguna cuenta.
+          example: motoya2026
     DriverRegistrationRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
@@ -23,12 +24,14 @@ Route::prefix('v1')->group(function () {
 
     // Endpoints de autenticación: van sin `auth:api` a propósito, así que
     // cualquiera puede golpearlos sin credenciales. Por eso el grupo lleva un
-    // límite de tasa más estricto que el general de la API — es el patrón que
-    // hereda el login cuando llegue (ver AppServiceProvider).
+    // límite de tasa más estricto que el general de la API (ver
+    // AppServiceProvider); para el login es, además, la contención principal
+    // contra la fuerza bruta sobre contraseñas.
     Route::middleware('throttle:auth')
         ->prefix('auth')
         ->name('auth.')
         ->group(function () {
+            Route::post('login', LoginController::class)->name('login');
             Route::post('refresh', RefreshTokenController::class)->name('refresh');
             Route::post('register/driver', RegisterDriverController::class)->name('register.driver');
             Route::post('register/passenger', RegisterPassengerController::class)->name('register.passenger');

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Contrato de POST /api/v1/auth/login — ver openapi.yaml.
+ *
+ * Es la puerta de entrada de las cuentas ya registradas, y el mismo endpoint
+ * para ambos roles. Lo que más se prueba acá no es el camino feliz sino la
+ * indistinguibilidad de los dos fallos posibles: si "contraseña incorrecta" y
+ * "email no registrado" no responden exactamente lo mismo, el endpoint sirve
+ * para averiguar qué emails tienen cuenta.
+ */
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const LOGIN_URI = '/api/v1/auth/login';
+
+    private const PROBE_URI = '/api/v1/_probe-protegida';
+
+    private const PASSWORD = 'motoya2026';
+
+    private const MENSAJE_GENERICO = 'El email o la contraseña no son correctos.';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('auth:api')->get(self::PROBE_URI, function () {
+            return response()->json(['user_id' => auth('api')->id()]);
+        });
+    }
+
+    public function test_autentica_a_la_cuenta_y_devuelve_la_forma_del_contrato(): void
+    {
+        // `expires_in` se calcula restándole "ahora" al claim `exp` del token
+        // emitido; sin congelar el reloj, cruzar un segundo entre ambas
+        // lecturas daría 899 y haría el test intermitente.
+        $this->freezeSecond();
+
+        $usuario = $this->cuentaRegistrada();
+
+        $this->postJson(self::LOGIN_URI, $this->credencialesValidas())
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'user' => ['id', 'name', 'email', 'phone', 'role'],
+                    'token' => ['access_token', 'token_type', 'expires_in'],
+                ],
+            ])
+            ->assertJsonPath('data.user.id', $usuario->id)
+            ->assertJsonPath('data.user.email', 'ana@example.com')
+            ->assertJsonPath('data.user.role', 'passenger')
+            ->assertJsonPath('data.token.token_type', 'bearer')
+            // 15 minutos de TTL expresados en segundos.
+            ->assertJsonPath('data.token.expires_in', 900);
+    }
+
+    public function test_el_token_devuelto_autentica_a_la_cuenta_que_inicio_sesion(): void
+    {
+        // Lo que hace útil al endpoint no es que devuelva "un string": es que
+        // ese token sirva de verdad contra la API, para el usuario correcto.
+        $usuario = $this->cuentaRegistrada();
+
+        $token = $this->postJson(self::LOGIN_URI, $this->credencialesValidas())
+            ->assertOk()
+            ->json('data.token.access_token');
+
+        $this->withToken($token)
+            ->getJson(self::PROBE_URI)
+            ->assertOk()
+            ->assertJson(['user_id' => $usuario->id]);
+    }
+
+    public function test_un_conductor_inicia_sesion_por_el_mismo_endpoint(): void
+    {
+        // Ambos roles comparten endpoint: el rol no se manda ni se elige, viaja
+        // de vuelta para que el cliente sepa qué UI mostrar.
+        $this->cuentaRegistrada(['email' => 'carlos@example.com'], conductor: true);
+
+        $this->postJson(self::LOGIN_URI, [
+            'email' => 'carlos@example.com',
+            'password' => self::PASSWORD,
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.user.role', 'driver');
+    }
+
+    public function test_rechaza_una_contrasena_incorrecta_con_401(): void
+    {
+        $this->cuentaRegistrada();
+
+        $this->postJson(self::LOGIN_URI, [
+            ...$this->credencialesValidas(),
+            'password' => 'motoya2027',
+        ])
+            ->assertUnauthorized()
+            ->assertExactJson(['message' => self::MENSAJE_GENERICO]);
+    }
+
+    public function test_rechaza_un_email_no_registrado_con_401(): void
+    {
+        // 401 y no 404: que el email no exista es un fallo de credenciales, y
+        // decir "no existe" ya sería contestar la pregunta que no queremos
+        // contestar.
+        $this->postJson(self::LOGIN_URI, $this->credencialesValidas())
+            ->assertUnauthorized()
+            ->assertExactJson(['message' => self::MENSAJE_GENERICO]);
+    }
+
+    public function test_los_dos_fallos_responden_exactamente_lo_mismo(): void
+    {
+        // El criterio de aceptación central de la historia. Cualquier
+        // diferencia —código, mensaje, un `errors` de más— convierte al
+        // endpoint en un oráculo de qué emails tienen cuenta, que es el primer
+        // paso de un relleno de credenciales.
+        $this->cuentaRegistrada();
+
+        $contrasenaIncorrecta = $this->postJson(self::LOGIN_URI, [
+            ...$this->credencialesValidas(),
+            'password' => 'motoya2027',
+        ]);
+
+        $emailInexistente = $this->postJson(self::LOGIN_URI, [
+            'email' => 'nadie@example.com',
+            'password' => self::PASSWORD,
+        ]);
+
+        $this->assertSame($contrasenaIncorrecta->getStatusCode(), $emailInexistente->getStatusCode());
+        $this->assertSame($contrasenaIncorrecta->json(), $emailInexistente->json());
+    }
+
+    public function test_no_devuelve_token_cuando_las_credenciales_son_incorrectas(): void
+    {
+        $this->cuentaRegistrada();
+
+        $respuesta = $this->postJson(self::LOGIN_URI, [
+            ...$this->credencialesValidas(),
+            'password' => 'motoya2027',
+        ])->assertUnauthorized();
+
+        $this->assertNull($respuesta->json('data'));
+        $this->assertStringNotContainsString('access_token', $respuesta->getContent());
+    }
+
+    public function test_acepta_el_email_en_cualquier_capitalizacion(): void
+    {
+        // El registro guarda el email en minúsculas (ver la normalización
+        // decidida en #6). Sin normalizar acá también, quien tecleó
+        // `Ana@Example.COM` en el teclado del móvil quedaría afuera de su
+        // propia cuenta con un mensaje que dice que su contraseña está mal.
+        $this->cuentaRegistrada();
+
+        $this->postJson(self::LOGIN_URI, [
+            'email' => 'Ana@Example.COM',
+            'password' => self::PASSWORD,
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.user.email', 'ana@example.com');
+    }
+
+    /**
+     * @param  list<string>  $camposEsperados
+     */
+    #[DataProvider('camposRequeridos')]
+    public function test_rechaza_la_falta_de_un_campo_requerido(string $campoFaltante, array $camposEsperados): void
+    {
+        $this->cuentaRegistrada();
+
+        $credenciales = $this->credencialesValidas();
+        unset($credenciales[$campoFaltante]);
+
+        $this->postJson(self::LOGIN_URI, $credenciales)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($camposEsperados);
+    }
+
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function camposRequeridos(): array
+    {
+        return [
+            'email' => ['email', ['email']],
+            'contraseña' => ['password', ['password']],
+        ];
+    }
+
+    public function test_rechaza_un_email_con_formato_invalido(): void
+    {
+        // Un 422 acá no delata nada: una cadena que no es un email no puede
+        // corresponder a ninguna cuenta, así que la respuesta no depende de qué
+        // haya en la base.
+        $this->postJson(self::LOGIN_URI, [
+            ...$this->credencialesValidas(),
+            'email' => 'ana-arroba-example.com',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+    }
+
+    #[DataProvider('contrasenasQueNoCumplenLaPoliticaDelRegistro')]
+    public function test_no_valida_la_contrasena_contra_la_politica_del_registro(string $password): void
+    {
+        // El login no aplica `Password::defaults()`: si lo hiciera, una
+        // contraseña corta o sin números respondería 422 y una larga y bien
+        // formada respondería 401, y esa diferencia delata cuál de los dos
+        // campos falló. Una contraseña que no cumple la política simplemente no
+        // coincide con ninguna cuenta.
+        $this->cuentaRegistrada();
+
+        $this->postJson(self::LOGIN_URI, [...$this->credencialesValidas(), 'password' => $password])
+            ->assertUnauthorized()
+            ->assertExactJson(['message' => self::MENSAJE_GENERICO]);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function contrasenasQueNoCumplenLaPoliticaDelRegistro(): array
+    {
+        return [
+            'demasiado corta' => ['moto26'],
+            'sin números' => ['motoyamotoya'],
+            'sin letras' => ['20262026262'],
+        ];
+    }
+
+    public function test_no_expone_la_contrasena_en_la_respuesta(): void
+    {
+        $this->cuentaRegistrada();
+
+        $respuesta = $this->postJson(self::LOGIN_URI, $this->credencialesValidas())->assertOk();
+
+        $this->assertArrayNotHasKey('password', $respuesta->json('data.user'));
+        $this->assertStringNotContainsString(self::PASSWORD, $respuesta->getContent());
+    }
+
+    public function test_limita_la_cantidad_de_intentos_por_minuto(): void
+    {
+        // El endpoint es anónimo y contesta "sí/no" sobre una contraseña: sin
+        // límite es un banco de pruebas de fuerza bruta. Es el mismo limitador
+        // `auth` que cubre al registro y al refresh (ver AppServiceProvider).
+        $this->cuentaRegistrada();
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson(self::LOGIN_URI, [
+                ...$this->credencialesValidas(),
+                'password' => "intento{$i}",
+            ])->assertUnauthorized();
+        }
+
+        $this->postJson(self::LOGIN_URI, $this->credencialesValidas())
+            ->assertStatus(429)
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $atributos
+     */
+    private function cuentaRegistrada(array $atributos = [], bool $conductor = false): User
+    {
+        $factory = $conductor ? User::factory()->driver() : User::factory();
+
+        return $factory->create([
+            'email' => 'ana@example.com',
+            'password' => self::PASSWORD,
+            ...$atributos,
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function credencialesValidas(): array
+    {
+        return [
+            'email' => 'ana@example.com',
+            'password' => self::PASSWORD,
+        ];
+    }
+}

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -235,6 +235,71 @@ class LoginTest extends TestCase
         ];
     }
 
+    public function test_rechaza_una_contrasena_con_un_byte_nulo(): void
+    {
+        // `password_hash()` no acepta un byte nulo: lanza un `ValueError` que
+        // `BcryptHasher::make()` re-lanza como `RuntimeException`, que no es una
+        // `InvalidCredentialsException` y por lo tanto salía como 500.
+        //
+        // El 422 acá no delata nada, por el mismo argumento que el del email mal
+        // formado: una contraseña con un byte nulo no puede ser la de ninguna
+        // cuenta —el alta tampoco pudo guardarla, el cast `hashed` habría
+        // fallado igual—, así que la respuesta no depende de qué haya en la base.
+        $this->cuentaRegistrada();
+
+        $this->postJson(self::LOGIN_URI, [
+            ...$this->credencialesValidas(),
+            'password' => "a\x00b",
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_los_dos_fallos_responden_igual_con_una_contrasena_que_no_se_puede_hashear(): void
+    {
+        // La misma afirmación que `test_los_dos_fallos_responden_exactamente_lo_mismo`,
+        // con la contraseña que el resto de los tests no cubría: las tres del
+        // provider `contrasenasQueNoCumplenLaPoliticaDelRegistro` son todas
+        // hasheables, así que ninguna llegaba a la rama que rompía.
+        //
+        // Sin la regla, esta misma contraseña daba 500 con el email inexistente
+        // y 401 con el registrado: el código de estado pasaba a depender de si
+        // el email tenía cuenta, que es exactamente el oráculo que el mensaje
+        // genérico, la excepción sin motivo y el hash de descarte evitan.
+        $this->cuentaRegistrada();
+
+        $emailRegistrado = $this->postJson(self::LOGIN_URI, [
+            'email' => 'ana@example.com',
+            'password' => "a\x00b",
+        ]);
+
+        $emailInexistente = $this->postJson(self::LOGIN_URI, [
+            'email' => 'nadie@example.com',
+            'password' => "a\x00b",
+        ]);
+
+        $this->assertSame($emailRegistrado->getStatusCode(), $emailInexistente->getStatusCode());
+        $this->assertSame($emailRegistrado->json(), $emailInexistente->json());
+        $this->assertLessThan(500, $emailInexistente->getStatusCode());
+    }
+
+    public function test_acepta_una_contrasena_larga_que_el_registro_pudo_guardar(): void
+    {
+        // Contracara de la regla de arriba: acota la forma, nunca el largo.
+        // `Password::defaults()` no le pone techo a la contraseña del registro,
+        // así que un `max` solo en el login dejaría a esa cuenta sin poder
+        // entrar —un 422 sobre una contraseña que es la correcta—. Y no hace
+        // falta para el 500: bcrypt trunca a 72 bytes sin lanzar nada.
+        $larga = str_repeat('motoya2026', 40);
+
+        $this->cuentaRegistrada(['password' => $larga]);
+
+        $this->postJson(self::LOGIN_URI, [
+            'email' => 'ana@example.com',
+            'password' => $larga,
+        ])->assertOk();
+    }
+
     public function test_no_expone_la_contrasena_en_la_respuesta(): void
     {
         $this->cuentaRegistrada();

--- a/tests/Unit/Actions/Auth/LoginActionTest.php
+++ b/tests/Unit/Actions/Auth/LoginActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\LoginAction;
+use App\DTOs\LoginCredentials;
+use App\Enums\UserRole;
+use App\Exceptions\Auth\InvalidCredentialsException;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ *
+ * Que el fallo sea una excepción del dominio, y la misma para ambos motivos, es
+ * lo que hace que la indistinguibilidad de los dos casos no dependa de que el
+ * controller se acuerde de unificarlos.
+ */
+class LoginActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PASSWORD = 'motoya2026';
+
+    public function test_devuelve_la_cuenta_para_credenciales_validas(): void
+    {
+        $usuario = $this->cuentaRegistrada();
+
+        $resultado = $this->action()->handle($this->credenciales());
+
+        $this->assertSame($usuario->id, $resultado->user->id);
+        $this->assertSame('ana@example.com', $resultado->user->email);
+        $this->assertSame(UserRole::Passenger, $resultado->user->role);
+    }
+
+    public function test_el_token_identifica_a_la_cuenta_que_inicio_sesion(): void
+    {
+        $usuario = $this->cuentaRegistrada();
+
+        $resultado = $this->action()->handle($this->credenciales());
+
+        $identificado = JWTAuth::setToken($resultado->token->accessToken)->authenticate();
+
+        $this->assertInstanceOf(User::class, $identificado);
+        $this->assertSame($usuario->id, $identificado->id);
+    }
+
+    public function test_el_token_declara_su_vencimiento_segun_el_ttl_configurado(): void
+    {
+        $this->freezeSecond();
+
+        $this->cuentaRegistrada();
+
+        $resultado = $this->action()->handle($this->credenciales());
+
+        $this->assertSame('bearer', $resultado->token->tokenType);
+        // 15 minutos de TTL (`jwt.ttl`) expresados en segundos.
+        $this->assertSame(900, $resultado->token->expiresInSeconds);
+    }
+
+    public function test_autentica_igual_a_un_conductor(): void
+    {
+        // El caso de uso es "iniciar sesión", no "iniciar sesión como pasajero":
+        // el rol no participa de la decisión.
+        $conductor = $this->cuentaRegistrada(conductor: true);
+
+        $resultado = $this->action()->handle($this->credenciales());
+
+        $this->assertSame($conductor->id, $resultado->user->id);
+        $this->assertTrue($resultado->user->isDriver());
+    }
+
+    public function test_rechaza_una_contrasena_incorrecta(): void
+    {
+        $this->cuentaRegistrada();
+
+        $this->expectException(InvalidCredentialsException::class);
+
+        $this->action()->handle(new LoginCredentials(
+            email: 'ana@example.com',
+            password: 'motoya2027',
+        ));
+    }
+
+    public function test_rechaza_un_email_que_no_corresponde_a_ninguna_cuenta(): void
+    {
+        // Mismo tipo de excepción que la contraseña incorrecta: la Action no
+        // ofrece forma de distinguir los dos motivos, así que ninguna capa de
+        // arriba puede filtrarla por accidente.
+        $this->expectException(InvalidCredentialsException::class);
+
+        $this->action()->handle(new LoginCredentials(
+            email: 'nadie@example.com',
+            password: self::PASSWORD,
+        ));
+    }
+
+    public function test_no_distingue_el_motivo_del_fallo_en_el_mensaje(): void
+    {
+        // Si la excepción llevara el motivo, tarde o temprano alguien lo
+        // renderizaría. El mensaje es el mismo para ambos casos, y el detalle
+        // que sirve para diagnosticar vive en los logs de la aplicación, no en
+        // el objeto que viaja hacia el controller.
+        $this->cuentaRegistrada();
+
+        $porContrasena = $this->motivoDelFallo('ana@example.com', 'motoya2027');
+        $porEmail = $this->motivoDelFallo('nadie@example.com', self::PASSWORD);
+
+        $this->assertSame($porContrasena, $porEmail);
+    }
+
+    private function motivoDelFallo(string $email, string $password): string
+    {
+        try {
+            $this->action()->handle(new LoginCredentials($email, $password));
+        } catch (InvalidCredentialsException $e) {
+            return $e->getMessage();
+        }
+
+        $this->fail('Se esperaba una InvalidCredentialsException.');
+    }
+
+    private function action(): LoginAction
+    {
+        return $this->app->make(LoginAction::class);
+    }
+
+    private function cuentaRegistrada(bool $conductor = false): User
+    {
+        $factory = $conductor ? User::factory()->driver() : User::factory();
+
+        return $factory->create([
+            'email' => 'ana@example.com',
+            'password' => self::PASSWORD,
+        ]);
+    }
+
+    private function credenciales(): LoginCredentials
+    {
+        return new LoginCredentials(
+            email: 'ana@example.com',
+            password: self::PASSWORD,
+        );
+    }
+}

--- a/tests/Unit/Actions/Auth/LoginActionTest.php
+++ b/tests/Unit/Actions/Auth/LoginActionTest.php
@@ -100,6 +100,34 @@ class LoginActionTest extends TestCase
         ));
     }
 
+    public function test_una_contrasena_que_no_se_puede_hashear_falla_como_credencial_invalida(): void
+    {
+        // El hash de descarte del email inexistente es la única línea de la
+        // Action que puede lanzar algo que no sea del dominio: `Hash::make()`
+        // con un byte nulo sale por `RuntimeException`. Que acá siga siendo una
+        // `InvalidCredentialsException` es lo que sostiene el `@throws` del
+        // método para quien llame al caso de uso sin pasar por HTTP —un comando
+        // o un job—, donde no hay Form Request que filtre la entrada.
+        $this->expectException(InvalidCredentialsException::class);
+
+        $this->action()->handle(new LoginCredentials(
+            email: 'nadie@example.com',
+            password: "a\x00b",
+        ));
+    }
+
+    public function test_no_distingue_el_motivo_del_fallo_con_una_contrasena_que_no_se_puede_hashear(): void
+    {
+        // Y el motivo tampoco se filtra por esta rama: el mensaje es el mismo
+        // que el de la contraseña incorrecta contra una cuenta que sí existe.
+        $this->cuentaRegistrada();
+
+        $porContrasena = $this->motivoDelFallo('ana@example.com', "a\x00b");
+        $porEmail = $this->motivoDelFallo('nadie@example.com', "a\x00b");
+
+        $this->assertSame($porContrasena, $porEmail);
+    }
+
     public function test_no_distingue_el_motivo_del_fallo_en_el_mensaje(): void
     {
         // Si la excepción llevara el motivo, tarde o temprano alguien lo


### PR DESCRIPTION
Closes #8

## Qué hace

`POST /api/v1/auth/login`: autentica una cuenta ya registrada y devuelve un access
token. **Un solo endpoint para ambos roles** — el rol no se manda ni se elige, sale de
la cuenta encontrada y viaja de vuelta en `user.role` solo para que el cliente sepa qué
UI mostrar. Responde 200 con el mismo schema `AuthenticatedUser` (`{user, token}`) que
los dos registros, así que la app móvil procesa igual el alta y el login.

Va sin `auth:api` y por lo tanto bajo el limitador `auth` (10/min por IP), que acá es
además la contención principal contra la fuerza bruta sobre contraseñas.

Piezas nuevas, siguiendo el patrón de los registros: `LoginAction`, `LoginController`,
`LoginRequest`, DTO `LoginCredentials`, `InvalidCredentialsException`. La decisión
completa quedó documentada en `.claude/STANDARDS.md`.

## Decisiones y riesgos

**El criterio central de la historia es que los dos fallos sean indistinguibles**
(contraseña incorrecta y email sin cuenta → 401 con el mismo cuerpo palabra por
palabra). Cualquier diferencia convierte al endpoint en un oráculo de qué emails tienen
cuenta. Lo sostienen cuatro decisiones, y vale la pena mirarlas juntas:

1. **Una sola excepción de dominio sin dato del motivo.** `InvalidCredentialsException`
   no distingue los dos casos. Si el motivo llegara al controller, tarde o temprano
   alguien lo renderizaría.
2. **El 401 se traduce en `bootstrap/app.php`**, junto al resto de fallos de
   autenticación; el controller no captura nada. El mensaje queda definido en un solo
   lugar, que es lo que garantiza que los dos casos no puedan separarse.
3. **La Action gasta un hash contra nada cuando el email no existe.** Sin eso, el email
   sin cuenta responde sin haber ejecutado bcrypt y el email real responde después de
   ejecutarlo: la diferencia es medible y reconstruye el mismo oráculo que el mensaje
   genérico evita. Laravel no lo hace por su cuenta —
   `EloquentUserProvider::retrieveByCredentials()` devuelve `null` y nadie llega a
   comparar nada.
4. **El login NO valida la contraseña contra `Password::defaults()`**, y es la única
   excepción deliberada a la política de contraseñas del proyecto. Aplicarla haría que
   una contraseña corta respondiera 422 y una bien formada 401, y esa diferencia de
   código de estado delata cuál de los dos campos falló. Tampoco hay
   `exists:users,email`, por el mismo motivo.

Otras dos:

- **El `email` se normaliza con el mismo trait `NormalizesAccountInput` que los
  registros.** No es comodidad: el alta guardó el email en minúsculas, así que un login
  que normalizara distinto dejaría a quien tecleó `Ana@Example.COM` afuera de su propia
  cuenta, con un mensaje que además le dice que su contraseña está mal.
- La contraseña en claro va marcada con `#[\SensitiveParameter]` en el DTO y en la
  Action, igual que hace Laravel en `EloquentUserProvider::validateCredentials()`: sin
  eso queda como argumento en el stack trace de cualquier excepción lanzada más abajo.

**Riesgo asumido / fuera de alcance:** no hay bloqueo de cuenta tras N intentos
fallidos. La contención hoy es el limitador por IP, que un atacante distribuido puede
diluir. El bloqueo por cuenta tiene su propio costo —permite que un tercero deje sin
servicio a un usuario conocido solo con fallar sus intentos— y es una decisión de
producto que merece su propia historia. También quedan fuera (declarados en el issue)
recuperación de contraseña y login con proveedores externos, más el rehash de la
contraseña al iniciar sesión.

## Cómo se probó

Flujo SDD → TDD del proyecto: primero el contrato en `openapi.yaml`, después los tests
(que fallaron los 23 antes de existir la implementación), después el código.

- **23 tests nuevos** (16 Feature + 7 Unit), uno por criterio de aceptación y por cada
  decisión de arriba. Los que más importan: que los dos fallos devuelvan
  `assertSame` del cuerpo completo y del status; que una contraseña que no cumple la
  política dé 401 y no 422; que el email en otra capitalización entre; que el token
  devuelto autentique de verdad contra una ruta protegida.
- Suite completa en verde: **195 tests, 601 assertions**.
- `./vendor/bin/pint --test`, `composer stan` (PHPStan nivel 5, 0 errores) y
  `composer audit` limpios.
- Conformidad OpenAPI **estática** (5 rutas, 0 avisos) y **dinámica** (5 operaciones
  probadas contra un servidor real, 0 omitidas, sin fallos).
- `laravel-api-review` (complejidad + arquitectura) y `laravel-security-review` sin
  hallazgos; los 8 avisos de env vars que reporta el security check son preexistentes y
  ajenos a este cambio.
- Smoke test manual contra `php artisan serve`: registro → login con el email en
  mayúsculas (200) → contraseña incorrecta (401) → email inexistente (401), verificando
  que los dos 401 son byte a byte iguales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)