### PR TITLE
feat(#13): actualizar los datos de mi vehículo

### DIFF
--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -104,3 +104,28 @@ que `dynamic_conformance.py` ordene las operaciones dejando para el final las qu
 invalidan el token (hoy `POST /auth/logout`), o que pida un token nuevo por operación.
 No se hizo dentro del PR de #12 para no mezclar un cambio de tooling que corre en CI
 con una feature — merece su propio issue.
+
+### 2026-07-31 — El chequeo dinámico nunca prueba el 401 sin `Accept: application/json`
+
+**Qué pasó:** implementando `PATCH /me/vehicle` (#13), el chequeo dinámico dio
+`OK: 9 operación(es) probadas` y el 401 documentado del endpoint validó sin problema.
+Pero pegándole al servidor real **sin** cabecera `Accept`, ese mismo 401 no existe:
+la API responde **500** (`Route [login] not defined.`) porque
+`AuthenticationException` cae en la rama de redirección al login web en vez de la de
+JSON. No es del endpoint nuevo — `GET /me` (#10) y `POST /me/vehicle` (#12) hacen
+exactamente lo mismo, así que el spec viene prometiendo un 401 que solo se cumple si
+el cliente manda `Accept`.
+
+**Por qué pasó:** `dynamic_conformance.py` fija `headers = {"Accept": "application/json"}`
+para todas las requests, así que el único camino que ejercita es justo el que funciona.
+Los tests de PHPUnit tampoco lo ven: `patchJson()`/`getJson()` ponen esa misma cabecera.
+Entre las dos herramientas, el caso quedó sin cubrir por ninguna.
+
+**Cómo evitarlo:** no dar por verificado un 401 documentado solo porque el chequeo
+dinámico lo valide — probarlo también sin `Accept` (`curl -X PATCH -H 'Content-Type:
+application/json' ...`) antes de cerrar una feature autenticada. La corrección de fondo
+es del backend, no del script (que `shouldRenderJsonWhen` aplique también a la rama de
+`unauthenticated()`, o `redirectGuestsTo(null)`), y toca a todos los endpoints
+protegidos a la vez: merece su propio issue en vez de colarse en el PR de una historia.
+Si se arregla, agregar al script una request de control sin `Accept` para que no
+vuelva a pasar inadvertido.

--- a/app/Actions/Vehicles/UpdateVehicleAction.php
+++ b/app/Actions/Vehicles/UpdateVehicleAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Vehicles;
+
+use App\DTOs\VehicleUpdate;
+use App\Models\Vehicle;
+
+/**
+ * Corrige los datos de la moto ya registrada de un conductor.
+ *
+ * Recibe el vehículo y no el conductor, al revés que `RegisterVehicleAction`:
+ * allá había que crear la fila y el dueño tenía que salir de quien invoca; acá
+ * la fila ya existe y quién puede editarla es una pregunta de autorización que
+ * responde `VehiclePolicy`, no esta Action. Lo que sí se mantiene es que el
+ * dueño no viaja en el DTO: esta Action no puede cambiar de manos una moto
+ * porque no tiene con qué.
+ *
+ * La placa no se normaliza acá, igual que en el alta: llevarla a su forma
+ * canónica es trabajo de la entrada (`prepareForValidation`), y tiene que pasar
+ * antes de validar la unicidad, no después.
+ */
+final class UpdateVehicleAction
+{
+    public function handle(Vehicle $vehicle, VehicleUpdate $update): Vehicle
+    {
+        // Descarta también la cadena vacía, y no solo `null`: las tres columnas
+        // son NOT NULL y una moto sin placa ni modelo no le sirve al pasajero
+        // que tiene que reconocerla. `UpdateVehicleRequest` ya lo ataja con
+        // `sometimes|required`, pero esta Action es invocable desde un job o un
+        // comando que no pasa por el Form Request, y su invariante propia es
+        // "no escribo un dato vacío".
+        $datos = array_filter(
+            [
+                'plate' => $update->plate,
+                'model' => $update->model,
+                'year' => $update->year,
+            ],
+            static fn (string|int|null $valor): bool => is_string($valor)
+                ? trim($valor) !== ''
+                : $valor !== null,
+        );
+
+        if ($datos !== []) {
+            $vehicle->update($datos);
+        }
+
+        return $vehicle;
+    }
+}

--- a/app/DTOs/VehicleUpdate.php
+++ b/app/DTOs/VehicleUpdate.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Datos a corregir en la moto ya registrada de un conductor, ya validados.
+ *
+ * Es un PATCH parcial: un campo en `null` significa "no vino en la request", no
+ * "bórralo" — ninguna de las tres columnas es nullable en `vehicles`.
+ *
+ * No lleva dueño, por la misma razón que `VehicleRegistration`: a quién
+ * pertenece la moto lo decide quien invoca la Action —el guard, en el caso del
+ * endpoint— y no los datos que manda el cliente. `user_id` es fillable en el
+ * modelo, así que si el campo existiera acá habría un camino por el que un
+ * conductor le regalaría su moto a otra cuenta.
+ */
+final readonly class VehicleUpdate
+{
+    public function __construct(
+        public ?string $plate = null,
+        public ?string $model = null,
+        public ?int $year = null,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Vehicles/UpdateVehicleController.php
+++ b/app/Http/Controllers/Api/V1/Vehicles/UpdateVehicleController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Vehicles;
+
+use App\Actions\Vehicles\UpdateVehicleAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Vehicles\UpdateVehicleRequest;
+use App\Http\Resources\VehicleResource;
+
+/**
+ * PATCH /api/v1/me/vehicle
+ *
+ * Corrige los datos de la moto del conductor autenticado.
+ *
+ * Qué vehículo se toca no se decide acá: lo resuelve el Form Request por la
+ * relación con la cuenta del token, que es también quien ya respondió el 403
+ * del rol, el 404 de la cuenta sin moto y el 422 de la entrada. Para cuando
+ * llega hasta este método no queda ninguna decisión pendiente.
+ */
+class UpdateVehicleController extends Controller
+{
+    public function __invoke(UpdateVehicleRequest $request, UpdateVehicleAction $updateVehicle): VehicleResource
+    {
+        $vehiculo = $updateVehicle->handle($request->vehicle(), $request->toUpdate());
+
+        return new VehicleResource($vehiculo);
+    }
+}

--- a/app/Http/Requests/Vehicles/UpdateVehicleRequest.php
+++ b/app/Http/Requests/Vehicles/UpdateVehicleRequest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Vehicles;
+
+use App\DTOs\VehicleUpdate;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Entrada de PATCH /api/v1/me/vehicle — ver openapi.yaml.
+ */
+class UpdateVehicleRequest extends FormRequest
+{
+    private ?Vehicle $vehicle = null;
+
+    /**
+     * Resuelve, en este orden, los tres rechazos posibles antes de la
+     * validación: el rol (403), el recurso inexistente (404) y la propiedad
+     * (403). El orden **es** el cuerpo de este método, y no es cosmético:
+     *
+     * - Al pasajero le corresponde 403 y no 404. Que no tenga moto no es un
+     *   dato que le falte cargar: operar vehículos no es de su rol, igual que
+     *   en el alta. Un 404 le sugeriría que registrando una podría seguir.
+     * - Al conductor sin moto le corresponde 404 antes que cualquier 422: que
+     *   el recurso no exista pesa más que la forma del body, y un 422 le haría
+     *   creer que corrigiendo los datos la request funcionaría.
+     *
+     * El 404 vive acá y no en `prepareForValidation()` porque ese hook corre
+     * **antes** que la autorización (`ValidatesWhenResolvedTrait::validateResolved()`),
+     * y ahí el pasajero se llevaría el 404 en vez del 403.
+     */
+    public function authorize(): bool
+    {
+        $driver = $this->user();
+
+        // "¿Podría esta cuenta tener una moto?" es exactamente la pregunta que
+        // responde `create`, así que se reusa en vez de inventar un tercer
+        // método de Policy que diría lo mismo. Va antes de buscar el vehículo
+        // porque es lo único que se puede contestar sin recurso.
+        if (! $driver instanceof User || ! $driver->can('create', Vehicle::class)) {
+            return false;
+        }
+
+        return $driver->can('update', $this->vehicle());
+    }
+
+    /**
+     * La moto de la cuenta autenticada, o 404 si todavía no registró ninguna.
+     *
+     * Se resuelve por la relación y nunca por un id de la entrada: es lo que
+     * hace que no exista forma de apuntar este endpoint al vehículo de otro
+     * conductor. La `VehiclePolicy` comprueba igual la propiedad —ver
+     * `VehiclePolicyTest`—: la garantía tiene que estar en la regla, no en que
+     * la ruta de hoy no lleve id.
+     *
+     * Memoizada porque la usan la autorización, las reglas y el controller, y
+     * las tres tienen que ver la misma fila.
+     */
+    public function vehicle(): Vehicle
+    {
+        if ($this->vehicle instanceof Vehicle) {
+            return $this->vehicle;
+        }
+
+        $driver = $this->user();
+        $vehicle = $driver instanceof User ? $driver->vehicle : null;
+
+        if (! $vehicle instanceof Vehicle) {
+            throw new NotFoundHttpException(
+                'No tienes un vehículo registrado; regístralo antes de actualizarlo.',
+            );
+        }
+
+        return $this->vehicle = $vehicle;
+    }
+
+    /**
+     * Lleva la placa a su forma canónica ANTES de validar, es decir antes de
+     * `unique` y del DTO — mismo motivo que en el alta: `unique` es un
+     * `where plate = ?` sobre una columna con índice único, así que sin
+     * normalizar bastaría escribirla en minúsculas para terminar con dos filas
+     * que son la misma moto.
+     *
+     * Solo se toca si vino: en un PATCH parcial, un campo ausente significa "no
+     * lo cambies", y mergear una placa vacía lo convertiría en un campo
+     * presente que además fallaría la validación.
+     */
+    protected function prepareForValidation(): void
+    {
+        $plate = $this->input('plate');
+
+        if (is_string($plate)) {
+            $this->merge(['plate' => Str::upper(trim($plate))]);
+        }
+    }
+
+    /**
+     * Las reglas son las del alta con `sometimes|required` delante: un dato
+     * corregido no puede quedar en un estado que el registro habría rechazado.
+     *
+     * `sometimes` a secas no alcanza —al contrario, sería un agujero—: ante una
+     * cadena vacía Laravel se salta TODAS las reglas no implícitas
+     * (`Validator::presentOrRuleIsImplicit()`), incluidas `regex` y `unique`,
+     * así que `{"plate": ""}` pasaría la validación y dejaría la moto sin placa
+     * contra una columna NOT NULL. `required` es implícita, corre igual sobre
+     * la cadena vacía y también cubre la que trae solo espacios.
+     *
+     * La unicidad de la placa se ignora contra la propia fila: si no, un
+     * cliente que manda el formulario completo sin haber tocado la placa
+     * recibiría un 422 por chocar consigo mismo.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'plate' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:10',
+                'regex:/^[A-Z0-9-]{5,10}$/',
+                Rule::unique('vehicles', 'plate')->ignore($this->vehicle()->getKey()),
+            ],
+            'model' => ['sometimes', 'required', 'string', 'max:100'],
+            // El tope es el año que viene porque los modelos se venden
+            // adelantados al calendario, igual que en el alta.
+            'year' => ['sometimes', 'required', 'integer', 'digits:4', 'min:1970', 'max:'.((int) date('Y') + 1)],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'plate.regex' => 'El campo plate debe tener entre 5 y 10 caracteres, solo letras, dígitos y guiones; se guarda siempre en mayúsculas.',
+        ];
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     *
+     * Los campos se leen uno por uno y no con `validated()`: es lo que
+     * garantiza que nada que no esté acá —un `user_id` o un `id` mandado por el
+     * cliente, por ejemplo— pueda colarse hasta la escritura. Se lee con `has()`
+     * y no con `filled()` porque lo que importa es si el campo vino en la
+     * request: para cuando esto corre, un valor vacío ya murió en el `required`
+     * de `rules()`, así que lo que llega es un valor real.
+     */
+    public function toUpdate(): VehicleUpdate
+    {
+        return new VehicleUpdate(
+            plate: $this->has('plate') ? $this->string('plate')->toString() : null,
+            model: $this->has('model') ? $this->string('model')->toString() : null,
+            year: $this->has('year') ? $this->integer('year') : null,
+        );
+    }
+}

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * vehículo, y una autorización que depende de que nadie renombre la clase es
  * más frágil de lo que conviene.
  *
+ * @property int $user_id
  * @property int $year
  */
 #[Fillable(['user_id', 'plate', 'model', 'year'])]

--- a/app/Policies/VehiclePolicy.php
+++ b/app/Policies/VehiclePolicy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\Vehicle;
 
 /**
  * Quién puede operar sobre un vehículo.
@@ -27,5 +28,25 @@ class VehiclePolicy
     public function create(User $user): bool
     {
         return $user->isDriver();
+    }
+
+    /**
+     * Corregir los datos de una moto es del conductor **dueño** de esa moto.
+     *
+     * `PATCH /me/vehicle` no lleva id en la ruta —se llega al vehículo por la
+     * cuenta que manda el token—, así que hoy no existe una request capaz de
+     * traer acá la moto de otra persona. La comprobación de propiedad se
+     * escribe igual: la garantía tiene que vivir en la regla y no en la forma
+     * de la ruta de hoy, para que siga en pie si el vehículo llega a
+     * direccionarse de otra manera. Se verifica en `VehiclePolicyTest`, que es
+     * el único lugar desde donde ese caso es alcanzable.
+     *
+     * El rol se comprueba además de la propiedad: nada impide que una fila
+     * apunte a una cuenta que dejó de ser conductor, y ahí la propiedad sola
+     * autorizaría a alguien que ya no opera vehículos.
+     */
+    public function update(User $user, Vehicle $vehicle): bool
+    {
+        return $user->isDriver() && $vehicle->user_id === $user->getKey();
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -689,6 +689,120 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+    patch:
+      tags:
+        - Vehicles
+      operationId: updateVehicle
+      summary: Actualizar los datos de mi vehículo
+      description: >-
+        Actualiza la moto ya registrada del conductor que envía el token: sirve
+        para corregir un dato mal cargado o para reflejar un cambio (una placa
+        que se rehizo, por ejemplo).
+
+        Es un PATCH parcial, igual que `PATCH /me`: solo los campos presentes
+        en el body se cambian, el resto conserva su valor. Un campo presente no
+        puede venir vacío — `{"model": ""}` responde 422, no borra el modelo;
+        las tres columnas son NOT NULL. La forma de no tocar un dato es no
+        mandarlo.
+
+        **No reemplaza el vehículo por otro.** Cambiar de moto —dar de baja la
+        actual y registrar una distinta— es otra operación y hoy no existe:
+        este endpoint asume que la fila que edita sigue siendo la misma moto.
+
+        Como el alta, cuelga de `/me` porque el vehículo es un sub-recurso de
+        la cuenta: se llega a él por el token, nunca por un id propio. Que no
+        haya id en la ruta es lo que hace estructuralmente imposible pedir el
+        de otro conductor; la propiedad se comprueba igual con `VehiclePolicy`,
+        que es donde vive la autorización de negocio y lo que mantiene la
+        garantía si algún día el vehículo se direcciona de otra forma.
+
+        La `plate` se normaliza a mayúsculas y sigue siendo única entre todos
+        los conductores; reenviar la propia sin cambiarla no responde 422.
+
+        Requiere un token vigente y rol `driver`. Un conductor que todavía no
+        registró su moto recibe 404: no hay nada que actualizar, y lo que le
+        corresponde es el alta (`POST /me/vehicle`).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VehicleUpdateRequest"
+            example:
+              model: Bajaj Boxer CT 100 ES
+              year: 2023
+      responses:
+        "200":
+          description: Vehículo actualizado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Vehicle"
+              example:
+                data:
+                  plate: ABC12D
+                  model: Bajaj Boxer CT 100 ES
+                  year: 2023
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no puede operar sobre este vehículo: o no es
+            de conductor, o el vehículo no le pertenece. Lo decide
+            `VehiclePolicy`, no la ruta.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: >-
+            La cuenta es de conductor pero todavía no tiene vehículo
+            registrado, así que no hay recurso que actualizar. Se responde
+            antes que cualquier 422: que el recurso no exista pesa más que la
+            forma de la entrada.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No tienes un vehículo registrado; regístralo antes de actualizarlo.
+        "422":
+          description: >-
+            La entrada no pasó la validación: un campo presente vino vacío,
+            tiene un formato inválido, o la placa ya está registrada por otro
+            conductor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The plate has already been taken.
+                errors:
+                  plate:
+                    - The plate has already been taken.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -1062,6 +1176,52 @@ components:
             declarar una antigüedad máxima de la flota; si el negocio quiere esa
             política, es otra decisión y su lugar es la configuración.
           example: 2022
+    VehicleUpdateRequest:
+      type: object
+      description: >-
+        Datos de la moto que el conductor puede corregir. Todos los campos son
+        opcionales: solo los que vienen en la request se cambian, el resto
+        queda como estaba. No lleva a quién pertenece, igual que el alta — el
+        dueño es siempre la cuenta que envía el token y no algo que la entrada
+        pueda elegir.
+
+        **Opcional no es vaciable.** Un campo que viene tiene que traer un
+        valor: las tres columnas son NOT NULL, y una moto sin placa ni modelo
+        no le sirve al pasajero que tiene que reconocerla. La forma de no
+        cambiar un dato es no mandarlo.
+
+        Las reglas de cada campo son las mismas del alta (`plate` normalizada y
+        única, `model` texto libre, `year` de cuatro dígitos hasta el que viene)
+        — un dato corregido no puede quedar en un estado que el alta habría
+        rechazado.
+      properties:
+        plate:
+          type: string
+          minLength: 5
+          maxLength: 10
+          description: >-
+            Placa del vehículo, única entre todos los conductores. Se normaliza
+            igual que en el alta (mayúsculas, sin espacios al borde). Reenviar
+            la placa que la moto ya tiene **no** responde 422: la unicidad se
+            comprueba ignorando la propia fila, así que un cliente que manda el
+            formulario completo sin haber tocado la placa no choca consigo
+            mismo.
+          pattern: "^[A-Z0-9-]{5,10}$"
+          example: ABC12D
+        model:
+          type: string
+          minLength: 1
+          maxLength: 100
+          description: Modelo de la moto, texto libre. Mismo criterio que el alta.
+          example: Bajaj Boxer CT 100 ES
+        year:
+          type: integer
+          minimum: 1970
+          description: >-
+            Año del modelo, de cuatro dígitos. Mismo rango que el alta: el
+            máximo es el año en curso más uno, por eso no se fija acá como
+            número.
+          example: 2023
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
+use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
 
@@ -76,4 +77,12 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('me/vehicle', RegisterVehicleController::class)
         ->name('vehicles.store');
+
+    // PATCH y no PUT, igual que el perfil: solo se aceptan los campos
+    // presentes en el body, el resto del vehículo no se toca (historia #13).
+    // Tampoco lleva id acá: es el mismo sub-recurso de `me`, así que la moto
+    // que se edita es siempre la de la cuenta del token.
+    Route::middleware('auth:api')
+        ->patch('me/vehicle', UpdateVehicleController::class)
+        ->name('vehicles.update');
 });

--- a/tests/Feature/Vehicles/UpdateVehicleTest.php
+++ b/tests/Feature/Vehicles/UpdateVehicleTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Vehicles;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de PATCH /api/v1/me/vehicle — ver openapi.yaml.
+ *
+ * Lo que fija esta suite es qué vehículo se toca (siempre el de la cuenta del
+ * token, nunca el de otra), que sea un PATCH de verdad —lo que no se manda no
+ * se cambia, y lo que se manda no puede venir vacío—, y el orden en que se
+ * responden los rechazos: 403 el rol, 404 el recurso que no existe, 422 la
+ * entrada. Ese orden importa: al revés, un 422 le detallaría la forma de la
+ * entrada a quien ni siquiera tiene el endpoint disponible.
+ */
+class UpdateVehicleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/vehicle';
+
+    public function test_actualiza_el_vehiculo_del_conductor_y_responde_los_nuevos_valores(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create([
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, [
+                'plate' => 'XYZ98W',
+                'model' => 'Bajaj Boxer CT 100 ES',
+                'year' => 2023,
+            ])
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'plate' => 'XYZ98W',
+                    'model' => 'Bajaj Boxer CT 100 ES',
+                    'year' => 2023,
+                ],
+            ]);
+
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'plate' => 'XYZ98W',
+            'model' => 'Bajaj Boxer CT 100 ES',
+            'year' => 2023,
+        ]);
+    }
+
+    public function test_solo_cambia_los_campos_presentes_en_el_body(): void
+    {
+        // Es un PATCH parcial: la forma de no tocar un dato es no mandarlo.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create([
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'plate' => 'ABC12D',
+                    'model' => 'Bajaj Boxer CT 100',
+                    'year' => 2023,
+                ],
+            ]);
+
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2023,
+        ]);
+    }
+
+    public function test_un_body_vacio_no_cambia_nada_y_devuelve_el_vehiculo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $vehiculo = Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+        $actualizadoEn = $vehiculo->updated_at;
+
+        $this->travel(1)->minute();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, [])
+            ->assertOk()
+            ->assertJsonPath('data.plate', 'ABC12D');
+
+        $this->assertEquals($actualizadoEn, $vehiculo->fresh()->updated_at);
+    }
+
+    public function test_la_respuesta_no_publica_el_id_de_la_fila_ni_el_dueno(): void
+    {
+        // Mismo criterio que el alta: al vehículo se llega por la cuenta que
+        // manda el token, nunca por un id propio.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertOk();
+
+        $respuesta->assertJsonMissingPath('data.id');
+        $respuesta->assertJsonMissingPath('data.user_id');
+    }
+
+    public function test_responde_404_si_el_conductor_todavia_no_registro_su_vehiculo(): void
+    {
+        // No hay recurso que actualizar: lo que le corresponde es el alta.
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertNotFound()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('vehicles', 0);
+    }
+
+    public function test_el_404_pesa_mas_que_la_entrada_invalida(): void
+    {
+        // Que el recurso no exista se responde antes que la forma del body: un
+        // 422 haría creer que corrigiendo los datos la request funcionaría.
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->patchJson(self::URI, ['year' => 'dos mil veintitrés'])
+            ->assertNotFound();
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_actualizar_un_vehiculo(): void
+    {
+        // 403 y no 404: para el pasajero no es que le falte registrar la moto,
+        // es que operar vehículos no es de su rol. Mismo trato que en el alta.
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_al_pasajero_le_responde_403_aunque_los_datos_sean_invalidos(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->patchJson(self::URI, ['year' => 'dos mil veintitrés'])
+            ->assertForbidden();
+    }
+
+    public function test_no_toca_el_vehiculo_de_otro_conductor_aunque_venga_su_id_en_el_body(): void
+    {
+        // La ruta no lleva id, así que no hay forma de direccionar el vehículo
+        // ajeno; esto verifica que tampoco se cuele por el body. Que la Policy
+        // rechace al no-dueño se prueba directo en VehiclePolicyTest: por esta
+        // ruta el caso es estructuralmente inalcanzable.
+        $otro = User::factory()->driver()->create();
+        $ajeno = Vehicle::factory()->create([
+            'user_id' => $otro->id,
+            'plate' => 'JJJ11J',
+            'model' => 'Honda CB 110',
+            'year' => 2020,
+        ]);
+
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, [
+                'id' => $ajeno->id,
+                'user_id' => $otro->id,
+                'model' => 'Yamaha YBR 125',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.plate', 'ABC12D');
+
+        $this->assertDatabaseHas('vehicles', [
+            'id' => $ajeno->id,
+            'user_id' => $otro->id,
+            'model' => 'Honda CB 110',
+        ]);
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'model' => 'Yamaha YBR 125',
+        ]);
+    }
+
+    public function test_rechaza_una_placa_ya_registrada_por_otro_conductor(): void
+    {
+        Vehicle::factory()->create(['plate' => 'XYZ98W']);
+
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['plate' => 'XYZ98W'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('plate');
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+    }
+
+    public function test_reenviar_la_placa_propia_sin_cambiarla_no_es_un_conflicto(): void
+    {
+        // La unicidad se comprueba ignorando la propia fila: un cliente que
+        // manda el formulario completo sin haber tocado la placa no puede
+        // chocar consigo mismo.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['plate' => 'ABC12D', 'year' => 2023])
+            ->assertOk()
+            ->assertJsonPath('data.plate', 'ABC12D')
+            ->assertJsonPath('data.year', 2023);
+    }
+
+    public function test_guarda_la_placa_en_su_forma_canonica(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['plate' => ' xyz98w '])
+            ->assertOk()
+            ->assertJsonPath('data.plate', 'XYZ98W');
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'XYZ98W']);
+    }
+
+    public function test_la_placa_duplicada_se_detecta_sin_importar_como_se_escriba(): void
+    {
+        Vehicle::factory()->create(['plate' => 'XYZ98W']);
+
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['plate' => '  xyz98w '])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('plate');
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+    }
+
+    #[DataProvider('entradasInvalidas')]
+    public function test_rechaza_la_entrada_invalida(array $body, string $campoConError): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create([
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, $body)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($campoConError);
+
+        $this->assertDatabaseHas('vehicles', [
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+    }
+
+    /**
+     * Un campo ausente es "no lo toques", pero uno presente no puede venir
+     * vacío ni en `null`: las tres columnas son NOT NULL y un vehículo sin
+     * placa ni modelo no le sirve al pasajero que tiene que reconocerlo.
+     *
+     * @return array<string, array{array<string, mixed>, string}>
+     */
+    public static function entradasInvalidas(): array
+    {
+        return [
+            'placa vacía' => [['plate' => ''], 'plate'],
+            'placa en null' => [['plate' => null], 'plate'],
+            'placa solo con espacios' => [['plate' => '   '], 'plate'],
+            'placa demasiado corta' => [['plate' => 'AB1'], 'plate'],
+            'placa demasiado larga' => [['plate' => 'ABCDE12345F'], 'plate'],
+            'placa con espacios interiores' => [['plate' => 'ABC 12D'], 'plate'],
+            'placa con símbolos' => [['plate' => 'ABC*12D'], 'plate'],
+            'modelo vacío' => [['model' => ''], 'model'],
+            'modelo en null' => [['model' => null], 'model'],
+            'modelo demasiado largo' => [['model' => str_repeat('a', 101)], 'model'],
+            'año en null' => [['year' => null], 'year'],
+            'año no numérico' => [['year' => 'dos mil veintidós'], 'year'],
+            'año de dos dígitos' => [['year' => 22], 'year'],
+            'año anterior al mínimo' => [['year' => 1969], 'year'],
+            'año con un dedazo hacia el futuro' => [['year' => 2205], 'year'],
+        ];
+    }
+
+    public function test_acepta_el_ano_siguiente_al_en_curso(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['year' => (int) date('Y') + 1])
+            ->assertOk();
+    }
+
+    public function test_ignora_el_dueno_que_venga_en_la_entrada(): void
+    {
+        // `user_id` es fillable en el modelo: si el Form Request pasara
+        // `validated()` completo o el DTO tuviera el campo, un cliente podría
+        // regalarle su moto a otra cuenta.
+        $victima = User::factory()->driver()->create();
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['user_id' => $victima->id, 'year' => 2023])
+            ->assertOk();
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'year' => 2023]);
+        $this->assertDatabaseMissing('vehicles', ['user_id' => $victima->id]);
+    }
+
+    public function test_rechaza_la_actualizacion_sin_token(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->patchJson(self::URI, ['year' => 2023])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+    }
+
+    public function test_rechaza_la_actualizacion_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_actualizacion_con_un_token_expirado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'year' => 2022]);
+        $token = JWTAuth::fromUser($conductor);
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->patchJson(self::URI, ['year' => 2023])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('vehicles', ['user_id' => $conductor->id, 'year' => 2022]);
+    }
+}

