### PR TITLE
feat(#9): cerrar sesión

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -236,7 +236,8 @@ solo con fallar sus intentos) y merece su propia historia.
 
 ### Cierre de sesión (decidido en #9)
 
-`POST /api/v1/auth/logout` invalida el access token que viaja en la cabecera. Responde
+`POST /api/v1/auth/logout` invalida el access token con el que se autenticó la request.
+Responde
 **204 sin cuerpo**: no hay ningún recurso que devolver y lo único que el cliente hace
 con la respuesta es descartar el token que ya tenía, así que envolver un mensaje en
 `data` sería inventar un recurso que no existe. Es la excepción declarada al envelope
@@ -256,6 +257,28 @@ de la sección "Envelope de las respuestas", no una omisión.
   token deja de ser renovable (14 días) y el cache la reclama sola; `addForever()` la
   escribiría de forma permanente y la blacklist crecería sin techo, un cierre de sesión
   a la vez.
+- **Con `JWT_BLACKLIST_ENABLED=false` el logout falla con 500, no responde 204.**
+  Escribir en el `Blacklist` directo se salta la única comprobación que jwt-auth hace
+  de esa opción (`Manager::invalidate()`), así que `LogoutAction` la repite a mano y
+  corta antes de tocar el token. Sin ella la entrada se escribe pero nadie la consulta
+  al validar: el token sigue vivo hasta vencer solo mientras el endpoint responde 204,
+  y el usuario cree que cerró una sesión que sigue abierta. Es un error de
+  configuración del servidor, no del token del cliente, y por eso escala a 500 como el
+  resto de ellos (ver "Autenticación" más arriba) en vez de disfrazarse de éxito.
+- **Se cierra el token que el guard aceptó, no el que traiga la cabecera.** El
+  controller lo lee de la instancia `tymon.jwt` —la misma que recibe el `JWTGuard`— y
+  no con `Request::bearerToken()`. jwt-auth no busca el token solo en `Authorization`:
+  su cadena de parsers es `AuthHeaders`, `QueryString`, `InputSource`, `RouteParams` y
+  `Cookies`, y este repo no la restringe, así que un `POST /auth/logout?token=<jwt>`
+  autentica igual. Con `bearerToken()` esos casos respondían 401 **con la sesión sin
+  cerrar**, que es el peor fallo posible acá: desde el cliente es indistinguible del
+  401 de "ya estaba cerrada", así que quien perdió el teléfono se queda con el token
+  vivo creyendo lo contrario. La convención `(string) $request->bearerToken()` del
+  refresh no sirve de precedente porque ese endpoint va **sin** `auth:api` y la
+  cabecera es su única fuente por definición; el logout es el primero que invalida un
+  token después de que el guard ya lo parseó. El contrato publicado en `openapi.yaml`
+  sigue siendo `bearerAuth`: esto es consistencia con el guard, no una nueva forma de
+  autenticarse.
 - **El token cerrado tampoco se puede renovar.** Sale gratis —el refresh valida contra
   la blacklist— pero es el requisito de fondo: si se pudiera canjear por uno nuevo,
   cerrar sesión no serviría de nada frente al caso que la historia describe.

--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -84,7 +84,8 @@ routes/
   atender. La validación (firma + ventana) la hace jwt-auth dentro de la Action.
 - La gracia de blacklist de 30 s existe porque las apps móviles disparan requests en
   paralelo: sin ella, la primera que refresca invalidaría el token que las otras ya
-  tenían en vuelo.
+  tenían en vuelo. **Aplica solo a la renovación**: el cierre de sesión la ignora a
+  propósito (ver "Cierre de sesión").
 - Los fallos del token que manda el cliente (`TokenExpiredException`,
   `TokenInvalidException` —de la que hereda `TokenBlacklistedException`— y
   `UserNotDefinedException`) se traducen a un 401 con el formato de error estándar en
@@ -233,6 +234,47 @@ al iniciar sesión. El bloqueo por cuenta, en particular, es una decisión de pr
 con su propio costo (permite que un tercero deje sin servicio a un usuario conocido
 solo con fallar sus intentos) y merece su propia historia.
 
