### PR TITLE
feat(#12): registrar mi vehículo

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -602,6 +602,58 @@ tabla `driver_profiles` para datos específicos del conductor.
 es el id de `User`), y `driver_profiles` mantiene la extensibilidad sin pre-optimizar
 una estructura multi-rol que todavía no existe en el producto.
 
+## Vehículo del conductor (decidido en #12)
+
+`POST /api/v1/me/vehicle` da de alta la moto del conductor autenticado. Responde
+**201** con el schema `Vehicle` (`plate`, `model`, `year`).
+
+- **Cuelga de `/me` y no de `/vehicles`**, por lo mismo que el perfil: es un
+  sub-recurso de la cuenta y se llega a él por el token, nunca por un id propio. Por
+  eso `VehicleResource` tampoco publica el `id` de la fila ni el `user_id`, igual que
+  `DriverProfileResource`.
+- **La relación es 1:1 y la sostiene el índice único de `vehicles.user_id`**, no solo
+  la validación. Un segundo registro responde **422**, no reemplaza al vehículo
+  existente: el endpoint es de alta, y un cliente móvil que reintenta una request que
+  ya había llegado no debe pisar en silencio los datos de la moto con la que el
+  conductor está trabajando. Actualizarla es la #13.
+- **Ese 422 viaja bajo la clave `vehicle`, que no es un campo de la entrada**, porque
+  no lo decide nada de lo que el cliente manda sino el estado de la cuenta. Se agrega
+  desde `after()` en el Form Request, no como regla de un campo.
+- **El rol se autoriza con `VehiclePolicy`, y una cuenta de pasajero recibe 403, no
+  422**: no es una entrada que se pueda corregir mandando otros datos, es una operación
+  que su rol no tiene. La Policy se invoca desde `authorize()` del Form Request para
+  que el 403 se resuelva **antes** que la validación — al revés, el 422 le detallaría a
+  una cuenta sin permiso qué forma tiene que tener la entrada. El primer uso de
+  Policies del proyecto; se declara con `#[UsePolicy]` en el modelo en vez de dejarla a
+  la convención de nombres.
+- **Que la cuenta ya tenga vehículo no se decide en la Policy**, aunque podría: el
+  conductor sí tiene el permiso, lo que le falta es actualizar lo que ya registró. Un
+  403 ahí le diría que el problema es de permisos, que es otra cosa.
+- **La `plate` tiene forma canónica** (recorte y mayúsculas en `prepareForValidation()`),
+  por el mismo motivo que `license_number`: `unique` es un `where plate = ?` sobre una
+  columna con índice único, así que sin normalizar bastaría escribirla en minúsculas
+  para registrar dos veces la misma moto — y ahí la placa dejaría de identificar a un
+  vehículo, que es para lo único que sirve. Los espacios interiores no se limpian:
+  `ABC 12D` es una placa mal escrita y corresponde un 422 explicable.
+- **El `regex` de la placa no codifica el formato de ningún país** (`^[A-Z0-9-]{5,10}$`).
+  El supuesto de región de la #3 es Colombia, pero atarlo al formato `AAA00A` haría que
+  cambiar de país fuera un cambio de código; la API tampoco verifica contra ninguna
+  entidad externa que la placa exista o esté vigente, igual que con la licencia.
+- **Los límites de `year` (1970 … año en curso + 1) atajan el dedazo, no declaran una
+  antigüedad máxima de la flota.** El tope es el año siguiente porque los modelos se
+  venden adelantados al calendario. Si el negocio quiere una política de antigüedad, es
+  otra decisión y su lugar es la configuración, no una regla de validación.
+- **La Action no usa transacción**, a diferencia del alta de conductor: escribe una sola
+  fila, así que no existe el estado a medias que allá había que evitar. Dos altas
+  simultáneas que pasen la validación a la vez terminan con la última perdiendo contra
+  el índice único (500), que es el mismo trato que la #7 le da a una licencia duplicada.
+
+Queda **fuera** de #12: los documentos del vehículo (la historia los menciona, pero no
+tiene criterio de aceptación para ellos y almacenarlos exige decidir antes dónde viven
+los archivos y quién los verifica — la verificación administrativa está declarada fuera
+de alcance en el propio issue); actualizar el vehículo (#13); y que un conductor tenga
+más de una moto.
+
 ## Proveedor de mapas/geocoding (decidido en #3)
 
 **Decisión**: **Google Maps Platform** — Routes API v2 (`computeRoutes`) para

--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -84,3 +84,23 @@ schema **rechace** un cuerpo inválido — sin ella no se distingue un schema co
 uno vacuamente permisivo. Alternativa de fondo, si el patrón se repite: que
 `dynamic_conformance.py` pida un token nuevo por operación, o que deje `/auth/logout`
 para el final.
+
+### 2026-07-31 — El "verde por omisión" del token compartido se repitió en #12
+
+**Qué pasó:** el mismo caso de la entrada anterior, ahora con `POST /me/vehicle` (#12):
+`dynamic_conformance.py --start-server` con un token de conductor reportó
+`OK: 7 operación(es) probadas, sin fallos`, y el 201 del endpoint nuevo **no se
+ejecutó ni una vez** — `POST /auth/logout` va antes en el orden del spec y dejó el
+token en la blacklist, así que `/me/vehicle` respondió el 401 que también está
+documentado. Se detectó porque la tabla `vehicles` quedó vacía después de la corrida.
+
+**Por qué pasó:** misma causa que en #10 — un único token compartido entre operaciones,
+una de las cuales lo invalida. Con esto deja de ser un caso aislado: le pasa a **toda**
+feature autenticada cuyo path ordene después de `/auth/logout`, que son casi todas.
+
+**Cómo evitarlo:** hasta que el script se arregle, seguir validando el camino de éxito
+aparte (como en #10 y acá). La corrección de fondo ya no es opcional y es contenida:
+que `dynamic_conformance.py` ordene las operaciones dejando para el final las que
+invalidan el token (hoy `POST /auth/logout`), o que pida un token nuevo por operación.
+No se hizo dentro del PR de #12 para no mezclar un cambio de tooling que corre en CI
+con una feature — merece su propio issue.

--- a/app/Actions/Vehicles/RegisterVehicleAction.php
+++ b/app/Actions/Vehicles/RegisterVehicleAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Vehicles;
+
+use App\DTOs\VehicleRegistration;
+use App\Models\User;
+use App\Models\Vehicle;
+
+/**
+ * Registra la moto de un conductor y se la asocia.
+ *
+ * El conductor llega como parámetro y no dentro del DTO: es lo que garantiza
+ * que el dueño salga siempre de quien invoca el caso de uso (el usuario que
+ * resolvió el guard) y nunca de la entrada.
+ *
+ * No hay transacción, a diferencia del registro de conductor: acá se escribe una
+ * sola fila, así que no existe el estado a medias que allá había que evitar. Lo
+ * que sostiene la unicidad —la placa y el "un vehículo por conductor"— son los
+ * índices de la tabla; el Form Request los adelanta para poder responder 422 en
+ * vez de 500, pero entre su consulta y este INSERT caben dos altas simultáneas y
+ * ahí la última pierde con una violación de constraint. Es el mismo trato que le
+ * da el alta de conductor a una licencia duplicada.
+ */
+final class RegisterVehicleAction
+{
+    public function handle(User $driver, VehicleRegistration $registration): Vehicle
+    {
+        return $driver->vehicle()->create([
+            'plate' => $registration->plate,
+            'model' => $registration->model,
+            'year' => $registration->year,
+        ]);
+    }
+}

--- a/app/DTOs/VehicleRegistration.php
+++ b/app/DTOs/VehicleRegistration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Datos con los que un conductor da de alta su moto, ya validados.
+ *
+ * No lleva dueño, por la misma razón por la que los DTOs de registro no llevan
+ * rol: quién es el conductor lo decide quien invoca la Action —el guard, en el
+ * caso del endpoint— y no los datos que manda el cliente. `user_id` es fillable
+ * en el modelo, así que si el campo existiera acá habría un camino por el que un
+ * cliente le registraría una moto a otra persona.
+ */
+final readonly class VehicleRegistration
+{
+    public function __construct(
+        public string $plate,
+        public string $model,
+        public int $year,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Vehicles/RegisterVehicleController.php
+++ b/app/Http/Controllers/Api/V1/Vehicles/RegisterVehicleController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Vehicles;
+
+use App\Actions\Vehicles\RegisterVehicleAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Vehicles\RegisterVehicleRequest;
+use App\Http\Resources\VehicleResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/me/vehicle
+ *
+ * Da de alta la moto del conductor autenticado, que es lo último que le falta
+ * para poder recibir solicitudes de viaje.
+ *
+ * El dueño sale del guard y no de la entrada: es el mismo criterio que el rol en
+ * los endpoints de registro. La autorización (solo conductores) la resuelve
+ * `VehiclePolicy` desde el Form Request, así que acá no queda ninguna decisión.
+ */
+class RegisterVehicleController extends Controller
+{
+    public function __invoke(
+        RegisterVehicleRequest $request,
+        RegisterVehicleAction $registerVehicle,
+    ): JsonResponse {
+        $vehicle = $registerVehicle->handle($request->user(), $request->toRegistration());
+
+        return (new VehicleResource($vehicle))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Vehicles/RegisterVehicleRequest.php
+++ b/app/Http/Requests/Vehicles/RegisterVehicleRequest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Vehicles;
+
+use App\DTOs\VehicleRegistration;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+
+/**
+ * Entrada de POST /api/v1/me/vehicle — ver openapi.yaml.
+ */
+class RegisterVehicleRequest extends FormRequest
+{
+    /**
+     * Registrar una moto es una operación del rol conductor: lo decide
+     * `VehiclePolicy`, no un `isDriver()` suelto acá.
+     *
+     * Va en el Form Request y no en el controller para que el 403 se resuelva
+     * **antes** que la validación. Al revés, una cuenta de pasajero recibiría un
+     * 422 detallándole qué forma tiene que tener la entrada de un endpoint que
+     * de todos modos no puede usar.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create', Vehicle::class) ?? false;
+    }
+
+    /**
+     * Lleva la placa a su forma canónica ANTES de validar, es decir antes de
+     * `unique` y del DTO.
+     *
+     * Mismo motivo que el `license_number` del registro de conductor: `unique`
+     * es un `where plate = ?` sobre una columna con índice único, así que sin
+     * normalizar bastaría escribirla en minúsculas para registrar dos veces la
+     * misma moto —y ahí la placa dejaría de identificar a un vehículo, que es
+     * para lo único que sirve.
+     *
+     * Solo se recortan los extremos y se pasa a mayúsculas. Los espacios
+     * interiores no se tocan: `ABC 12D` es una placa mal escrita y lo correcto
+     * es que muera en el `regex` con un 422 explicable, no que el servidor
+     * decida por su cuenta cómo debería haberse escrito.
+     */
+    protected function prepareForValidation(): void
+    {
+        $plate = $this->input('plate');
+
+        if (is_string($plate)) {
+            $this->merge(['plate' => Str::upper(trim($plate))]);
+        }
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            // `unique` acá y no solo el índice de la tabla: sin la regla, una
+            // placa repetida escalaría a un 500 por violación de constraint en
+            // vez del 422 que el conductor puede entender y corregir.
+            'plate' => [
+                'required',
+                'string',
+                'max:10',
+                'regex:/^[A-Z0-9-]{5,10}$/',
+                'unique:vehicles,plate',
+            ],
+            'model' => ['required', 'string', 'max:100'],
+            // El tope es el año que viene porque los modelos se venden
+            // adelantados al calendario. Los dos límites atajan el dedazo
+            // (`2205`, `19999`), no declaran una antigüedad máxima de la flota:
+            // si el negocio quiere esa política, es otra decisión y su lugar es
+            // la configuración, no una regla de validación.
+            'year' => ['required', 'integer', 'digits:4', 'min:1970', 'max:'.((int) date('Y') + 1)],
+        ];
+    }
+
+    /**
+     * El "un vehículo por conductor" se comprueba acá y no con una regla sobre
+     * un campo, porque no lo decide nada de lo que el cliente manda: lo decide
+     * el estado de la cuenta autenticada. Por eso el error viaja bajo la clave
+     * `vehicle`, que no es un campo de la entrada.
+     *
+     * Es 422 y no 409: para el cliente móvil es el mismo camino que cualquier
+     * otro rechazo del formulario, y el endpoint ya responde 422 por la placa
+     * duplicada, que es el mismo tipo de choque.
+     *
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                $driver = $this->user();
+
+                if ($driver instanceof User && $driver->vehicle()->exists()) {
+                    $validator->errors()->add(
+                        'vehicle',
+                        'Ya tienes un vehículo registrado; actualiza el existente en vez de registrar otro.',
+                    );
+                }
+            },
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'plate.regex' => 'El campo plate debe tener entre 5 y 10 caracteres, solo letras, dígitos y guiones; se guarda siempre en mayúsculas.',
+        ];
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     *
+     * Los campos se leen uno por uno en vez de con `validated()`, igual que en
+     * los registros: es lo que garantiza que nada que no esté acá —un `user_id`
+     * mandado por el cliente, por ejemplo— pueda colarse hasta la escritura.
+     */
+    public function toRegistration(): VehicleRegistration
+    {
+        return new VehicleRegistration(
+            plate: $this->string('plate')->toString(),
+            model: $this->string('model')->toString(),
+            year: $this->integer('year'),
+        );
+    }
+}

--- a/app/Http/Resources/VehicleResource.php
+++ b/app/Http/Resources/VehicleResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Vehicle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el vehículo según el schema `Vehicle` de openapi.yaml.
+ *
+ * No lleva el `id` de la fila ni el `user_id`, por el mismo criterio que
+ * `DriverProfileResource`: son claves internas de una relación 1:1 a la que se
+ * llega por la cuenta que manda el token, nunca por un id propio, y publicarlas
+ * invitaría a intentar direccionar el vehículo por ahí.
+ *
+ * @property-read Vehicle $resource
+ */
+class VehicleResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'plate' => $this->resource->plate,
+            'model' => $this->resource->model,
+            'year' => $this->resource->year,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,6 +37,23 @@ class User extends Authenticatable implements JWTSubject
         return $this->hasOne(DriverProfile::class);
     }
 
+    /**
+     * La moto del conductor. Uno a uno: `vehicles.user_id` es único, y un
+     * conductor que quiere cambiar de moto actualiza la que tiene en vez de
+     * registrar otra.
+     *
+     * El tipo de la relación se declara con sus genéricos porque
+     * `RegisterVehicleAction` escribe a través de ella: sin esto, `create()`
+     * devuelve un `Model` genérico y PHPStan no puede verificar que la Action
+     * cumple su propio contrato de retorno.
+     *
+     * @return HasOne<Vehicle, $this>
+     */
+    public function vehicle(): HasOne
+    {
+        return $this->hasOne(Vehicle::class);
+    }
+
     public function isDriver(): bool
     {
         return $this->role === UserRole::Driver;

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Policies\VehiclePolicy;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * La moto con la que trabaja un conductor. Relación 1:1 con `User`, sostenida
+ * por el índice único de `user_id`.
+ *
+ * La Policy se declara con el atributo en vez de dejarla a la convención de
+ * nombres: acá es la que decide el 403 del pasajero que intenta registrar un
+ * vehículo, y una autorización que depende de que nadie renombre la clase es
+ * más frágil de lo que conviene.
+ *
+ * @property int $year
+ */
+#[Fillable(['user_id', 'plate', 'model', 'year'])]
+#[UsePolicy(VehiclePolicy::class)]
+class Vehicle extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'year' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Policies/VehiclePolicy.php
+++ b/app/Policies/VehiclePolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Quién puede operar sobre un vehículo.
+ *
+ * La autorización de negocio vive acá y no en los claims del token (ver
+ * .claude/STANDARDS.md): el `role` del JWT quedó congelado al emitirse, y una
+ * cuenta que dejó de ser conductor seguiría registrando motos hasta que su token
+ * venciera.
+ */
+class VehiclePolicy
+{
+    /**
+     * Registrar una moto es una operación del rol conductor.
+     *
+     * Que la cuenta ya tenga vehículo **no** se decide acá: eso responde 422,
+     * porque el conductor sí puede registrar motos y lo que le falta es
+     * actualizar la que tiene (historia #13). Un 403 le diría que el permiso le
+     * falta, que es otra cosa.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isDriver();
+    }
+}

--- a/database/factories/VehicleFactory.php
+++ b/database/factories/VehicleFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Vehicle>
+ */
+class VehicleFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->driver(),
+            // Formato de placa de moto colombiana (tres letras, dos dígitos,
+            // una letra). La API no lo exige —el `regex` del Form Request es
+            // más laxo a propósito, ver openapi.yaml— pero para los datos de
+            // prueba conviene que se parezcan a los reales.
+            'plate' => fake()->unique()->bothify('???##?', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+            'model' => fake()->randomElement([
+                'Bajaj Boxer CT 100',
+                'Yamaha YBR 125',
+                'Honda CB 110',
+                'Suzuki GN 125',
+            ]),
+            'year' => fake()->numberBetween(2010, (int) date('Y')),
+        ];
+    }
+}

--- a/database/migrations/2026_07_31_000001_create_vehicles_table.php
+++ b/database/migrations/2026_07_31_000001_create_vehicles_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vehicles', function (Blueprint $table) {
+            $table->id();
+            // Único: la relación con el conductor es uno a uno. Es el índice, y
+            // no la validación, lo que lo garantiza cuando dos requests del
+            // mismo conductor llegan a la vez.
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('plate', 10)->unique();
+            $table->string('model', 100);
+            // Entero y no `year`: el tipo YEAR de MySQL no existe en SQLite (el
+            // motor de desarrollo y de la suite) y solo cubre 1901-2155, un
+            // rango que no aporta nada sobre la validación del Form Request.
+            $table->unsignedSmallInteger('year');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vehicles');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -508,6 +508,108 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me/vehicle:
+    post:
+      tags:
+        - Vehicles
+      operationId: registerVehicle
+      summary: Registrar la moto del conductor autenticado
+      description: >-
+        Da de alta el vehículo del conductor que envía el token. Un conductor no
+        puede recibir solicitudes de viaje hasta tener uno registrado, así que
+        este endpoint es el último paso del alta antes de poder trabajar.
+
+        Cuelga de `/me` y no de `/vehicles` porque el vehículo es un
+        sub-recurso de la cuenta: se llega a él por el token, nunca por un id
+        propio. Por eso tampoco lleva un id en la respuesta (mismo criterio que
+        `driver_profile` en `GET /me`).
+
+        **La relación es uno a uno.** Un segundo registro no crea otra moto:
+        responde 422 pidiendo que se actualice la existente (historia #13). El
+        endpoint es de alta, no de alta-o-reemplazo, para que un cliente que
+        reintenta una request que ya había llegado no pise en silencio los datos
+        del vehículo con el que el conductor está trabajando.
+
+        La `plate` es única entre todos los conductores y se normaliza a
+        mayúsculas antes de validarla y de guardarla, igual que el
+        `license_number` del registro de conductor. La API **no** verifica
+        contra ninguna entidad externa que la placa exista, que esté vigente ni
+        que corresponda a quien la declara.
+
+        Requiere un token vigente y rol `driver`: una cuenta de pasajero recibe
+        403, no 422 — no es una entrada malformada, es una operación que su rol
+        no tiene.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VehicleRegistrationRequest"
+            example:
+              plate: ABC12D
+              model: Bajaj Boxer CT 100
+              year: 2022
+      responses:
+        "201":
+          description: Vehículo registrado y asociado a la cuenta del conductor.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Vehicle"
+              example:
+                data:
+                  plate: ABC12D
+                  model: Bajaj Boxer CT 100
+                  year: 2022
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no es de conductor. Registrar un vehículo no
+            es algo que un pasajero pueda hacer con otros datos, así que no es
+            un 422.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: >-
+            La entrada no pasó la validación: falta un campo, la placa ya está
+            registrada por otro conductor, o esta cuenta ya tiene un vehículo
+            —en cuyo caso el error viaja bajo la clave `vehicle`, que no es un
+            campo de la entrada sino el estado de la cuenta.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The plate has already been taken.
+                errors:
+                  plate:
+                    - The plate has already been taken.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -624,6 +726,35 @@ components:
                 perfil creado. En una cuenta de pasajero la clave se omite
                 entera, en vez de venir como `null`: no es un dato que falte,
                 es un dato que no aplica.
+    Vehicle:
+      type: object
+      description: >-
+        La moto con la que trabaja un conductor. Relación uno a uno con la
+        cuenta.
+
+        No lleva `id` ni `user_id`, por el mismo criterio que `DriverProfile`:
+        se llega al vehículo por la cuenta que envía el token, nunca por un id
+        propio, así que publicarlos solo invitaría a intentar direccionarlo por
+        ahí.
+      required:
+        - plate
+        - model
+        - year
+      properties:
+        plate:
+          type: string
+          description: >-
+            Placa tal como quedó guardada, en su forma canónica (mayúsculas,
+            sin espacios al borde).
+          example: ABC12D
+        model:
+          type: string
+          description: Modelo declarado por el conductor, texto libre.
+          example: Bajaj Boxer CT 100
+        year:
+          type: integer
+          description: Año del modelo.
+          example: 2022
     LoginRequest:
       type: object
       description: >-
@@ -765,6 +896,55 @@ components:
             Mínimo 8 caracteres, con al menos una letra y al menos un número
             (ver la política en .claude/STANDARDS.md).
           example: motoya2026
+    VehicleRegistrationRequest:
+      type: object
+      description: >-
+        Datos con los que un conductor da de alta su moto. No lleva a quién
+        pertenece: el dueño es siempre la cuenta que envía el token.
+      required:
+        - plate
+        - model
+        - year
+      properties:
+        plate:
+          type: string
+          minLength: 5
+          maxLength: 10
+          description: >-
+            Placa del vehículo, única entre todos los conductores. Se normaliza
+            a mayúsculas y sin espacios al borde antes de validarla y de
+            guardarla, así que `abc12d` y `ABC12D` son la misma placa y la
+            segunda alta responde 422. Solo se admiten letras, dígitos y
+            guiones; los espacios interiores **no** se limpian, porque
+            `ABC 12D` es una placa mal escrita y corresponde un 422 explicable
+            en vez de que el servidor adivine cómo debería haberse escrito.
+
+            La API no verifica contra ninguna entidad externa que la placa
+            exista, que esté vigente ni que corresponda a quien la declara:
+            registra lo que el conductor dice, igual que con el número de
+            licencia.
+          pattern: "^[A-Z0-9-]{5,10}$"
+          example: ABC12D
+        model:
+          type: string
+          maxLength: 100
+          description: >-
+            Modelo de la moto, texto libre: no hay catálogo de marcas ni
+            modelos, y fabricar uno para un dato que hoy solo sirve para que el
+            pasajero reconozca la moto que lo recoge sería inventar un problema.
+          example: Bajaj Boxer CT 100
+        year:
+          type: integer
+          minimum: 1970
+          description: >-
+            Año del modelo, de cuatro dígitos. El máximo es el año en curso más
+            uno —los modelos se venden adelantados al calendario— y por eso no
+            se fija acá como número: quedaría desactualizado cada enero.
+
+            Los límites existen para atajar el dedazo (`2205`, `19999`), no para
+            declarar una antigüedad máxima de la flota; si el negocio quiere esa
+            política, es otra decisión y su lugar es la configuración.
+          example: 2022
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
+use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
 
@@ -59,4 +60,13 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->get('me', ShowProfileController::class)
         ->name('profile.show');
+
+    // El vehículo del conductor cuelga de `me` porque es un sub-recurso de la
+    // cuenta: se llega a él por el token, nunca por un id propio. Que solo los
+    // conductores puedan registrarlo no se declara acá con un middleware de
+    // rol, sino con `VehiclePolicy` (ver .claude/STANDARDS.md: la autorización
+    // de negocio va en Policies, no en el token ni en la ruta).
+    Route::middleware('auth:api')
+        ->post('me/vehicle', RegisterVehicleController::class)
+        ->name('vehicles.store');
 });

--- a/tests/Feature/Vehicles/RegisterVehicleTest.php
+++ b/tests/Feature/Vehicles/RegisterVehicleTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Vehicles;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/me/vehicle — ver openapi.yaml.
+ *
+ * Un conductor no puede recibir solicitudes de viaje hasta tener una moto
+ * registrada, así que lo que fija esta suite es de quién queda el vehículo (de
+ * la cuenta del token, nunca de otra), que la placa no se pueda duplicar, y que
+ * un segundo registro no pise en silencio el vehículo con el que el conductor
+ * ya está trabajando.
+ */
+class RegisterVehicleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/vehicle';
+
+    public function test_registra_el_vehiculo_y_lo_asocia_a_la_cuenta_del_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated()
+            ->assertExactJson([
+                'data' => [
+                    'plate' => 'ABC12D',
+                    'model' => 'Bajaj Boxer CT 100',
+                    'year' => 2022,
+                ],
+            ]);
+
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+    }
+
+    public function test_la_respuesta_no_publica_el_id_de_la_fila_ni_el_dueno(): void
+    {
+        // Al vehículo se llega por la cuenta que manda el token, nunca por un
+        // id propio: publicarlos solo invitaría a intentar direccionarlo por
+        // ahí. Mismo criterio que `driver_profile` en GET /me.
+        $conductor = User::factory()->driver()->create();
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $respuesta->assertJsonMissingPath('data.id');
+        $respuesta->assertJsonMissingPath('data.user_id');
+    }
+
+    public function test_el_vehiculo_queda_del_dueno_del_token_y_no_de_otra_cuenta(): void
+    {
+        $otroConductor = User::factory()->driver()->create();
+        $propio = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($propio))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $propio->id]);
+        $this->assertDatabaseMissing('vehicles', ['user_id' => $otroConductor->id]);
+    }
+
+    public function test_rechaza_una_placa_ya_registrada_por_otro_conductor(): void
+    {
+        Vehicle::factory()->create(['plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('plate');
+
+        $this->assertDatabaseCount('vehicles', 1);
+    }
+
+    public function test_la_placa_duplicada_se_detecta_sin_importar_como_se_escriba(): void
+    {
+        // `unique` es un `where plate = ?` sobre una columna con índice único,
+        // así que sin normalizar bastaría escribirla en minúsculas para
+        // registrar dos veces la misma moto.
+        Vehicle::factory()->create(['plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, [...$this->datosValidos(), 'plate' => '  abc12d '])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('plate');
+
+        $this->assertDatabaseCount('vehicles', 1);
+    }
+
+    public function test_guarda_la_placa_en_su_forma_canonica(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [...$this->datosValidos(), 'plate' => ' abc12d '])
+            ->assertCreated()
+            ->assertJsonPath('data.plate', 'ABC12D');
+
+        $this->assertDatabaseHas('vehicles', ['plate' => 'ABC12D']);
+    }
+
+    public function test_rechaza_un_segundo_vehiculo_para_la_misma_cuenta(): void
+    {
+        // El endpoint es de alta, no de alta-o-reemplazo: un cliente que
+        // reintenta una request que ya había llegado no debe pisar en silencio
+        // los datos de la moto con la que el conductor está trabajando.
+        // Actualizarla es la historia #13.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'XYZ98W']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('vehicle');
+
+        $this->assertDatabaseCount('vehicles', 1);
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'XYZ98W']);
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_registrar_un_vehiculo(): void
+    {
+        // 403 y no 422: no es una entrada que se pueda corregir mandando otros
+        // datos, es una operación que el rol no tiene.
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('vehicles', 0);
+    }
+
+    public function test_al_pasajero_le_responde_403_aunque_los_datos_sean_invalidos(): void
+    {
+        // La autorización corre antes que la validación: si no, el 422 le
+        // diría a una cuenta sin permiso qué forma tiene que tener la entrada
+        // para seguir intentando.
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [])
+            ->assertForbidden();
+    }
+
+    #[DataProvider('entradasInvalidas')]
+    public function test_rechaza_la_entrada_invalida(array $sobrescritura, string $campoConError): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, [...$this->datosValidos(), ...$sobrescritura])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($campoConError);
+
+        $this->assertDatabaseCount('vehicles', 0);
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, string}>
+     */
+    public static function entradasInvalidas(): array
+    {
+        return [
+            'sin placa' => [['plate' => null], 'plate'],
+            'placa vacía' => [['plate' => ''], 'plate'],
+            'placa demasiado corta' => [['plate' => 'AB1'], 'plate'],
+            'placa demasiado larga' => [['plate' => 'ABCDE12345F'], 'plate'],
+            // Los espacios interiores no se limpian a propósito: `ABC 12D` es
+            // una placa mal escrita y corresponde un 422 explicable, no que el
+            // servidor adivine cómo debería haberse escrito.
+            'placa con espacios interiores' => [['plate' => 'ABC 12D'], 'plate'],
+            'placa con símbolos' => [['plate' => 'ABC*12D'], 'plate'],
+            'sin modelo' => [['model' => null], 'model'],
+            'modelo vacío' => [['model' => ''], 'model'],
+            'modelo demasiado largo' => [['model' => str_repeat('a', 101)], 'model'],
+            'sin año' => [['year' => null], 'year'],
+            'año no numérico' => [['year' => 'dos mil veintidós'], 'year'],
+            'año de dos dígitos' => [['year' => 22], 'year'],
+            'año anterior al mínimo' => [['year' => 1969], 'year'],
+            'año con un dedazo hacia el futuro' => [['year' => 2205], 'year'],
+        ];
+    }
+
+    public function test_acepta_el_ano_siguiente_al_en_curso(): void
+    {
+        // Los modelos se venden adelantados al calendario, así que el tope es
+        // el año que viene y no el actual.
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, [...$this->datosValidos(), 'year' => (int) date('Y') + 1])
+            ->assertCreated();
+    }
+
+    public function test_ignora_el_dueno_que_venga_en_la_entrada(): void
+    {
+        // El dueño es siempre la cuenta del token. `user_id` es fillable en el
+        // modelo, así que si el Form Request pasara `validated()` completo o el
+        // DTO tuviera el campo, un cliente podría registrarle una moto a otra
+        // persona.
+        $victima = User::factory()->driver()->create();
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [...$this->datosValidos(), 'user_id' => $victima->id])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id]);
+        $this->assertDatabaseMissing('vehicles', ['user_id' => $victima->id]);
+    }
+
+    public function test_rechaza_el_registro_sin_token(): void
+    {
+        $this->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('vehicles', 0);
+    }
+
+    public function test_rechaza_el_registro_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_el_registro_con_un_token_expirado(): void
+    {
+        $token = JWTAuth::fromUser(User::factory()->driver()->create());
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('vehicles', 0);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function datosValidos(): array
+    {
+        return [
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ];
+    }
+}