--- a/tests/Unit/Actions/Vehicles/UpdateVehicleActionTest.php
+++ b/tests/Unit/Actions/Vehicles/UpdateVehicleActionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Vehicles;
+
+use App\Actions\Vehicles\UpdateVehicleAction;
+use App\DTOs\VehicleUpdate;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ */
+class UpdateVehicleActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_actualiza_solo_los_campos_presentes_en_el_dto(): void
+    {
+        $vehiculo = $this->vehiculo();
+
+        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(year: 2023));
+
+        $this->assertSame('ABC12D', $resultado->plate);
+        $this->assertSame('Bajaj Boxer CT 100', $resultado->model);
+        $this->assertSame(2023, $resultado->year);
+    }
+
+    public function test_no_escribe_en_la_base_si_el_dto_no_trae_ningun_campo(): void
+    {
+        $vehiculo = $this->vehiculo();
+        $actualizadoEn = $vehiculo->updated_at;
+
+        $this->travel(1)->minute();
+        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate);
+
+        $this->assertSame('ABC12D', $resultado->plate);
+        $this->assertEquals($actualizadoEn, $vehiculo->fresh()->updated_at);
+    }
+
+    /**
+     * La Action no depende de que la haya llamado el Form Request: un job o un
+     * comando pueden armar el DTO a mano, y las tres columnas son NOT NULL.
+     */
+    public function test_ignora_los_campos_de_texto_que_vienen_vacios_en_el_dto(): void
+    {
+        $vehiculo = $this->vehiculo();
+
+        $resultado = $this->action()->handle(
+            $vehiculo,
+            new VehicleUpdate(plate: '   ', model: ''),
+        );
+
+        $this->assertSame('ABC12D', $resultado->plate);
+        $this->assertSame('Bajaj Boxer CT 100', $resultado->model);
+
+        $recargado = $vehiculo->fresh();
+
+        $this->assertSame('ABC12D', $recargado->plate);
+        $this->assertSame('Bajaj Boxer CT 100', $recargado->model);
+    }
+
+    public function test_el_dueno_no_cambia_porque_el_dto_no_lo_tiene(): void
+    {
+        // `VehicleUpdate` no tiene campo de dueño a propósito, igual que
+        // `VehicleRegistration`: a quién pertenece la moto no es algo que la
+        // entrada pueda elegir.
+        $vehiculo = $this->vehiculo();
+        $dueno = $vehiculo->user_id;
+
+        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(model: 'Yamaha YBR 125'));
+
+        $this->assertSame($dueno, $resultado->user_id);
+        $this->assertDatabaseHas('vehicles', ['user_id' => $dueno, 'model' => 'Yamaha YBR 125']);
+    }
+
+    public function test_devuelve_la_instancia_con_los_datos_ya_actualizados(): void
+    {
+        $vehiculo = $this->vehiculo();
+
+        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(plate: 'XYZ98W'));
+
+        $this->assertSame($vehiculo->id, $resultado->id);
+        $this->assertSame('XYZ98W', $resultado->plate);
+        $this->assertSame('XYZ98W', $vehiculo->fresh()->plate);
+    }
+
+    public function test_no_toca_ningun_otro_vehiculo(): void
+    {
+        $ajeno = Vehicle::factory()->create(['plate' => 'JJJ11J', 'model' => 'Honda CB 110']);
+
+        $this->action()->handle($this->vehiculo(), new VehicleUpdate(model: 'Yamaha YBR 125'));
+
+        $this->assertDatabaseHas('vehicles', ['id' => $ajeno->id, 'model' => 'Honda CB 110']);
+    }
+
+    private function action(): UpdateVehicleAction
+    {
+        return $this->app->make(UpdateVehicleAction::class);
+    }
+
+    private function vehiculo(): Vehicle
+    {
+        return Vehicle::factory()->create([
+            'user_id' => User::factory()->driver(),
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+    }
+}

--- a/tests/Unit/Policies/VehiclePolicyTest.php
+++ b/tests/Unit/Policies/VehiclePolicyTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Policies;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Policy invocada directo, sin pasar por HTTP.
+ *
+ * `PATCH /me/vehicle` no lleva id en la ruta, así que hoy no existe una request
+ * que le pase a la Policy el vehículo de otra persona. Eso hace que el caso
+ * "conductor que intenta editar la moto ajena" sea inalcanzable por HTTP y solo
+ * verificable acá — y por eso la garantía se escribe en la Policy y no en el
+ * hecho de que la ruta no tenga id: si el vehículo llega a direccionarse de otra
+ * forma (un panel, un endpoint con id), la regla ya está puesta y no hay que
+ * acordarse de agregarla.
+ */
+class VehiclePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_conductor_puede_registrar_un_vehiculo(): void
+    {
+        $this->assertTrue(User::factory()->driver()->create()->can('create', Vehicle::class));
+    }
+
+    public function test_el_pasajero_no_puede_registrar_un_vehiculo(): void
+    {
+        $this->assertFalse(User::factory()->create()->can('create', Vehicle::class));
+    }
+
+    public function test_el_conductor_puede_actualizar_su_propio_vehiculo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $vehiculo = Vehicle::factory()->create(['user_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('update', $vehiculo));
+    }
+
+    public function test_el_conductor_no_puede_actualizar_el_vehiculo_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $ajeno = Vehicle::factory()->create(['user_id' => User::factory()->driver()]);
+
+        $this->assertFalse($conductor->can('update', $ajeno));
+    }
+
+    public function test_el_pasajero_no_puede_actualizar_un_vehiculo_aunque_figure_como_dueno(): void
+    {
+        // La base no impide que una fila apunte a una cuenta de pasajero (un
+        // rol degradado a mano, por ejemplo). Operar vehículos sigue siendo del
+        // rol conductor, así que la propiedad sola no alcanza.
+        $pasajero = User::factory()->create();
+        $vehiculo = Vehicle::factory()->create(['user_id' => $pasajero->id]);
+
+        $this->assertFalse($pasajero->can('update', $vehiculo));
+    }
+}