+### Cierre de sesión (decidido en #9)
+
+`POST /api/v1/auth/logout` invalida el access token que viaja en la cabecera. Responde
+**204 sin cuerpo**: no hay ningún recurso que devolver y lo único que el cliente hace
+con la respuesta es descartar el token que ya tenía, así que envolver un mensaje en
+`data` sería inventar un recurso que no existe. Es la excepción declarada al envelope
+de la sección "Envelope de las respuestas", no una omisión.
+
+- **Sí lleva `auth:api`**, al revés que el refresh. Un token vencido ya no sirve para
+  consumir la API, que es exactamente el estado al que el logout quiere llevarlo: no
+  queda nada que cerrar y el 401 del guard es la respuesta correcta.
+- **No hay periodo de gracia, y es la decisión central de la historia.** Los 30 s de
+  `JWT_BLACKLIST_GRACE_PERIOD` existen para que las requests en vuelo sobrevivan a una
+  *renovación*; aplicarlos acá dejaría vivo medio minuto más justo el token que el
+  usuario pide matar porque perdió el dispositivo. `LogoutAction` baja la gracia a 0
+  solo para esa escritura y la restaura en un `finally`: el `Blacklist` es un singleton
+  compartido con el refresh y dejarlo en 0 le quitaría el margen que sí necesita.
+- **Se invalida con `Blacklist::add()`, no con `invalidate(forceForever: true)`**,
+  aunque las dos formas son inmediatas. `add()` guarda la entrada solo hasta que el
+  token deja de ser renovable (14 días) y el cache la reclama sola; `addForever()` la
+  escribiría de forma permanente y la blacklist crecería sin techo, un cierre de sesión
+  a la vez.
+- **El token cerrado tampoco se puede renovar.** Sale gratis —el refresh valida contra
+  la blacklist— pero es el requisito de fondo: si se pudiera canjear por uno nuevo,
+  cerrar sesión no serviría de nada frente al caso que la historia describe.
+- **Se invalida el token enviado, no la cuenta**: cerrar sesión en el teléfono no echa
+  a la tableta. El cierre remoto en todos los dispositivos queda fuera de #9 y necesita
+  llevar registro de los tokens activos por usuario.
+- **La Action recibe `Tymon\JWTAuth\JWT`, no su subclase `JWTAuth`.** Son dos singletons
+  distintos (`tymon.jwt` y `tymon.jwt.auth`) y el guard `api` se construye con el
+  primero. Como `JWT::getToken()` devuelve lo que tenga cacheado antes de leer la
+  cabecera, la Action suelta el token con `unsetToken()` al terminar —igual que
+  `JWTGuard::logout()`—: si no, un contenedor que sobrevive a la request (worker de
+  colas, suite de tests, Octane) reusaría el token ya invalidado en la siguiente
+  autenticación y rechazaría credenciales válidas.
+- **Queda bajo el limitador general `api`, no bajo `throttle:auth`.** Exige token
+  vigente, así que no es un endpoint anónimo; bajo `throttle:auth` compartiría la cuota
+  por IP con el login y una IP con muchos usuarios detrás —el NAT de una oficina, una
+  red móvil— se quedaría sin poder cerrar sesión porque otros estuvieron intentando
+  entrar.
+
 ### Política de contraseñas (decidida en #6)
 
 Mínimo **8 caracteres, con al menos una letra y al menos un número**, declarada una
@@ -256,6 +298,10 @@ Los API Resources de Laravel envuelven la respuesta en `data` y ese es el format
 sigue la API (`{"data": {...}}` en éxito). Los errores no se envuelven: van como
 `{"message": ...}` (+ `errors` en validación). Ambas formas están documentadas en
 [`openapi.yaml`](../openapi.yaml).
+
+Una operación que no devuelve ningún recurso responde **204 sin cuerpo** en vez de
+envolver un mensaje en `data` (hoy: el cierre de sesión). El envelope es para
+recursos; inventar uno para decir "listo" no le da nada al cliente.
 
 ## Tiempo real: Laravel Reverb
 