--- a/tests/Unit/Actions/Vehicles/RegisterVehicleActionTest.php
+++ b/tests/Unit/Actions/Vehicles/RegisterVehicleActionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Vehicles;
+
+use App\Actions\Vehicles\RegisterVehicleAction;
+use App\DTOs\VehicleRegistration;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ */
+class RegisterVehicleActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_el_vehiculo_asociado_al_conductor_recibido(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $vehiculo = $this->action()->handle($conductor, $this->registracion());
+
+        $this->assertTrue($vehiculo->exists);
+        $this->assertSame('ABC12D', $vehiculo->plate);
+        $this->assertSame('Bajaj Boxer CT 100', $vehiculo->model);
+        $this->assertSame(2022, $vehiculo->year);
+        $this->assertDatabaseCount('vehicles', 1);
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+        ]);
+    }
+
+    public function test_el_dueno_sale_del_conductor_recibido_y_no_del_dto(): void
+    {
+        // `VehicleRegistration` no tiene campo de dueño a propósito: quién
+        // registra la moto lo decide quien invoca la Action (el guard, en el
+        // caso del endpoint), no los datos que llegan del cliente.
+        $conductor = User::factory()->driver()->create();
+
+        $vehiculo = $this->action()->handle($conductor, $this->registracion());
+
+        $this->assertSame($conductor->id, $vehiculo->user_id);
+        $this->assertTrue($conductor->vehicle()->is($vehiculo));
+    }
+
+    public function test_la_placa_duplicada_no_deja_un_segundo_vehiculo(): void
+    {
+        // El Form Request ya valida que la placa esté libre, pero entre esa
+        // consulta y este INSERT cabe otra alta con la misma placa: el índice
+        // único de la tabla es lo que garantiza que no queden dos.
+        Vehicle::factory()->create(['plate' => 'ABC12D']);
+
+        $this->expectException(QueryException::class);
+
+        try {
+            $this->action()->handle(User::factory()->driver()->create(), $this->registracion());
+        } finally {
+            $this->assertDatabaseCount('vehicles', 1);
+        }
+    }
+
+    public function test_el_conductor_que_ya_tiene_vehiculo_no_puede_registrar_otro(): void
+    {
+        // Misma carrera que la placa, pero sobre el dueño: la relación es uno a
+        // uno y el índice único de `user_id` la sostiene aunque dos requests
+        // pasen la validación a la vez.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'XYZ98W']);
+
+        $this->expectException(QueryException::class);
+
+        try {
+            $this->action()->handle($conductor, $this->registracion());
+        } finally {
+            $this->assertDatabaseCount('vehicles', 1);
+            $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'XYZ98W']);
+        }
+    }
+
+    private function action(): RegisterVehicleAction
+    {
+        return $this->app->make(RegisterVehicleAction::class);
+    }
+
+    private function registracion(): VehicleRegistration
+    {
+        return new VehicleRegistration(
+            plate: 'ABC12D',
+            model: 'Bajaj Boxer CT 100',
+            year: 2022,
+        );
+    }
+}


