### PR TITLE
feat(#10): ver mi perfil

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -298,6 +298,43 @@ de la sección "Envelope de las respuestas", no una omisión.
   red móvil— se quedaría sin poder cerrar sesión porque otros estuvieron intentando
   entrar.
 
+### Perfil propio (decidido en #10)
+
+`GET /api/v1/me` devuelve la cuenta que envió el token. Responde **200** con el schema
+`Profile`, que es `User` más lo que depende del rol.
+
+- **Los datos salen de la base, no de los claims del token.** El `role` del JWT quedó
+  congelado al emitirse y viaja solo para que el cliente elija qué UI mostrar (ver
+  "Autenticación"); este endpoint existe justo para responder el estado *actual* de la
+  cuenta, así que leerlo del token respondería el del pasado. Un test lo fija:
+  cambiando el rol en la base, la respuesta refleja el nuevo y no el del token.
+- **Es el único endpoint que devuelve el `license_number`**, dentro de un objeto
+  `driver_profile`. Lo prometió la #7 al dejarlo fuera de `AuthenticatedUser`, y sin
+  esto el dato no volvería al cliente desde ningún lado. Por eso `Profile` es un schema
+  aparte y no un campo nuevo en `User`: `User` es lo que responden el login y los dos
+  registros, donde un `driver_profile` no aplica.
+- **La clave se omite entera cuando no aplica, en vez de viajar en `null`.** En una
+  cuenta de pasajero no es un dato que falte; un `null` no dejaría distinguirla de un
+  conductor que todavía no tiene perfil creado.
+- **No hay Action detrás, y es deliberado.** Leer la cuenta que el guard ya resolvió no
+  decide ni cambia nada: una Action acá sería un pasamanos. La regla de este documento
+  existe para que la lógica no se esconda en los controllers, no para envolver lo que no
+  la tiene — la #11 (actualizar el perfil) sí la va a necesitar, porque ahí sí se escribe.
+- **Tampoco hay Policy**: el recurso *es* el usuario autenticado, así que no existe la
+  pregunta "¿puede este usuario ver este perfil?". Ver el perfil ajeno (el del conductor
+  asignado a un viaje) es otro endpoint y ahí la autorización sí tendrá qué decidir.
+- **La ruta es `/me`, no `/auth/me`.** Bajo `auth/` viven las operaciones sobre la sesión
+  (entrar, salir, renovar); esto es el recurso de la cuenta, y de él cuelgan sus
+  sub-recursos — el vehículo del conductor es `POST /me/vehicle` (#12). Queda con el
+  limitador general `api`, no con `throttle:auth`, por lo mismo que el logout: exige token
+  vigente, así que no es un endpoint anónimo.
+- **`DriverProfileResource` no publica el `id` de la fila ni el `user_id`**: son claves
+  internas de una relación 1:1 a la que se llega por la cuenta, nunca por su id.
+
+Queda **fuera** de #10: consultar el perfil de otra persona (se resuelve dentro de la
+historia del viaje correspondiente, con lo que ahí corresponda mostrar) y actualizar el
+propio (#11).
+
 ### Política de contraseñas (decidida en #6)
 
 Mínimo **8 caracteres, con al menos una letra y al menos un número**, declarada una

--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -58,3 +58,29 @@ warning para mantener el script más simple en esta v1.
 avisar), migrar `dynamic_conformance.py` a `referencing.Registry` +
 `jsonschema.validators.validator_for(schema)(schema, registry=registry)` en vez de
 `RefResolver.from_schema`.
+
+### 2026-07-31 — `dynamic_conformance.py` da OK sin haber probado ningún 200 autenticado
+
+**Qué pasó:** implementando `GET /me` (#10), correr
+`dynamic_conformance.py --start-server --auth-token <jwt>` reportó
+`7 operación(es) probadas, sin fallos`, pero el 200 de `/me` **nunca se ejecutó**: el
+script recorre las operaciones en el orden del spec, `POST /auth/logout` va antes que
+`/me` y usa el mismo token, así que lo deja en la blacklist. `/me` recibió 401, que
+también está documentado y valida contra el schema `Error` — y el resultado global fue
+verde igual.
+
+**Por qué pasó:** el script comparte un único token entre todas las operaciones y no
+sabe que una de ellas lo invalida. El OK es real (la respuesta cumplió *un* schema
+documentado), pero no dice nada del camino de éxito, que es justo lo que la feature
+necesitaba verificar. Es un falso "verde por omisión", no un falso positivo.
+
+**Cómo evitarlo:** el `OK: N operación(es)` no alcanza para dar por validada una
+feature autenticada — hay que confirmar **qué código de estado** respondió cada
+operación propia, no solo que no hubo fallos. Mientras el script no lo reporte por
+operación, validar el cuerpo de éxito aparte: cargar `openapi.yaml`, sacar el schema de
+la respuesta 200 y correr `jsonschema.validate` sobre la forma real (una por rama del
+contrato: conductor con perfil y pasajero sin él), incluyendo una contra-prueba que el
+schema **rechace** un cuerpo inválido — sin ella no se distingue un schema correcto de
+uno vacuamente permisivo. Alternativa de fondo, si el patrón se repite: que
+`dynamic_conformance.py` pida un token nuevo por operación, o que deje `/auth/logout`
+para el final.

--- a/app/Http/Controllers/Api/V1/Profile/ShowProfileController.php
+++ b/app/Http/Controllers/Api/V1/Profile/ShowProfileController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Profile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ProfileResource;
+use Illuminate\Http\Request;
+
+/**
+ * GET /api/v1/me
+ *
+ * Devuelve el perfil de la cuenta que envió el token. Es la primera request de
+ * las apps móviles al arrancar: con ella saben quién es el usuario y con qué rol
+ * está operando.
+ *
+ * No hay Action detrás y es a propósito: leer la cuenta que el guard ya resolvió
+ * no es un caso de uso de negocio, no decide nada y no cambia nada. Una Action
+ * acá sería un pasamanos, y la regla de .claude/STANDARDS.md existe para que la
+ * lógica no se esconda en los controllers, no para envolver lo que no la tiene.
+ * La #11 (actualizar el perfil) sí la va a necesitar, porque ahí sí se escribe.
+ *
+ * Tampoco hay Policy: el recurso *es* el usuario autenticado, así que no existe
+ * la pregunta "¿puede este usuario ver este perfil?" — no hay forma de pedir el
+ * de otra persona. Ver el perfil ajeno (el del conductor asignado a un viaje) es
+ * otro endpoint, y ahí la autorización sí tendrá algo que decidir.
+ */
+class ShowProfileController extends Controller
+{
+    /**
+     * El usuario sale del guard, **no de los claims del token**: el `role` del
+     * JWT quedó congelado cuando se emitió y viaja solo para que el cliente
+     * elija qué UI mostrar (ver .claude/STANDARDS.md). Este endpoint existe para
+     * responder el estado actual de la cuenta, así que leerlo del token
+     * respondería el del pasado.
+     */
+    public function __invoke(Request $request): ProfileResource
+    {
+        return new ProfileResource($request->user());
+    }
+}

--- a/app/Http/Resources/DriverProfileResource.php
+++ b/app/Http/Resources/DriverProfileResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DriverProfile;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el perfil de conductor según el schema `DriverProfile` de
+ * openapi.yaml.
+ *
+ * No lleva el `id` de la fila ni el `user_id`: son claves internas de una
+ * relación 1:1 que el cliente nunca necesita nombrar —al perfil se llega por la
+ * cuenta, no por su id— y publicarlas invitaría a que alguien intentara
+ * direccionarlo por ahí.
+ *
+ * @property-read DriverProfile $resource
+ */
+class DriverProfileResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'license_number' => $this->resource->license_number,
+        ];
+    }
+}