--- a/app/Actions/Auth/LogoutAction.php
+++ b/app/Actions/Auth/LogoutAction.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use Tymon\JWTAuth\JWT;
+
+/**
+ * Cierra la sesión invalidando el access token que la sostiene.
+ *
+ * Invalida **solo el token recibido**, no la cuenta: cerrar sesión en el
+ * teléfono no puede echar a la tableta. El cierre remoto en todos los
+ * dispositivos es otra historia y necesita llevar registro de los tokens
+ * activos por usuario.
+ */
+final class LogoutAction
+{
+    /**
+     * Se inyecta `JWT` y no su subclase `JWTAuth` a propósito: son dos
+     * singletons distintos (`tymon.jwt` y `tymon.jwt.auth`), y el guard `api`
+     * se construye con el primero. El `unsetToken()` del final tiene que caer
+     * sobre esa instancia y no sobre la otra para que sirva de algo.
+     */
+    public function __construct(
+        private readonly JWT $jwt,
+        private readonly Blacklist $blacklist,
+    ) {}
+
+    /**
+     * @throws TokenExpiredException si el token ya venció.
+     * @throws TokenInvalidException si es ilegible, si la firma no cierra, o si
+     *                               la sesión ya se había cerrado con él.
+     */
+    public function handle(string $token): void
+    {
+        // `getPayload()` es lo que valida el token —firma, vencimiento y
+        // blacklist— antes de tocar nada. El endpoint va detrás de `auth:api`,
+        // que ya lo rechazaría, pero la Action tiene que sostener sus `@throws`
+        // por su cuenta para quien la invoque desde un comando o un job.
+        $payload = $this->jwt->setToken($token)->getPayload();
+
+        // El cierre de sesión ignora la gracia de blacklist a propósito. Esos
+        // 30 s existen para que las requests que ya iban en vuelo sobrevivan a
+        // una *renovación* (ver .claude/STANDARDS.md); acá dejarían vivo medio
+        // minuto más justo el token que el usuario está pidiendo matar porque
+        // perdió el dispositivo.
+        //
+        // Se hace bajando la gracia a 0 en vez de con `invalidate(forever)`
+        // —que también sería inmediato— porque `add()` guarda la entrada solo
+        // hasta que el token deje de ser renovable (14 días), y el cache la
+        // reclama sola; `addForever()` la escribiría de forma permanente y la
+        // blacklist crecería sin techo, un cierre de sesión a la vez.
+        //
+        // El Blacklist es el singleton que comparte todo jwt-auth, así que la
+        // gracia se restaura pase lo que pase: dejarla en 0 le quitaría al
+        // refresh el margen que sí necesita.
+        $graciaConfigurada = $this->blacklist->getGracePeriod();
+
+        try {
+            $this->blacklist->setGracePeriod(0)->add($payload);
+        } finally {
+            $this->blacklist->setGracePeriod($graciaConfigurada);
+        }
+
+        // `JWT` es un singleton y su `getToken()` devuelve el token que tenga
+        // cacheado *antes* de intentar leerlo de la cabecera, así que dejarlo
+        // puesto es dejar uno ya invalidado como el token "actual" de la
+        // aplicación. Con una request por proceso da igual —el contenedor
+        // nace limpio—, pero no cuando sobrevive a la request: en un worker de
+        // colas, en la suite de tests o con Octane, la siguiente autenticación
+        // reusaría este token muerto en vez del que venga en la cabecera, y
+        // rechazaría a un usuario que mandó credenciales perfectamente
+        // válidas. Es lo mismo que hace `JWTGuard::logout()` tras invalidar.
+        $this->jwt->unsetToken();
+    }
+}

--- a/app/Actions/Auth/LogoutAction.php
+++ b/app/Actions/Auth/LogoutAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Auth;
 
 use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
 use Tymon\JWTAuth\JWT;