### PR DESCRIPTION
Closes #12

## Qué hace

Agrega `POST /api/v1/me/vehicle`: un conductor autenticado da de alta su moto
(`plate`, `model`, `year`) y queda asociada a su cuenta. Responde **201** con el
schema `Vehicle`.

Los tres criterios de aceptación del issue:

| Criterio | Respuesta |
|---|---|
| Conductor autenticado + datos válidos | **201**, vehículo asociado a su cuenta |
| Placa ya registrada por otro conductor | **422** con `errors.plate` |
| La cuenta ya tiene un vehículo | **422** con `errors.vehicle` (mensaje: actualizar el existente) |

Piezas: migración `vehicles`, `App\Models\Vehicle`, `User::vehicle()`,
`VehicleRegistration` (DTO), `RegisterVehicleAction`, `VehiclePolicy`,
`RegisterVehicleRequest`, `VehicleResource`, `RegisterVehicleController`, factory,
el contrato en `openapi.yaml` y la decisión en `.claude/STANDARDS.md`.

## Cómo se probó

- **32 tests nuevos** (feature + unit), escritos antes de la implementación y
  confirmados en rojo primero. Suite completa: **263 passed**.
- `./vendor/bin/pint --test`, `composer stan` (PHPStan nivel 5), complejidad,
  arquitectura y `laravel-security-review`: todos en verde, sin hallazgos nuevos.