### PR DESCRIPTION
Closes #13

## Qué hace

Agrega `PATCH /api/v1/me/vehicle`: el conductor corrige los datos de la moto que ya
registró (renovó documentos, cargó mal un dato). Parcial como `PATCH /me` — lo que no
se manda no se cambia, y un campo presente no puede venir vacío contra tres columnas
NOT NULL.

Piezas, siguiendo el patrón del alta (#12) y del perfil (#11):

- `UpdateVehicleAction` — la escritura. Recibe el `Vehicle` y no el `User`: la fila ya
  existe y quién puede editarla lo responde la Policy, no la Action. El DTO no lleva
  dueño, así que no tiene con qué cambiar de manos una moto.
- `VehicleUpdate` — DTO parcial (`null` = "no vino", no "bórralo").
- `UpdateVehicleRequest` — resuelve el vehículo por la relación con la cuenta del
  token, normaliza la placa antes de validar, y reusa las reglas del alta con
  `sometimes|required` delante.
- `VehiclePolicy::update` — rol conductor **y** propiedad.
- `UpdateVehicleController` + ruta `vehicles.update`.
- `openapi.yaml`: la operación completa (`updateVehicle`) y el schema
  `VehicleUpdateRequest`.

### Orden de los rechazos

Es lo menos obvio del PR, así que va explícito: **403 → 404 → 422**, y el orden es el
cuerpo de `UpdateVehicleRequest::authorize()`.

- Pasajero → **403**, no 404. Que no tenga moto no es un dato que le falte cargar:
  operar vehículos no es de su rol, igual que en el alta. Un 404 le sugeriría que
  registrando una podría seguir.
- Conductor sin moto → **404**, antes que cualquier 422: que el recurso no exista pesa
  más que la forma del body, y un 422 le haría creer que corrigiendo los datos la
  request funcionaría.

El 404 no puede vivir en `prepareForValidation()`: ese hook corre **antes** que la
autorización (`ValidatesWhenResolvedTrait::validateResolved()`), y ahí el pasajero se
llevaría el 404 en vez del 403.

## Cómo se probó

TDD: los tests se escribieron contra el spec y fallaron primero (34 failures / 6
errors por ruta y Action inexistentes) antes de la implementación.

- `tests/Feature/Vehicles/UpdateVehicleTest.php` — un test por criterio de aceptación,
  más el orden de los rechazos, el PATCH parcial, la normalización de la placa, la
  unicidad ignorando la propia fila, y que `user_id`/`id` en el body no se cuelen.
- `tests/Unit/Actions/Vehicles/UpdateVehicleActionTest.php` — la Action invocada
  directo (sirve igual desde un job o un comando).
- `tests/Unit/Policies/VehiclePolicyTest.php` — **acá vive el criterio 3**. Ver abajo.

Verde: **335 tests, 1022 assertions**. `./vendor/bin/pint --test` OK. PHPStan nivel 5
sin errores. Conformidad estática contra el spec: 10 rutas, 0 avisos.

Conformidad dinámica: `9 operación(es) probadas, sin fallos`. Ese OK **no alcanza** por
sí solo (ver `KNOWN_ERRORS.md`: `/auth/logout` va antes en el spec y deja el token en
la blacklist), así que el camino de éxito se validó aparte contra el servidor real —
200, 422 y sus bodies validados contra el schema documentado de cada código.

## Decisiones y riesgos

**El criterio de aceptación 3 se cumple, pero no por HTTP.** El criterio pide que un
conductor que intenta actualizar el vehículo de otro "vía manipulación de id" reciba
403. La ruta no lleva id —el vehículo se resuelve por la relación con la cuenta del
token— así que ese caso es estructuralmente inalcanzable por HTTP: no hay request que
pueda pedir la moto ajena. Se cubre en dos partes:

- `VehiclePolicyTest` prueba la regla directo (no-dueño → deniega), que es el único
  lugar desde donde el caso es alcanzable.
- El feature test verifica que mandar `id`/`user_id` ajenos en el body no toca la moto
  de la otra cuenta.

La comprobación de propiedad se escribió igual en la Policy en vez de apoyarse en que
la ruta no tenga id: si el vehículo llega a direccionarse de otra forma, la regla ya
está puesta.

**Hallazgo fuera de alcance — el 401 documentado depende de `Accept: application/json`.**
Sin esa cabecera, la API responde **500** (`Route [login] not defined.`) en vez del 401
que el spec promete. **No es de este endpoint**: `GET /me` (#10) y `POST /me/vehicle`
(#12) hacen exactamente lo mismo — `AuthenticationException` cae en la rama de
redirección al login web. Ni los tests (`patchJson` pone la cabecera) ni el chequeo
dinámico (la fija para todas las requests) lo veían.

No se corrige acá a propósito: la corrección va en `bootstrap/app.php` y cambia el
comportamiento de todos los endpoints protegidos a la vez, que es bastante más que
"actualizar los datos de mi vehículo". Queda registrado en
`.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md` (único archivo del PR fuera
del alcance de la historia, y es documentación) y merece su propio issue.

**Sin migración.** La tabla `vehicles` (#12) ya tiene todo lo necesario; el cambio es
solo de contrato de API, y aditivo: no toca `POST /me/vehicle` ni ningún endpoint
existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)