@@ -31,12 +32,32 @@ final class LogoutAction
     ) {}
 
     /**
+     * @throws JWTException si la blacklist está deshabilitada: sin ella no
+     *                      hay forma de cerrar la sesión. Escala a 500 a
+     *                      propósito (ver más abajo).
      * @throws TokenExpiredException si el token ya venció.
      * @throws TokenInvalidException si es ilegible, si la firma no cierra, o si
      *                               la sesión ya se había cerrado con él.
      */
     public function handle(string $token): void
     {
+        // Sin blacklist no hay cierre de sesión posible: la entrada se
+        // escribiría igual, pero nadie la consultaría al validar, así que el
+        // token seguiría sirviendo hasta vencer solo mientras el endpoint
+        // responde 204. Es la peor respuesta posible — el usuario cree que
+        // cerró la sesión y no la cerró.
+        //
+        // Esta es la verificación que trae de regalo `Manager::invalidate()`
+        // (el único punto donde jwt-auth la hace) y que se pierde al escribir
+        // en el `Blacklist` directo, como hace la línea de más abajo. Se
+        // comprueba antes que el token porque es un error de configuración del
+        // servidor, no del cliente: se lanza `JWTException`, que a propósito
+        // **no** está mapeada a 401 en bootstrap/app.php y escala a 500 para
+        // que el monitoreo la vea (ver .claude/STANDARDS.md).
+        if (! config('jwt.blacklist_enabled')) {
+            throw new JWTException('You must have the blacklist enabled to invalidate a token.');
+        }
+
         // `getPayload()` es lo que valida el token —firma, vencimiento y
         // blacklist— antes de tocar nada. El endpoint va detrás de `auth:api`,
         // que ya lo rechazaría, pero la Action tiene que sostener sus `@throws`

--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\LogoutAction;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * POST /api/v1/auth/logout
+ *
+ * Sí lleva `auth:api`, al revés que el refresh: un token vencido ya no sirve
+ * para consumir la API, así que no queda nada que cerrar con él y el 401 del
+ * guard es la respuesta correcta.
+ *
+ * Responde 204 y no un API Resource porque no hay ningún recurso que devolver:
+ * lo único que el cliente hace con la respuesta es descartar el token que ya
+ * tenía (ver .claude/STANDARDS.md, "Envelope de las respuestas").
+ */
+class LogoutController extends Controller
+{
+    public function __invoke(Request $request, LogoutAction $logout): Response
+    {
+        $logout->handle((string) $request->bearerToken());
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -6,8 +6,8 @@ namespace App\Http\Controllers\Api\V1\Auth;
 
 use App\Actions\Auth\LogoutAction;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Tymon\JWTAuth\JWT;
 
 /**
  * POST /api/v1/auth/logout
@@ -22,9 +22,28 @@ use Illuminate\Http\Response;
  */
 class LogoutController extends Controller
 {
-    public function __invoke(Request $request, LogoutAction $logout): Response
+    /**
+     * Se cierra **el token que el guard aceptó**, y por eso se lee de la misma
+     * instancia con la que lo resolvió (`tymon.jwt`, la que recibe el
+     * `JWTGuard`) en vez de volver a leer la cabecera con `bearerToken()`.
+     *
+     * jwt-auth no busca el token solo en `Authorization`: su cadena de parsers
+     * es `AuthHeaders`, `QueryString`, `InputSource`, `RouteParams` y `Cookies`
+     * (LaravelServiceProvider), y este repo no la restringe. Con
+     * `bearerToken()`, un `POST /api/v1/auth/logout?token=<jwt>` autenticaba
+     * bien y aun así respondía 401 con la sesión **sin cerrar** — el peor fallo
+     * posible en este endpoint, porque quien perdió el teléfono no puede
+     * distinguir ese 401 del de "ya estaba cerrada" y se queda con el token
+     * vivo creyendo lo contrario.
+     *
+     * La convención `(string) $request->bearerToken()` del refresh no aplica
+     * acá: ese endpoint va **sin** `auth:api`, así que la cabecera es su única
+     * fuente por definición. El logout es el primero que invalida un token
+     * *después* de que el guard ya lo parseó.
+     */
+    public function __invoke(JWT $jwt, LogoutAction $logout): Response
     {
-        $logout->handle((string) $request->bearerToken());
+        $logout->handle((string) $jwt->getToken());
 
         return response()->noContent();
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -105,6 +105,58 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /auth/logout:
+    post:
+      tags:
+        - Auth
+      operationId: logout
+      summary: Cerrar sesión invalidando el access token
+      description: >-
+        Invalida el access token que viaja en `Authorization: Bearer`, sin
+        esperar a que venza por su cuenta. El caso que justifica el endpoint es
+        perder el dispositivo o cambiar de teléfono.
+
+        A diferencia del refresh, **no hay periodo de gracia**: el token queda
+        inservible en el mismo instante, tanto para consumir la API como para
+        renovarse en `/auth/refresh`. La gracia de 30 s existe para que las
+        requests en vuelo sobrevivan a una renovación; aplicarla acá dejaría el
+        token robado vivo medio minuto más, que es justo lo que quien cierra
+        sesión está pidiendo evitar (ver .claude/STANDARDS.md).
+
+        Invalida **solo el token enviado**, no las demás sesiones de la misma
+        cuenta: cerrar sesión en el teléfono no debe echar a la tableta. El
+        cierre remoto en todos los dispositivos queda fuera de esta historia.
+
+        Lleva `auth:api`, así que un token ausente, ilegible, ya expirado o ya
+        cerrado responde 401 — no hay nada que invalidar en ninguno de esos
+        casos.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: >-
+            Sesión cerrada; el token quedó invalidado. Sin cuerpo: no hay
+            ningún recurso que devolver, y el cliente lo único que hace con la
+            respuesta es descartar el token que ya tenía.
+        "401":
+          description: >-
+            Falta el access token, es ilegible, ya venció, o ya se había
+            cerrado la sesión con él.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "429":
+          description: >-
+            Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /auth/refresh:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Auth\LoginController;
+use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
@@ -22,18 +23,27 @@ Route::prefix('v1')->group(function () {
         ->post('broadcasting/auth', [BroadcastController::class, 'authenticate'])
         ->name('broadcasting.auth');
 
-    // Endpoints de autenticación: van sin `auth:api` a propósito, así que
-    // cualquiera puede golpearlos sin credenciales. Por eso el grupo lleva un
-    // límite de tasa más estricto que el general de la API (ver
-    // AppServiceProvider); para el login es, además, la contención principal
-    // contra la fuerza bruta sobre contraseñas.
-    Route::middleware('throttle:auth')
-        ->prefix('auth')
-        ->name('auth.')
-        ->group(function () {
+    Route::prefix('auth')->name('auth.')->group(function () {
+        // Estos van sin `auth:api` a propósito, así que cualquiera puede
+        // golpearlos sin credenciales. Por eso llevan un límite de tasa más
+        // estricto que el general de la API (ver AppServiceProvider); para el
+        // login es, además, la contención principal contra la fuerza bruta
+        // sobre contraseñas.
+        Route::middleware('throttle:auth')->group(function () {
             Route::post('login', LoginController::class)->name('login');
             Route::post('refresh', RefreshTokenController::class)->name('refresh');
             Route::post('register/driver', RegisterDriverController::class)->name('register.driver');
             Route::post('register/passenger', RegisterPassengerController::class)->name('register.passenger');
         });
+
+        // El cierre de sesión, en cambio, exige un token vigente, así que se
+        // queda con el limitador general de la API (60/min por usuario). Bajo
+        // `throttle:auth` compartiría la cuota por IP con los endpoints
+        // anónimos, y una IP con muchos usuarios detrás —el NAT de una oficina,
+        // una red móvil— se quedaría sin poder cerrar sesión porque otros
+        // estuvieron intentando entrar.
+        Route::middleware('auth:api')
+            ->post('logout', LogoutController::class)
+            ->name('logout');
+    });
 });

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/auth/logout — ver openapi.yaml.
+ *
+ * La regla que justifica el endpoint: quien pierde el dispositivo necesita que
+ * su token deje de servir *ahora*, no cuando venza. De ahí las dos diferencias
+ * con el refresh que estos tests fijan: el token cerrado tampoco puede
+ * renovarse, y no hay periodo de gracia.
+ */
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const LOGOUT_URI = '/api/v1/auth/logout';
+
+    private const REFRESH_URI = '/api/v1/auth/refresh';
+
+    private const PROBE_URI = '/api/v1/_probe-protegida';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('auth:api')->get(self::PROBE_URI, function () {
+            return response()->json(['user_id' => auth('api')->id()]);
+        });
+    }
+
+    public function test_cierra_la_sesion_y_responde_sin_cuerpo(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)
+            ->postJson(self::LOGOUT_URI)
+            ->assertNoContent();
+    }
+
+    public function test_el_token_cerrado_deja_de_servir_para_la_api(): void
+    {
+        // El criterio de aceptación de la historia #9, y la razón por la que el
+        // cierre de sesión no puede usar la gracia de blacklist del refresh:
+        // no se viaja en el tiempo entre las dos requests, así que si el token
+        // siguiera aceptándose durante los 30 s de gracia, esto fallaría.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)->postJson(self::LOGOUT_URI)->assertNoContent();
+
+        $this->olvidarGuards();
+
+        $this->withToken($token)
+            ->getJson(self::PROBE_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_el_token_cerrado_tampoco_sirve_para_renovarse(): void
+    {
+        // Si se pudiera canjear por uno nuevo, cerrar sesión no serviría de
+        // nada frente al caso que la historia describe —un teléfono perdido—:
+        // quien tuviera el token robado recuperaría el acceso con un refresh.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)->postJson(self::LOGOUT_URI)->assertNoContent();
+
+        $this->olvidarGuards();
+
+        $this->withToken($token)
+            ->postJson(self::REFRESH_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_cerrar_la_sesion_no_toca_la_gracia_configurada_para_el_refresh(): void
+    {
+        // El cierre de sesión ignora la gracia, pero no puede *cambiarla*: el
+        // Blacklist es un singleton compartido con el refresh, así que si el
+        // logout lo dejara en 0, la primera renovación posterior tumbaría las
+        // requests que el cliente ya tenía en vuelo.
+        $graciaConfigurada = $this->app->make(Blacklist::class)->getGracePeriod();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::LOGOUT_URI)
+            ->assertNoContent();
+
+        $this->assertSame(
+            $graciaConfigurada,
+            $this->app->make(Blacklist::class)->getGracePeriod(),
+        );
+
+        // Y se comprueba sobre el comportamiento, no solo sobre el getter: el
+        // token renovado sigue sirviendo durante la gracia de 30 s.
+        $otroToken = JWTAuth::fromUser(User::factory()->create());
+
+        $this->olvidarGuards();
+        $this->withToken($otroToken)->postJson(self::REFRESH_URI)->assertOk();
+
+        $this->travel(20)->seconds();
+
+        $this->olvidarGuards();
+        $this->withToken($otroToken)->postJson(self::REFRESH_URI)->assertOk();
+    }
+
+    public function test_no_cierra_las_demas_sesiones_de_la_misma_cuenta(): void
+    {
+        // Cerrar sesión en el teléfono no puede echar a la tableta: se invalida
+        // el token enviado, no la cuenta. El cierre remoto en todos los
+        // dispositivos queda fuera de la historia #9 y necesita llevar registro
+        // de los tokens activos por usuario.
+        $usuario = User::factory()->create();
+
+        $telefono = JWTAuth::fromUser($usuario);
+        $tableta = JWTAuth::fromUser($usuario);
+
+        $this->withToken($telefono)->postJson(self::LOGOUT_URI)->assertNoContent();
+
+        $this->olvidarGuards();
+
+        $this->withToken($tableta)
+            ->getJson(self::PROBE_URI)
+            ->assertOk()
+            ->assertJson(['user_id' => $usuario->id]);
+    }
+
+    public function test_rechaza_el_cierre_de_sesion_sin_token(): void
+    {
+        $this->postJson(self::LOGOUT_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_el_cierre_de_sesion_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->postJson(self::LOGOUT_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_el_cierre_de_sesion_con_un_token_expirado(): void
+    {
+        // El segundo criterio de aceptación: un token vencido responde 401, no
+        // un error sin controlar. A diferencia del refresh, acá el token
+        // expirado no tiene nada que hacer — ya no sirve para consumir la API,
+        // que es exactamente el estado al que el logout quiere llevarlo.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->postJson(self::LOGOUT_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_cerrar_la_sesion_dos_veces_responde_401(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)->postJson(self::LOGOUT_URI)->assertNoContent();
+
+        $this->olvidarGuards();
+
+        $this->withToken($token)
+            ->postJson(self::LOGOUT_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * En producción cada request estrena aplicación; acá los requests comparten
+     * instancia, así que el guard `api` conserva cacheado el usuario que
+     * resolvió en la request anterior. Sin esto, la siguiente pasaría sin
+     * volver a validar el token contra la blacklist.
+     */
+    private function olvidarGuards(): void
+    {
+        $this->app['auth']->forgetGuards();
+    }
+}

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -65,6 +65,41 @@ class LogoutTest extends TestCase
             ->assertJsonStructure(['message']);
     }
 
+    public function test_cierra_la_sesion_del_token_que_el_guard_acepto_aunque_no_venga_en_la_cabecera(): void
+    {
+        // jwt-auth no busca el token solo en `Authorization`: su cadena de
+        // parsers incluye `QueryString`, `InputSource`, `RouteParams` y
+        // `Cookies`, y este repo no la restringe. Todo token que el guard acepte
+        // tiene que poder cerrarse, porque el 401 alternativo es indistinguible
+        // —desde el cliente— del de una sesión ya cerrada, y dejaría vivo el
+        // token que el usuario pidió matar.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->postJson(self::LOGOUT_URI.'?token='.$token)->assertNoContent();
+
+        $this->olvidarGuards();
+
+        $this->withToken($token)
+            ->getJson(self::PROBE_URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_la_blacklist_deshabilitada_no_se_disfraza_de_sesion_cerrada(): void
+    {
+        // Sin blacklist el token sigue sirviendo hasta vencer solo, así que
+        // responder 204 sería mentir sobre lo único que el endpoint promete.
+        // Es un error de configuración del servidor y escala a 500 para que el
+        // monitoreo lo vea (ver .claude/STANDARDS.md y JwtExceptionRenderingTest).
+        config(['jwt.blacklist_enabled' => false]);
+
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)
+            ->postJson(self::LOGOUT_URI)
+            ->assertStatus(500);
+    }
+
     public function test_el_token_cerrado_tampoco_sirve_para_renovarse(): void
     {
         // Si se pudiera canjear por uno nuevo, cerrar sesión no serviría de

--- a/tests/Unit/Actions/Auth/LogoutActionTest.php
+++ b/tests/Unit/Actions/Auth/LogoutActionTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
 use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Exceptions\TokenInvalidException;
@@ -114,6 +115,33 @@ class LogoutActionTest extends TestCase
             $usuario->id,
             JWTAuth::setToken($tableta)->authenticate()?->id,
         );
+    }
+
+    public function test_no_cierra_nada_si_la_blacklist_esta_deshabilitada(): void
+    {
+        // Escribir en el `Blacklist` directo —en vez de pasar por
+        // `Manager::invalidate()`— se salta el único punto donde jwt-auth
+        // comprueba que la blacklist esté habilitada. Sin esta verificación, la
+        // Action escribía una entrada que después nadie consulta al validar y
+        // terminaba sin excepción: el token seguía sirviendo hasta vencer solo
+        // mientras el endpoint respondía 204.
+        config(['jwt.blacklist_enabled' => false]);
+
+        $token = JWTAuth::fromUser(User::factory()->create());
+        $payload = JWTAuth::setToken($token)->getPayload();
+
+        try {
+            $this->action()->handle($token);
+            $this->fail('Se esperaba una JWTException por la blacklist deshabilitada.');
+        } catch (JWTException $e) {
+            // Tiene que ser la clase base y no una de sus hijas: las hijas
+            // (TokenInvalid/TokenExpired) están mapeadas a 401 en
+            // bootstrap/app.php, y esto no es culpa del token del cliente sino
+            // del despliegue. Solo la clase base escala a 500.
+            $this->assertSame(JWTException::class, $e::class);
+        }
+
+        $this->assertFalse($this->app->make(Blacklist::class)->has($payload));
     }
 
     public function test_no_deja_el_token_muerto_cacheado_en_la_instancia_del_guard(): void

--- a/tests/Unit/Actions/Auth/LogoutActionTest.php
+++ b/tests/Unit/Actions/Auth/LogoutActionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\LogoutAction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Blacklist;
+use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use Tymon\JWTAuth\Facades\JWTAuth;
+use Tymon\JWTAuth\JWT;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ *
+ * Lo que se fija acá es que la invalidación sea inmediata y que el efecto sobre
+ * el Blacklist compartido termine donde termina la Action.
+ */
+class LogoutActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invalida_el_token_de_inmediato(): void
+    {
+        // Sin avanzar el reloj: con la gracia configurada (30 s) el token
+        // seguiría considerándose válido, que es justo lo que el cierre de
+        // sesión no puede permitir.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        // Se lee antes de cerrar la sesión: después, `getPayload()` valida
+        // contra la blacklist y saldría por excepción en vez de devolverlo.
+        $payload = JWTAuth::setToken($token)->getPayload();
+
+        $this->action()->handle($token);
+
+        $this->assertTrue($this->app->make(Blacklist::class)->has($payload));
+    }
+
+    public function test_el_token_invalidado_ya_no_autentica(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->action()->handle($token);
+
+        $this->expectException(TokenBlacklistedException::class);
+
+        JWTAuth::setToken($token)->authenticate();
+    }
+
+    public function test_deja_la_gracia_configurada_como_estaba(): void
+    {
+        // El Blacklist es un singleton compartido con el refresh: bajarle la
+        // gracia a 0 y no devolverla dejaría a las renovaciones sin el margen
+        // que las requests en vuelo necesitan.
+        $blacklist = $this->app->make(Blacklist::class);
+        $graciaConfigurada = $blacklist->getGracePeriod();
+
+        $this->action()->handle(JWTAuth::fromUser(User::factory()->create()));
+
+        $this->assertSame($graciaConfigurada, $blacklist->getGracePeriod());
+    }
+
+    public function test_devuelve_la_gracia_aunque_la_invalidacion_falle(): void
+    {
+        $blacklist = $this->app->make(Blacklist::class);
+        $graciaConfigurada = $blacklist->getGracePeriod();
+
+        try {
+            $this->action()->handle('no-es-un-jwt');
+        } catch (TokenInvalidException) {
+            // El fallo es el esperado; lo que se comprueba es lo de abajo.
+        }
+
+        $this->assertSame($graciaConfigurada, $blacklist->getGracePeriod());
+    }
+
+    public function test_rechaza_un_token_ilegible(): void
+    {
+        $this->expectException(TokenInvalidException::class);
+
+        $this->action()->handle('no-es-un-jwt');
+    }
+
+    public function test_rechaza_un_token_expirado(): void
+    {
+        // Que el motivo sea una excepción de jwt-auth —y no un `void`
+        // silencioso— es lo que sostiene el 401 del endpoint: la traducción a
+        // HTTP vive en bootstrap/app.php, no en el controller.
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->travel(30)->minutes();
+
+        $this->expectException(TokenExpiredException::class);
+
+        $this->action()->handle($token);
+    }
+
+    public function test_no_invalida_los_demas_tokens_de_la_misma_cuenta(): void
+    {
+        $usuario = User::factory()->create();
+
+        $telefono = JWTAuth::fromUser($usuario);
+        $tableta = JWTAuth::fromUser($usuario);
+
+        $this->action()->handle($telefono);
+
+        $this->assertSame(
+            $usuario->id,
+            JWTAuth::setToken($tableta)->authenticate()?->id,
+        );
+    }
+
+    public function test_no_deja_el_token_muerto_cacheado_en_la_instancia_del_guard(): void
+    {
+        // `JWT::getToken()` devuelve lo que tenga cacheado antes de leer la
+        // cabecera, y el guard `api` se construye con el singleton `tymon.jwt`
+        // —no con `tymon.jwt.auth`, que es otro—. Si la Action invalidara el
+        // token sobre la instancia equivocada, o no lo soltara, la siguiente
+        // autenticación en un contenedor que sobrevive a la request reusaría
+        // este token ya invalidado y rechazaría credenciales válidas.
+        $this->action()->handle(JWTAuth::fromUser(User::factory()->create()));
+
+        $this->assertNull($this->app->make(JWT::class)->getToken());
+    }
+
+    private function action(): LogoutAction
+    {
+        return $this->app->make(LogoutAction::class);
+    }
+}


### PR DESCRIPTION
Closes #9

## Qué hace

`POST /api/v1/auth/logout` invalida el access token que viaja en `Authorization: Bearer` y responde **204 sin cuerpo**.

- **Lleva `auth:api`**, al revés que el refresh: un token vencido ya no sirve para consumir la API, que es justo el estado al que el logout quiere llevarlo, así que no queda nada que cerrar y el 401 del guard es la respuesta correcta.
- **Sin periodo de gracia.** Los 30 s de `JWT_BLACKLIST_GRACE_PERIOD` existen para que las requests en vuelo sobrevivan a una *renovación*; aplicarlos acá dejaría vivo medio minuto más justo el token que el usuario pide matar porque perdió el dispositivo. `LogoutAction` baja la gracia a 0 solo para esa escritura y la restaura en un `finally`, porque el `Blacklist` es un singleton compartido con el refresh.
- **El token cerrado tampoco se puede renovar** — sale de que el refresh valida contra la blacklist, pero es el requisito de fondo: si se pudiera canjear por uno nuevo, cerrar sesión no serviría de nada.
- **Se invalida el token enviado, no la cuenta**: cerrar sesión en el teléfono no echa a la tableta. El cierre remoto en todos los dispositivos queda fuera de la historia.

Archivos: `LogoutAction`, `LogoutController`, ruta, `openapi.yaml` y la sección "Cierre de sesión (decidido en #9)" de `.claude/STANDARDS.md`.

## Cómo se probó

- `php artisan test` — **217 tests / 647 assertions en verde**, 17 de ellos nuevos para esta historia (`tests/Feature/Auth/LogoutTest.php`, `tests/Unit/Actions/Auth/LogoutActionTest.php`), uno por criterio de aceptación más los bordes: token ausente / ilegible / expirado, doble cierre, y que no se toquen las demás sesiones de la cuenta.
- `vendor/bin/pint --test` y PHPStan/Larastan nivel 5 — sin hallazgos.
- `complexity_check.py`, `architecture_check.py`, `security_check.py` — sin violaciones (los 8 AVISOS de `env()` del check de seguridad son preexistentes y ajenos a este cambio).
- Conformidad **estática**: 6 rutas revisadas, 0 avisos. Conformidad **dinámica**: 6 operaciones probadas contra el spec, sin fallos.
- **Verificación end-to-end contra un servidor real** (`php artisan serve`), que es lo que la suite no cubre: los tests usan cache `array` y en desarrollo la blacklist vive en el cache `database`. Registro → 201, ruta protegida antes del logout → 200, `logout` → **204 con 0 bytes**, y después: ruta protegida **401**, refresh **401**, segundo logout **401**.

## Decisiones y riesgos

- **`Blacklist::add()` con gracia 0, no `invalidate(forceForever: true)`.** Las dos son inmediatas, pero `add()` guarda la entrada solo hasta que el token deja de ser renovable (14 días) y el cache la reclama sola; `addForever()` la escribiría de forma permanente y la blacklist crecería sin techo, un cierre de sesión a la vez.
- **La Action recibe `Tymon\JWTAuth\JWT`, no su subclase `JWTAuth`.** Son dos singletons distintos (`tymon.jwt` y `tymon.jwt.auth`) y el guard `api` se construye con el primero. Lo detectó un test que fallaba: como `JWT::getToken()` devuelve el token cacheado antes de leer la cabecera, dejarlo puesto hacía que la siguiente autenticación reusara el token ya invalidado y rechazara credenciales válidas. La Action lo suelta con `unsetToken()` al terminar, igual que `JWTGuard::logout()`. Solo se nota cuando el contenedor sobrevive a la request (worker de colas, tests, Octane); hay un test que fija ese comportamiento para que no se revierta sin querer.
- **204 en vez del envelope `data`.** No hay recurso que devolver y lo único que el cliente hace con la respuesta es descartar el token. Queda documentado como la excepción explícita al envelope en `STANDARDS.md`.
- **Fuera de `throttle:auth`.** El endpoint exige token vigente, así que no es anónimo; bajo ese limitador compartiría la cuota por IP con el login, y una IP con muchos usuarios detrás (el NAT de una oficina, una red móvil) se quedaría sin poder cerrar sesión porque otros estuvieron intentando entrar. Para que conviviera con el resto se reordenó el grupo de rutas de `auth` en `routes/api.php`: los cuatro endpoints anónimos conservan `throttle:auth` exactamente como estaban.
- Fuera de alcance, según el propio issue: cierre remoto en todos los dispositivos, que necesita llevar registro de los tokens activos por usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)