- Conformidad OpenAPI **estática**: `8 rutas revisadas, 0 avisos`.
- Conformidad OpenAPI **dinámica**: además del runner, se validó el **201 en vivo**
  contra el schema del spec con un token fresco, y se comprobaron a mano el 422 de
  placa duplicada y el 403 del pasajero (ver la nota de tooling más abajo).

## Decisiones y riesgos

- **`/me/vehicle`, no `/vehicles`**: es un sub-recurso de la cuenta, se llega por el
  token. Por eso `VehicleResource` no publica `id` ni `user_id`, igual que
  `DriverProfileResource`.
- **Un segundo registro es 422, no reemplazo.** El endpoint es de alta: un cliente que
  reintenta una request que ya había llegado no debe pisar en silencio la moto con la
  que el conductor está trabajando. Actualizarla es la #13.
- **Primer uso de Policies del proyecto.** `VehiclePolicy::create()` decide el rol; se
  invoca desde `authorize()` del Form Request para que el 403 salga *antes* que la
  validación — al revés, un 422 le detallaría a una cuenta sin permiso qué forma debe
  tener la entrada. El pasajero recibe **403**, no 422: no es una entrada corregible.
- **"Ya tiene vehículo" no está en la Policy**, aunque cabría: el conductor sí tiene el
  permiso, lo que le falta es actualizar. Un 403 ahí diría que el problema es de
  permisos, que es otra cosa. Va como error bajo la clave `vehicle`, que no es un campo
  de la entrada porque no lo decide la entrada.