--- a/app/Http/Resources/ProfileResource.php
+++ b/app/Http/Resources/ProfileResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa la cuenta autenticada vista por su dueño, según el schema `Profile`
+ * de openapi.yaml.
+ *
+ * Es `UserResource` más lo que depende del rol, y por eso se compone sobre él
+ * en vez de repetir sus campos: `User` es el schema que devuelven el login y los
+ * registros, y si las dos listas divergieran, la app móvil recibiría una cuenta
+ * distinta según por dónde entró.
+ *
+ * @property-read User $resource
+ */
+class ProfileResource extends JsonResource
+{
+    /**
+     * La clave `driver_profile` **se omite entera** cuando no aplica, en vez de
+     * viajar en `null`: en una cuenta de pasajero no es un dato que falte, y un
+     * `null` dejaría al cliente sin poder distinguirla de un conductor que
+     * todavía no cargó su licencia.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $datos = (new UserResource($this->resource))->toArray($request);
+
+        $perfilDeConductor = $this->resource->isDriver()
+            ? $this->resource->driverProfile
+            : null;
+
+        if ($perfilDeConductor !== null) {
+            $datos['driver_profile'] = new DriverProfileResource($perfilDeConductor);
+        }
+
+        return $datos;
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -445,6 +445,69 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me:
+    get:
+      tags:
+        - Profile
+      operationId: showProfile
+      summary: Consultar el perfil de la cuenta autenticada
+      description: >-
+        Devuelve los datos de la cuenta que envió el token. Es lo primero que
+        consultan las apps móviles al arrancar, para saber quién es el usuario
+        y con qué rol está operando.
+
+        Los datos salen de la base, **no de los claims del token**: el `role`
+        del JWT existe solo para que el cliente decida qué UI mostrar sin una
+        request extra, y quedó fijado al emitirse. Este endpoint es el que
+        responde con el estado actual de la cuenta.
+
+        Para las cuentas de conductor incluye además `driver_profile` con el
+        número de licencia. Es el único endpoint que lo devuelve: los registros
+        y el login responden el schema `User`, que a propósito no lo tiene
+        porque en las cuentas de pasajero estaría siempre vacío (ver la
+        decisión de la historia #7 en .claude/STANDARDS.md). En una cuenta de
+        pasajero la clave no viene vacía: **no viene**.
+
+        Devuelve siempre el perfil propio. Consultar el de otra persona (los
+        datos del conductor asignado, por ejemplo) se resuelve dentro de la
+        historia del viaje correspondiente, con lo que ahí corresponda mostrar.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Perfil de la cuenta autenticada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Profile"
+              example:
+                data:
+                  id: 1
+                  name: Ana García
+                  email: ana@example.com
+                  phone: "+573001234567"
+                  role: passenger
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -526,6 +589,41 @@ components:
           $ref: "#/components/schemas/User"
         token:
           $ref: "#/components/schemas/AuthToken"
+    DriverProfile:
+      type: object
+      description: >-
+        Datos que solo existen para una cuenta de conductor. Hoy es únicamente
+        la licencia; los documentos del vehículo son otra entidad y se registran
+        aparte (historia #12).
+      required:
+        - license_number
+      properties:
+        license_number:
+          type: string
+          description: >-
+            Número de la licencia tal como quedó guardado en el registro, en su
+            forma canónica (mayúsculas, sin espacios al borde). La API no
+            verifica contra ninguna entidad externa que exista ni que esté
+            vigente: devuelve lo que el conductor declaró.
+          example: LIC-445566
+    Profile:
+      description: >-
+        Cuenta autenticada vista por su dueño. Es el schema `User` más lo que
+        depende del rol, y por eso está separado de él: `User` es lo que
+        devuelven el login y los registros, donde un `driver_profile` no tendría
+        sentido.
+      allOf:
+        - $ref: "#/components/schemas/User"
+        - type: object
+          properties:
+            driver_profile:
+              allOf:
+                - $ref: "#/components/schemas/DriverProfile"
+              description: >-
+                Presente solo en cuentas con rol `driver` que ya tienen su
+                perfil creado. En una cuenta de pasajero la clave se omite
+                entera, en vez de venir como `null`: no es un dato que falte,
+                es un dato que no aplica.
     LoginRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
 
@@ -46,4 +47,16 @@ Route::prefix('v1')->group(function () {
             ->post('logout', LogoutController::class)
             ->name('logout');
     });
+
+    // El perfil propio no cuelga de `auth/`: ahí viven las operaciones sobre la
+    // sesión (entrar, salir, renovar), y esto es el recurso de la cuenta. De
+    // `me` cuelgan además sus sub-recursos, como el vehículo del conductor
+    // (historia #12, `POST /me/vehicle`).
+    //
+    // Se queda con el limitador general de la API (60/min por usuario) y no con
+    // `throttle:auth`: exige token vigente, así que no es un endpoint anónimo, y
+    // es la primera request que hace la app móvil al arrancar.
+    Route::middleware('auth:api')
+        ->get('me', ShowProfileController::class)
+        ->name('profile.show');
 });

--- a/tests/Feature/Profile/ShowProfileTest.php
+++ b/tests/Feature/Profile/ShowProfileTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Profile;
+
+use App\Enums\UserRole;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/me — ver openapi.yaml.
+ *
+ * Es la primera request que hacen las apps móviles al arrancar, así que lo que
+ * fija esta suite es de quién son los datos que devuelve (los del token, y no
+ * los de otra cuenta ni los que el token traía cacheados en sus claims) y qué
+ * datos nunca salen (la contraseña).
+ */
+class ShowProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me';
+
+    public function test_devuelve_los_datos_de_la_cuenta_autenticada(): void
+    {
+        $pasajera = User::factory()->create([
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajera))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'id' => $pasajera->id,
+                    'name' => 'Ana García',
+                    'email' => 'ana@example.com',
+                    'phone' => '+573001234567',
+                    'role' => 'passenger',
+                ],
+            ]);
+    }
+
+    public function test_no_expone_la_contrasena_ni_su_hash(): void
+    {
+        // `assertExactJson` de arriba ya lo cubre para el pasajero, pero esto es
+        // el criterio de aceptación explícito de la historia y no depende de que
+        // nadie afloje esa aserción: se comprueba contra el cuerpo crudo, así
+        // que también atrapa un hash escondido dentro de `driver_profile`.
+        $conductor = User::factory()->driver()->create(['password' => 'motoya2026']);
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk();
+
+        $respuesta->assertJsonMissingPath('data.password');
+        $this->assertStringNotContainsString('motoya2026', $respuesta->getContent());
+        $this->assertStringNotContainsString($conductor->getAuthPassword(), $respuesta->getContent());
+    }
+
+    public function test_el_perfil_del_conductor_incluye_su_licencia(): void
+    {
+        // El registro de conductor (#7) responde el schema `User`, que no lleva
+        // la licencia a propósito; este endpoint es el único lugar donde el dato
+        // vuelve al cliente (ver .claude/STANDARDS.md).
+        $conductor = User::factory()->driver()->create([
+            'name' => 'Carlos Ramírez',
+            'email' => 'carlos@example.com',
+            'phone' => '+573009876543',
+        ]);
+        DriverProfile::factory()->create([
+            'user_id' => $conductor->id,
+            'license_number' => 'LIC-445566',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'id' => $conductor->id,
+                    'name' => 'Carlos Ramírez',
+                    'email' => 'carlos@example.com',
+                    'phone' => '+573009876543',
+                    'role' => 'driver',
+                    'driver_profile' => [
+                        'license_number' => 'LIC-445566',
+                    ],
+                ],
+            ]);
+    }
+
+    public function test_la_cuenta_de_pasajero_omite_la_clave_del_perfil_de_conductor(): void
+    {
+        // Omitida entera, no en `null`: no es un dato que falte, es un dato que
+        // no aplica, y un `null` empujaría al cliente a preguntarse si el
+        // conductor todavía no cargó su licencia.
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonMissingPath('data.driver_profile');
+    }
+
+    public function test_el_conductor_sin_perfil_creado_tambien_omite_la_clave(): void
+    {
+        // El registro crea cuenta y perfil en una transacción, así que este
+        // estado no debería existir; si aparece igual (una carga de datos, un
+        // rol cambiado a mano) el endpoint tiene que responder el perfil que sí
+        // hay, no reventar buscando el que falta.
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonPath('data.role', 'driver')
+            ->assertJsonMissingPath('data.driver_profile');
+    }
+
+    public function test_devuelve_el_perfil_de_quien_manda_el_token_y_no_el_de_otra_cuenta(): void
+    {
+        User::factory()->create(['name' => 'Otra Persona']);
+        $propia = User::factory()->create(['name' => 'Ana García']);
+
+        $this->withToken(JWTAuth::fromUser($propia))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonPath('data.id', $propia->id)
+            ->assertJsonPath('data.name', 'Ana García');
+    }
+
+    public function test_los_datos_salen_de_la_base_y_no_de_los_claims_del_token(): void
+    {
+        // El `role` viaja en el JWT solo para que el cliente sepa qué UI
+        // mostrar, y quedó congelado al emitirse. Si este endpoint lo leyera de
+        // ahí, respondería el estado de la cuenta en el pasado — que es justo lo
+        // contrario de para lo que la app móvil lo consulta al arrancar.
+        $usuario = User::factory()->create(['name' => 'Ana García']);
+
+        $token = JWTAuth::fromUser($usuario);
+
+        $usuario->forceFill([
+            'name' => 'Ana García Ruiz',
+            'role' => UserRole::Driver,
+        ])->save();
+
+        $this->withToken($token)
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Ana García Ruiz')
+            ->assertJsonPath('data.role', 'driver');
+    }
+
+    public function test_rechaza_la_consulta_sin_token(): void
+    {
+        $this->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_con_un_token_expirado(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_con_un_token_ya_cerrado(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->withToken($token)->postJson('/api/v1/auth/logout')->assertNoContent();
+
+        // En producción cada request estrena aplicación; acá el guard `api`
+        // conserva cacheado el usuario de la request anterior y pasaría sin
+        // volver a validar el token contra la blacklist.
+        $this->app['auth']->forgetGuards();
+
+        $this->withToken($token)
+            ->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+}


### PR DESCRIPTION
Closes #10

## Qué hace

`GET /api/v1/me` devuelve el perfil de la cuenta que envió el token. Es la primera request que hacen las apps móviles al arrancar: con ella saben quién es el usuario y con qué rol está operando.

- **Los datos salen de la base, no de los claims del token.** El `role` del JWT quedó congelado cuando se emitió y viaja solo para que el cliente elija qué UI mostrar; leerlo de ahí haría que este endpoint respondiera el estado de la cuenta *en el pasado*, que es lo contrario de para lo que se consulta al arrancar. Hay un test que lo fija: cambiando el rol en la base, la respuesta refleja el nuevo y no el del token.
- **Es el único endpoint que devuelve el `license_number`**, dentro de un objeto `driver_profile`. Lo prometió la #7 al dejarlo fuera de `AuthenticatedUser` ("el dato del perfil se consulta por el endpoint de perfil (#10)"), y sin esto no volvía al cliente desde ningún lado — ninguna otra historia abierta lo cubre (#11 son datos de contacto, #12 es el vehículo). Por eso el schema nuevo se llama `Profile` y **no** se le agregó un campo a `User`: `User` es lo que responden el login y los dos registros, donde `driver_profile` no aplica.
- **La clave se omite entera cuando no aplica**, en vez de viajar en `null`. En una cuenta de pasajero no es un dato que falte; un `null` no dejaría distinguirla de un conductor que todavía no tiene perfil creado.
- **La ruta es `/me`, no `/auth/me`**: bajo `auth/` viven las operaciones sobre la sesión (entrar, salir, renovar), y esto es el recurso de la cuenta — de él cuelgan sus sub-recursos, como `POST /me/vehicle` de la #12. Queda con el limitador general `api` y no con `throttle:auth`, por lo mismo que el logout: exige token vigente, así que no es un endpoint anónimo.

## Cómo se probó

Flujo completo de la skill `laravel-feature-workflow` (spec → tests en rojo → implementación → conformidad):

- **11 tests Feature nuevos** (`tests/Feature/Profile/ShowProfileTest.php`), escritos antes del código y confirmados en rojo (404) antes de implementar. Cubren los dos criterios de aceptación y sus bordes: el perfil propio y no el de otra cuenta, la licencia del conductor, el conductor *sin* perfil creado, el pasajero sin la clave, los datos leídos de la base y no del token, y 401 sin token / ilegible / expirado / ya cerrado. La contraseña se comprueba contra el cuerpo crudo, no solo con `assertExactJson`, para que también atrape un hash escondido dentro de `driver_profile`.
- Suite completa **231 tests en verde**, `pint --test` limpio, `composer stan` 0 errores, complejidad/arquitectura y `laravel-security-review` sin hallazgos nuevos (los 8 avisos de `env()` son preexistentes y ajenos a este cambio).
- Conformidad **estática**: 7 rutas, 0 avisos. **Dinámica**: 7 operaciones, sin fallos.
- Además, validación aparte del cuerpo de éxito contra el schema `Profile` en sus dos ramas (conductor con perfil, pasajero sin la clave), con una contra-prueba de que el schema rechaza un `driver_profile` sin `license_number`. El motivo está en el punto siguiente.

## Decisiones y riesgos

- **`dynamic_conformance.py` daba verde sin haber probado ningún 200 autenticado.** Recorre las operaciones en el orden del spec, `POST /auth/logout` va antes que `/me` y comparte el token, así que lo deja en la blacklist: `/me` recibía 401, que también está documentado, y el resultado global era OK igual. No es un falso positivo sino un verde por omisión, pero deja sin verificar justo el camino de éxito. Queda registrado en `KNOWN_ERRORS.md` con la forma de validarlo aparte mientras el script no reporte el código de estado por operación.
- **Sin Action y sin Policy, a propósito.** Leer la cuenta que el guard ya resolvió no decide ni cambia nada: una Action sería un pasamanos, y la regla de STANDARDS existe para que la lógica no se esconda en los controllers, no para envolver lo que no la tiene (la #11 sí la va a necesitar, porque ahí se escribe). La Policy tampoco tiene qué decidir: el recurso *es* el usuario autenticado y no hay forma de pedir el de otra persona.
- **`ProfileResource` se compone sobre `UserResource` en vez de repetir sus campos.** Si las dos listas divergieran, la app móvil recibiría una cuenta distinta según por dónde entró (login vs. perfil).
- `DriverProfileResource` no publica el `id` de la fila ni el `user_id`: son claves internas de una relación 1:1 a la que se llega por la cuenta, nunca por su id.
- **Riesgo asumido**: incluir `driver_profile` va un paso más allá de la letra del criterio de aceptación de la #10, que solo enumera nombre, email, teléfono y rol. Se incluyó porque la #7 declaró explícitamente a este endpoint como el lugar donde ese dato se consulta, y dejarlo afuera lo volvía inalcanzable. Si se prefiere acotar la historia, sacarlo es borrar un resource, una rama del schema y dos tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)