### PR TITLE
feat(#11): actualizar mi perfil

### DIFF
--- a/app/Actions/Auth/UpdateProfileAction.php
+++ b/app/Actions/Auth/UpdateProfileAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\DTOs\ProfileUpdate;
+use App\Models\User;
+
+/**
+ * Actualiza los datos de contacto de una cuenta ya autenticada.
+ *
+ * Solo escribe los campos que `ProfileUpdate` trae en `null` distinto —el DTO
+ * no tiene `role` ni acepta un `id` de destino, así que la única cuenta que
+ * esta Action puede tocar es la que el controller le pasa, y lo único que
+ * puede cambiar en ella es nombre, email o teléfono.
+ */
+final class UpdateProfileAction
+{
+    public function handle(User $user, ProfileUpdate $update): User
+    {
+        $datos = array_filter(
+            [
+                'name' => $update->name,
+                'email' => $update->email,
+                'phone' => $update->phone,
+            ],
+            static fn (?string $valor): bool => $valor !== null,
+        );
+
+        if ($datos !== []) {
+            $user->update($datos);
+        }
+
+        return $user;
+    }
+}

--- a/app/Actions/Auth/UpdateProfileAction.php
+++ b/app/Actions/Auth/UpdateProfileAction.php
@@ -19,13 +19,20 @@ final class UpdateProfileAction
 {
     public function handle(User $user, ProfileUpdate $update): User
     {
+        // Descarta también la cadena vacía, y no solo `null`: `email` y `phone`
+        // son NOT NULL UNIQUE y con el login por email, así que un `''` que
+        // llegue hasta acá deja la cuenta sin forma de entrar y la siguiente
+        // que repita el vaciado revienta el índice único. `UpdateProfileRequest`
+        // ya lo ataja con `sometimes|required`, pero esta Action es invocable
+        // desde un job o un comando que no pasa por el Form Request, y su
+        // invariante propia es "no escribo un contacto vacío".
         $datos = array_filter(
             [
                 'name' => $update->name,
                 'email' => $update->email,
                 'phone' => $update->phone,
             ],
-            static fn (?string $valor): bool => $valor !== null,
+            static fn (?string $valor): bool => $valor !== null && trim($valor) !== '',
         );
 
         if ($datos !== []) {

--- a/app/DTOs/ProfileUpdate.php
+++ b/app/DTOs/ProfileUpdate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Datos de contacto a cambiar en la cuenta autenticada, ya validados.
+ *
+ * Es un PATCH parcial: un campo en `null` significa "no vino en la request",
+ * no "bórralo" — ninguno de los tres es nullable en `users`. No lleva `role`
+ * ni `id` a propósito, igual que `PassengerRegistration`: el caso de uso es
+ * actualizar datos de contacto, así que no hay forma de que uno de los dos
+ * llegue hasta la fila por esta vía.
+ */
+final readonly class ProfileUpdate
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $email = null,
+        public ?string $phone = null,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Profile/UpdateProfileController.php
+++ b/app/Http/Controllers/Api/V1/Profile/UpdateProfileController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Profile;
+
+use App\Actions\Auth\UpdateProfileAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\UpdateProfileRequest;
+use App\Http\Resources\ProfileResource;
+
+/**
+ * PATCH /api/v1/me
+ *
+ * A diferencia de `ShowProfileController`, acá sí hay una Action detrás: este
+ * endpoint escribe, y `.claude/STANDARDS.md` pide que la escritura viva en una
+ * Action, no en el controller, para que sirva igual desde un job o un comando.
+ *
+ * Tampoco hay Policy: el recurso es la cuenta autenticada y no un id de la
+ * ruta, así que no existe la pregunta "¿puede este usuario editar este
+ * perfil?" — no hay forma de pedir el de otra persona.
+ */
+class UpdateProfileController extends Controller
+{
+    public function __invoke(UpdateProfileRequest $request, UpdateProfileAction $action): ProfileResource
+    {
+        $usuario = $action->handle($request->user(), $request->toUpdate());
+
+        return new ProfileResource($usuario);
+    }
+}

--- a/app/Http/Requests/Auth/UpdateProfileRequest.php
+++ b/app/Http/Requests/Auth/UpdateProfileRequest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\DTOs\ProfileUpdate;
+use App\Http\Requests\Concerns\NormalizesAccountInput;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Entrada de PATCH /api/v1/me — ver openapi.yaml.
+ *
+ * No define `authorize()`: el recurso *es* la cuenta autenticada (la resuelve
+ * el guard, no un id de la ruta), así que no hay una pregunta de autorización
+ * distinta de "¿tiene un token válido?", que ya resuelve el middleware
+ * `auth:api`.
+ */
+class UpdateProfileRequest extends FormRequest
+{
+    use NormalizesAccountInput;
+
+    /**
+     * Lleva `email` y `phone` a su forma canónica ANTES de validar, igual que
+     * el registro — el porqué está en `NormalizesAccountInput`. Solo toca los
+     * campos que de verdad vinieron: `canonicalAccountInput()` ya se salta los
+     * que faltan, que es justo lo que este PATCH parcial necesita.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge($this->canonicalAccountInput());
+    }
+
+    /**
+     * Todas las reglas van con `sometimes`: es un PATCH parcial, así que un
+     * campo ausente no es un error, es "no lo toques". La unicidad de email y
+     * phone se ignora contra la propia cuenta —si no, reenviar el mismo valor
+     * sin cambiarlo respondería 422 contra uno mismo.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        $usuario = $this->user();
+
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'email' => [
+                'sometimes', 'string', 'email', 'max:255',
+                Rule::unique('users', 'email')->ignore($usuario->getKey()),
+            ],
+            'phone' => [
+                'sometimes', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/',
+                Rule::unique('users', 'phone')->ignore($usuario->getKey()),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return $this->accountMessages();
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     *
+     * Los campos se leen uno por uno y no con `validated()`: es lo que
+     * garantiza que nada que no esté acá —un `role` o un `id` mandado por el
+     * cliente, por ejemplo— pueda colarse hasta la Action. Se lee con `has()`
+     * y no con `filled()` porque lo que importa es si el campo vino en la
+     * request, no si vino vacío: un `email` vacío ya murió en `rules()`.
+     */
+    public function toUpdate(): ProfileUpdate
+    {
+        return new ProfileUpdate(
+            name: $this->has('name') ? $this->string('name')->toString() : null,
+            email: $this->has('email') ? $this->string('email')->toString() : null,
+            phone: $this->has('phone') ? $this->string('phone')->toString() : null,
+        );
+    }
+}

--- a/app/Http/Requests/Auth/UpdateProfileRequest.php
+++ b/app/Http/Requests/Auth/UpdateProfileRequest.php
@@ -33,10 +33,19 @@ class UpdateProfileRequest extends FormRequest
     }
 
     /**
-     * Todas las reglas van con `sometimes`: es un PATCH parcial, así que un
-     * campo ausente no es un error, es "no lo toques". La unicidad de email y
-     * phone se ignora contra la propia cuenta —si no, reenviar el mismo valor
-     * sin cambiarlo respondería 422 contra uno mismo.
+     * Todas las reglas van con `sometimes|required`: es un PATCH parcial, así
+     * que un campo ausente no es un error, es "no lo toques"; pero uno presente
+     * no puede venir vacío. `sometimes` a secas no alcanza —al contrario, sería
+     * un agujero—: ante una cadena vacía Laravel se salta TODAS las reglas no
+     * implícitas (`Validator::presentOrRuleIsImplicit()`), incluidas `email`,
+     * `regex` y `unique`, así que `{"email": ""}` pasaría la validación y
+     * borraría el email de la cuenta. Y `users.email`/`users.phone` son NOT
+     * NULL UNIQUE, con lo que la segunda cuenta que lo hiciera reventaría el
+     * índice con un 500. `required` es implícita, corre igual sobre la cadena
+     * vacía y también cubre la que trae solo espacios.
+     *
+     * La unicidad de email y phone se ignora contra la propia cuenta —si no,
+     * reenviar el mismo valor sin cambiarlo respondería 422 contra uno mismo.
      *
      * @return array<string, array<int, mixed>>
      */
@@ -45,13 +54,13 @@ class UpdateProfileRequest extends FormRequest
         $usuario = $this->user();
 
         return [
-            'name' => ['sometimes', 'string', 'max:255'],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
             'email' => [
-                'sometimes', 'string', 'email', 'max:255',
+                'sometimes', 'required', 'string', 'email', 'max:255',
                 Rule::unique('users', 'email')->ignore($usuario->getKey()),
             ],
             'phone' => [
-                'sometimes', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/',
+                'sometimes', 'required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/',
                 Rule::unique('users', 'phone')->ignore($usuario->getKey()),
             ],
         ];
@@ -73,7 +82,8 @@ class UpdateProfileRequest extends FormRequest
      * garantiza que nada que no esté acá —un `role` o un `id` mandado por el
      * cliente, por ejemplo— pueda colarse hasta la Action. Se lee con `has()`
      * y no con `filled()` porque lo que importa es si el campo vino en la
-     * request, no si vino vacío: un `email` vacío ya murió en `rules()`.
+     * request: para cuando esto corre, un valor vacío ya murió en el
+     * `required` de `rules()`, así que lo que llega es un valor real.
      */
     public function toUpdate(): ProfileUpdate
     {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -508,6 +508,81 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+    patch:
+      tags:
+        - Profile
+      operationId: updateProfile
+      summary: Actualizar mis datos de contacto
+      description: >-
+        Actualiza nombre, email y/o teléfono de la cuenta autenticada. Es un
+        PATCH parcial: solo los campos presentes en el body se cambian, el
+        resto conserva su valor actual.
+
+        No acepta `role` ni ningún otro campo que no sea de contacto — si
+        viaja en el body, se ignora: la Action solo lee `name`, `email` y
+        `phone` del DTO de entrada, así que no hay ningún camino por el que un
+        `role` (o un `id`) mandado por el cliente llegue a aplicarse. Cambio
+        de contraseña y de email verificado son historias aparte (ver el
+        issue #11).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateProfileRequest"
+            example:
+              name: Ana García Pérez
+              phone: "+573007654321"
+      responses:
+        "200":
+          description: Perfil actualizado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Profile"
+              example:
+                data:
+                  id: 1
+                  name: Ana García Pérez
+                  email: ana@example.com
+                  phone: "+573007654321"
+                  role: passenger
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "422":
+          description: >-
+            La entrada no pasó la validación: un campo tiene un formato
+            inválido, o el email/teléfono ya están en uso por otra cuenta.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The email has already been taken.
+                errors:
+                  email:
+                    - The email has already been taken.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /me/vehicle:
     post:
       tags:
@@ -726,6 +801,35 @@ components:
                 perfil creado. En una cuenta de pasajero la clave se omite
                 entera, en vez de venir como `null`: no es un dato que falte,
                 es un dato que no aplica.
+    UpdateProfileRequest:
+      type: object
+      description: >-
+        Datos de contacto que el dueño de la cuenta puede actualizar. Todos
+        los campos son opcionales: solo los que vienen en la request se
+        cambian, el resto queda como estaba. No lleva `role` ni `id` a
+        propósito — el rol no se acepta como entrada acá tampoco, así que no
+        hay forma de escalar de pasajero a conductor (u otro usuario) por
+        esta vía.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          example: Ana García Pérez
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: >-
+            Se normaliza a minúsculas antes de validar, igual que en el
+            registro. Cambiarlo a uno ya usado por otra cuenta responde 422.
+          example: ana.garcia@example.com
+        phone:
+          type: string
+          description: >-
+            Mismo formato y normalización que en el registro (`+` opcional en
+            la entrada, se guarda siempre con él). Cambiarlo a uno ya usado
+            por otra cuenta responde 422.
+          example: "+573007654321"
     Vehicle:
       type: object
       description: >-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -524,6 +524,9 @@ paths:
         `role` (o un `id`) mandado por el cliente llegue a aplicarse. Cambio
         de contraseña y de email verificado son historias aparte (ver el
         issue #11).
+
+        Un campo presente no puede venir vacío: `{"email": ""}` responde 422,
+        no borra el email. Para dejar un dato como está, no se manda.
       security:
         - bearerAuth: []
       requestBody:
@@ -564,8 +567,9 @@ paths:
                 message: Unauthenticated.
         "422":
           description: >-
-            La entrada no pasó la validación: un campo tiene un formato
-            inválido, o el email/teléfono ya están en uso por otra cuenta.
+            La entrada no pasó la validación: un campo presente vino vacío,
+            tiene un formato inválido, o el email/teléfono ya están en uso por
+            otra cuenta.
           content:
             application/json:
               schema:
@@ -810,14 +814,22 @@ components:
         propósito — el rol no se acepta como entrada acá tampoco, así que no
         hay forma de escalar de pasajero a conductor (u otro usuario) por
         esta vía.
+
+        **Opcional no es vaciable.** Un campo que viene tiene que traer un
+        valor: `minLength: 1` en los tres. La forma de no cambiar un dato es
+        no mandarlo, no mandarlo vacío — la cuenta necesita email y teléfono
+        para iniciar sesión y para que la contacten, y ninguno de los dos
+        admite `null` en la base.
       properties:
         name:
           type: string
+          minLength: 1
           maxLength: 255
           example: Ana García Pérez
         email:
           type: string
           format: email
+          minLength: 1
           maxLength: 255
           description: >-
             Se normaliza a minúsculas antes de validar, igual que en el
@@ -825,6 +837,7 @@ components:
           example: ana.garcia@example.com
         phone:
           type: string
+          minLength: 1
           description: >-
             Mismo formato y normalización que en el registro (`+` opcional en
             la entrada, se guarda siempre con él). Cambiarlo a uno ya usado

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
+use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
@@ -60,6 +61,12 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->get('me', ShowProfileController::class)
         ->name('profile.show');
+
+    // PATCH y no PUT: solo se aceptan los campos de contacto presentes en el
+    // body, el resto de la cuenta no se toca (historia #11).
+    Route::middleware('auth:api')
+        ->patch('me', UpdateProfileController::class)
+        ->name('profile.update');
 
     // El vehículo del conductor cuelga de `me` porque es un sub-recurso de la
     // cuenta: se llega a él por el token, nunca por un id propio. Que solo los

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Profile;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de PATCH /api/v1/me — ver openapi.yaml.
+ *
+ * Es un PATCH parcial (historia #11): solo los campos de contacto presentes
+ * en el body cambian, el rol nunca se acepta como entrada, y no hay forma de
+ * tocar la cuenta de otra persona.
+ */
+class UpdateProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me';
+
+    public function test_actualiza_el_nombre(): void
+    {
+        $usuario = User::factory()->create(['name' => 'Ana García']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['name' => 'Ana García Pérez'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Ana García Pérez');
+
+        $this->assertSame('Ana García Pérez', $usuario->fresh()->name);
+    }
+
+    public function test_actualiza_el_email(): void
+    {
+        $usuario = User::factory()->create(['email' => 'ana@example.com']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['email' => 'ana.garcia@example.com'])
+            ->assertOk()
+            ->assertJsonPath('data.email', 'ana.garcia@example.com');
+
+        $this->assertSame('ana.garcia@example.com', $usuario->fresh()->email);
+    }
+
+    public function test_normaliza_el_email_a_minusculas(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['email' => 'Ana.Garcia@Example.com'])
+            ->assertOk()
+            ->assertJsonPath('data.email', 'ana.garcia@example.com');
+    }
+
+    public function test_actualiza_el_telefono_y_lo_normaliza_con_el_signo_mas(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['phone' => '573007654321'])
+            ->assertOk()
+            ->assertJsonPath('data.phone', '+573007654321');
+
+        $this->assertSame('+573007654321', $usuario->fresh()->phone);
+    }
+
+    public function test_actualiza_varios_campos_a_la_vez(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, [
+                'name' => 'Ana García Pérez',
+                'email' => 'ana.nueva@example.com',
+                'phone' => '+573007654321',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Ana García Pérez')
+            ->assertJsonPath('data.email', 'ana.nueva@example.com')
+            ->assertJsonPath('data.phone', '+573007654321');
+    }
+
+    public function test_los_campos_ausentes_del_body_no_cambian(): void
+    {
+        $usuario = User::factory()->create([
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['name' => 'Ana García Pérez'])
+            ->assertOk()
+            ->assertJsonPath('data.email', 'ana@example.com')
+            ->assertJsonPath('data.phone', '+573001234567');
+    }
+
+    public function test_reenviar_el_propio_email_sin_cambiarlo_no_es_un_conflicto(): void
+    {
+        $usuario = User::factory()->create(['email' => 'ana@example.com']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['email' => 'ana@example.com', 'name' => 'Ana García Pérez'])
+            ->assertOk();
+    }
+
+    public function test_rechaza_cambiar_el_email_a_uno_ya_usado_por_otra_cuenta(): void
+    {
+        User::factory()->create(['email' => 'otra@example.com']);
+        $usuario = User::factory()->create(['email' => 'ana@example.com']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['email' => 'otra@example.com'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+
+        $this->assertSame('ana@example.com', $usuario->fresh()->email);
+    }
+
+    public function test_rechaza_cambiar_el_telefono_a_uno_ya_usado_por_otra_cuenta(): void
+    {
+        User::factory()->create(['phone' => '+573009999999']);
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['phone' => '+573009999999'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
+
+        $this->assertSame('+573001234567', $usuario->fresh()->phone);
+    }
+
+    public function test_rechaza_un_email_con_formato_invalido(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['email' => 'no-es-un-email'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_rechaza_un_telefono_con_formato_invalido(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['phone' => 'no-es-un-telefono'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['phone']);
+    }
+
+    public function test_ignora_un_rol_enviado_en_el_body(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['role' => 'driver', 'name' => 'Ana García Pérez'])
+            ->assertOk()
+            ->assertJsonPath('data.role', 'passenger');
+
+        $this->assertTrue($usuario->fresh()->isPassenger());
+    }
+
+    public function test_ignora_un_id_enviado_en_el_body(): void
+    {
+        $otra = User::factory()->create();
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['id' => $otra->id, 'name' => 'Ana García Pérez'])
+            ->assertOk()
+            ->assertJsonPath('data.id', $usuario->id);
+
+        $this->assertSame('Ana García Pérez', $usuario->fresh()->name);
+        $this->assertNotSame('Ana García Pérez', $otra->fresh()->name);
+    }
+
+    public function test_no_permite_cambiar_la_contrasena_por_esta_via(): void
+    {
+        $usuario = User::factory()->create(['password' => 'motoya2026']);
+        $hashOriginal = $usuario->password;
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, ['password' => 'otra-contrasena-999'])
+            ->assertOk();
+
+        $this->assertSame($hashOriginal, $usuario->fresh()->password);
+        $this->assertTrue(Hash::check('motoya2026', $usuario->fresh()->password));
+    }
+
+    public function test_el_perfil_del_conductor_conserva_su_licencia_tras_actualizar_el_nombre(): void
+    {
+        $conductor = User::factory()->driver()->create(['name' => 'Carlos Ramírez']);
+        DriverProfile::factory()->create([
+            'user_id' => $conductor->id,
+            'license_number' => 'LIC-445566',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['name' => 'Carlos Ramírez Ruiz'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Carlos Ramírez Ruiz')
+            ->assertJsonPath('data.driver_profile.license_number', 'LIC-445566');
+    }
+
+    public function test_rechaza_la_actualizacion_sin_token(): void
+    {
+        $this->patchJson(self::URI, ['name' => 'Ana García Pérez'])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_no_afecta_a_otra_cuenta(): void
+    {
+        $otra = User::factory()->create(['name' => 'Otra Persona']);
+        $propia = User::factory()->create(['name' => 'Ana García']);
+
+        $this->withToken(JWTAuth::fromUser($propia))
+            ->patchJson(self::URI, ['name' => 'Ana García Pérez'])
+            ->assertOk();
+
+        $this->assertSame('Otra Persona', $otra->fresh()->name);
+    }
+}

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -8,6 +8,7 @@ use App\Models\DriverProfile;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -154,6 +155,51 @@ class UpdateProfileTest extends TestCase
             ->patchJson(self::URI, ['phone' => 'no-es-un-telefono'])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['phone']);
+    }
+
+    /**
+     * Un campo presente pero vacío es 422, no un borrado: `users.email` es NOT
+     * NULL UNIQUE y el login es por email, así que aceptarlo dejaría la cuenta
+     * sin forma de entrar —y a la segunda que lo hiciera, con un 500 por el
+     * índice único en vez del 422 que el resto del repo garantiza.
+     *
+     * @param  string  $campo  el que va vacío en el body
+     * @param  string  $vacio  la forma de "vacío" que se prueba
+     */
+    #[DataProvider('camposVacios')]
+    public function test_rechaza_un_campo_presente_pero_vacio(string $campo, string $vacio): void
+    {
+        $usuario = User::factory()->create([
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->patchJson(self::URI, [$campo => $vacio])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors([$campo]);
+
+        $recargado = $usuario->fresh();
+
+        $this->assertSame('Ana García', $recargado->name);
+        $this->assertSame('ana@example.com', $recargado->email);
+        $this->assertSame('+573001234567', $recargado->phone);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function camposVacios(): array
+    {
+        return [
+            'name vacío' => ['name', ''],
+            'name solo espacios' => ['name', '   '],
+            'email vacío' => ['email', ''],
+            'email solo espacios' => ['email', '   '],
+            'phone vacío' => ['phone', ''],
+            'phone solo espacios' => ['phone', '   '],
+        ];
     }
 
     public function test_ignora_un_rol_enviado_en_el_body(): void

--- a/tests/Unit/Actions/Auth/UpdateProfileActionTest.php
+++ b/tests/Unit/Actions/Auth/UpdateProfileActionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\UpdateProfileAction;
+use App\DTOs\ProfileUpdate;
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class UpdateProfileActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_actualiza_solo_los_campos_presentes_en_el_dto(): void
+    {
+        $usuario = User::factory()->create([
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+
+        $resultado = $this->action()->handle(
+            $usuario,
+            new ProfileUpdate(name: 'Ana García Pérez'),
+        );
+
+        $this->assertSame('Ana García Pérez', $resultado->name);
+        $this->assertSame('ana@example.com', $resultado->email);
+        $this->assertSame('+573001234567', $resultado->phone);
+    }
+
+    public function test_no_escribe_en_la_base_si_el_dto_no_trae_ningun_campo(): void
+    {
+        $usuario = User::factory()->create(['name' => 'Ana García']);
+        $actualizadoEn = $usuario->updated_at;
+
+        $this->travel(1)->minute();
+        $resultado = $this->action()->handle($usuario, new ProfileUpdate);
+
+        $this->assertSame('Ana García', $resultado->name);
+        $this->assertEquals($actualizadoEn, $usuario->fresh()->updated_at);
+    }
+
+    public function test_el_rol_no_cambia_porque_el_dto_no_lo_tiene(): void
+    {
+        $usuario = User::factory()->create();
+
+        $resultado = $this->action()->handle(
+            $usuario,
+            new ProfileUpdate(name: 'Ana García Pérez'),
+        );
+
+        $this->assertSame(UserRole::Passenger, $resultado->role);
+    }
+
+    public function test_devuelve_la_instancia_con_los_datos_ya_actualizados(): void
+    {
+        $usuario = User::factory()->create();
+
+        $resultado = $this->action()->handle(
+            $usuario,
+            new ProfileUpdate(email: 'nueva@example.com'),
+        );
+
+        $this->assertSame($usuario->id, $resultado->id);
+        $this->assertSame('nueva@example.com', $resultado->email);
+        $this->assertSame('nueva@example.com', $usuario->fresh()->email);
+    }
+
+    private function action(): UpdateProfileAction
+    {
+        return $this->app->make(UpdateProfileAction::class);
+    }
+}

--- a/tests/Unit/Actions/Auth/UpdateProfileActionTest.php
+++ b/tests/Unit/Actions/Auth/UpdateProfileActionTest.php
@@ -48,6 +48,34 @@ class UpdateProfileActionTest extends TestCase
         $this->assertEquals($actualizadoEn, $usuario->fresh()->updated_at);
     }
 
+    /**
+     * La Action no depende de que la haya llamado el Form Request: un job o un
+     * comando pueden armar el DTO a mano, y un contacto vacío dejaría la cuenta
+     * sin email de login o reventando el índice único de `users`.
+     */
+    public function test_ignora_los_campos_que_vienen_vacios_en_el_dto(): void
+    {
+        $usuario = User::factory()->create([
+            'name' => 'Ana García',
+            'email' => 'ana@example.com',
+            'phone' => '+573001234567',
+        ]);
+
+        $resultado = $this->action()->handle(
+            $usuario,
+            new ProfileUpdate(name: '   ', email: '', phone: ''),
+        );
+
+        $this->assertSame('Ana García', $resultado->name);
+        $this->assertSame('ana@example.com', $resultado->email);
+        $this->assertSame('+573001234567', $resultado->phone);
+
+        $recargado = $usuario->fresh();
+
+        $this->assertSame('ana@example.com', $recargado->email);
+        $this->assertSame('+573001234567', $recargado->phone);
+    }
+
     public function test_el_rol_no_cambia_porque_el_dto_no_lo_tiene(): void
     {
         $usuario = User::factory()->create();


### PR DESCRIPTION
Closes #11

## Qué hace

Agrega `PATCH /api/v1/me` para que la cuenta autenticada actualice sus
datos de contacto (`name`, `email`, `phone`) de forma parcial: solo los
campos presentes en el body se cambian, el resto conserva su valor.

- `App\DTOs\ProfileUpdate` — datos ya validados, sin `role` ni `id` (igual
  patrón que `PassengerRegistration`).
- `App\Http\Requests\Auth\UpdateProfileRequest` — reglas `sometimes` para
  cada campo, normalización de email/phone reusando
  `NormalizesAccountInput`, y unicidad de email/phone que se ignora contra
  la propia cuenta (`Rule::unique(...)->ignore($user->id)`).
- `App\Actions\Auth\UpdateProfileAction` — escribe solo los campos no nulos
  del DTO.
- `App\Http\Controllers\Api\V1\Profile\UpdateProfileController` — controller
  fino, delega en la Action.
- `routes/api.php` — `PATCH /me` bajo el mismo grupo `auth:api` que
  `GET /me`, con el limitador general (no `throttle:auth`: exige token).
- `openapi.yaml` — contrato del nuevo endpoint (`UpdateProfileRequest`,
  200/401/422/429) siguiendo el mismo shape que `GET /me`.

## Cómo se probó

- `tests/Feature/Profile/UpdateProfileTest.php` — un test por criterio de
  aceptación del issue: actualización parcial de cada campo y de varios a
  la vez, campos ausentes no cambian, conflicto de email/phone con otra
  cuenta (422), formato inválido (422), `role`/`id`/`password` enviados en
  el body se ignoran sin error, el `driver_profile` del conductor no se ve
  afectado, sin token (401), no se puede tocar la cuenta de otra persona.
- `tests/Unit/Actions/Auth/UpdateProfileActionTest.php` — la Action
  invocada directo: solo escribe los campos presentes en el DTO, no toca
  la base si el DTO viene vacío, el rol nunca cambia porque el DTO no lo
  tiene.
- Suite completa: `php artisan test` → 252/252 en verde.
- `./vendor/bin/pint --test` → sin errores.
- `composer stan` (PHPStan/Larastan) → 0 errores.
- Revisión manual de arquitectura y seguridad contra `.claude/STANDARDS.md`
  (Actions sin HTTP, Controller fino, sin mass assignment de `role`/`id`,
  sin SQL crudo, autorización implícita vía `$request->user()` sin
  parámetro de ruta que permita IDOR).

## Decisiones y riesgos

- **Campos ignorados vs. rechazados** (AC del issue: "esos campos son
  ignorados o rechazados, nunca aplicados"): se optó por **ignorar**
  `role`/`id`/cualquier campo no declarado, mismo criterio que ya usan los
  endpoints de registro con `role` — no se agregó una regla de rechazo
  explícito porque no aporta seguridad adicional (el DTO ya hace
  imposible que lleguen a aplicarse) y evita un 422 confuso si el cliente
  reenvía el propio `id` sin intención maliciosa.
- **Mensaje de conflicto de email/phone ya usado** revela que el valor
  existe en otra cuenta — es el mismo comportamiento que ya tienen
  `POST /auth/register/driver` y `POST /auth/register/passenger` en este
  repo, así que no es una vía de enumeración nueva.
- **Scripts de conformidad de la skill `laravel-feature-workflow`
  (`static_conformance.py`, `dynamic_conformance.py`) y los de
  `laravel-api-review`/`laravel-security-review` no pudieron correr**:
  este entorno no tiene Python instalado (solo el stub de Microsoft Store).
  Se compensó con:
  - Revisión manual de la indentación/estructura del YAML agregado a
    `openapi.yaml` contra el resto del archivo.
  - `composer stan` (PHPStan/Larastan, no depende de Python) en 0 errores.
  - Revisión manual de arquitectura y seguridad contra los mismos
    criterios que automatizan esas skills (detallado arriba).
  Si se instala Python en el runner de CI/agente, vale la pena correr esos
  scripts sobre esta rama para confirmar conformidad dinámica contra el
  spec.
- El working copy no tenía `vendor/tymon/jwt-auth` instalado al empezar
  (`composer install` fallaba por `ext-sodium` deshabilitada); se habilitó
  la extensión `sodium` (ya vinculada en el PHP local, solo comentada en
  `php.ini`) para poder correr `composer install`/tests localmente — no es
  un cambio de este repo.