- **La placa no codifica el formato de ningún país** (`^[A-Z0-9-]{5,10}$`). Atarla al
  `AAA00A` colombiano haría que cambiar de país fuera un cambio de código; la API
  tampoco verifica que exista o esté vigente, igual que con la licencia.
- **`year` entre 1970 y el año en curso + 1**: atajan el dedazo (`2205`, `19999`), no
  declaran antigüedad máxima de flota. El tope es el año siguiente porque los modelos
  se venden adelantados al calendario.
- **Sin transacción en la Action**, a diferencia del alta de conductor: se escribe una
  sola fila y no hay estado a medias que evitar. Riesgo asumido y explícito: dos altas
  simultáneas que pasen la validación a la vez terminan con la última perdiendo contra
  el índice único (**500**) — el mismo trato que la #7 le da a una licencia duplicada.
- **Los documentos del vehículo quedan fuera.** La historia los menciona en la frase de
  apertura, pero no hay ningún criterio de aceptación para ellos y guardarlos exige
  decidir antes dónde viven los archivos y quién los verifica — y la verificación
  administrativa está declarada fuera de alcance en el propio issue. Se deja anotado en
  STANDARDS.md en vez de improvisar un upload.

### Nota de tooling (no bloquea este PR)

`dynamic_conformance.py` reportó `OK, sin fallos` **sin haber ejecutado nunca el 201**:
recorre las operaciones en orden del spec, `POST /auth/logout` va antes que
`/me/vehicle` y comparte el token, así que el endpoint solo recibió el 401 que también
está documentado. Ya le había pasado a la #10, así que deja de ser un caso aislado: le
ocurre a toda feature autenticada que ordene después de `/auth/logout`. Queda registrado
en `KNOWN_ERRORS.md` con la corrección concreta (ordenar al final las operaciones que
invalidan el token, o pedir un token por operación). **No se arregla acá** para no
mezclar un cambio de tooling que corre en CI con una feature — merece su propio issue.

### Posible conflicto

El PR #41 (#11, `PATCH /me`) toca `routes/api.php`, `openapi.yaml` y `STANDARDS.md`.
Según cuál se mergee primero, el otro probablemente necesite un rebase; los cambios son
adiciones en zonas distintas de cada archivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)