### PR TITLE
feat(#14): ver tarifa estimada antes de solicitar un viaje

### DIFF
--- a/app/DTOs/RideEstimate.php
+++ b/app/DTOs/RideEstimate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Estimación de un viaje que todavía no se solicitó: el trayecto que devolvió
+ * el proveedor de mapas junto con lo que costaría según la tarifa vigente.
+ *
+ * Combina ambos en un solo objeto para que el controller tenga una sola cosa
+ * que pasarle al API Resource, en vez de manejar `RouteEstimate` y
+ * `FareBreakdown` como dos parámetros sueltos.
+ */
+final readonly class RideEstimate
+{
+    public function __construct(
+        public RouteEstimate $route,
+        public FareBreakdown $fare,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Rides/EstimateRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/EstimateRideController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\RideEstimate;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\EstimateRideRequest;
+use App\Http\Resources\RideEstimateResource;
+use App\Services\Maps\RouteEstimator;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/estimate
+ *
+ * Le muestra al pasajero cuánto costaría un viaje antes de solicitarlo. No
+ * crea nada: el modelo `Ride` todavía no existe (historia #15), así que esto
+ * es solo una consulta contra el proveedor de mapas y el motor de tarifa, con
+ * la misma fórmula que se usa al cobrar el viaje real (ver CalculateFareAction).
+ */
+class EstimateRideController extends Controller
+{
+    public function __invoke(
+        EstimateRideRequest $request,
+        RouteEstimator $routeEstimator,
+        CalculateFareAction $calculateFare,
+    ): JsonResponse {
+        $route = $routeEstimator->estimate($request->origin(), $request->destination());
+
+        $estimate = new RideEstimate($route, $calculateFare->handle($route));
+
+        return (new RideEstimateResource($estimate))->response();
+    }
+}

--- a/app/Http/Requests/Rides/EstimateRideRequest.php
+++ b/app/Http/Requests/Rides/EstimateRideRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\DTOs\Coordinates;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/estimate — ver openapi.yaml.
+ */
+class EstimateRideRequest extends FormRequest
+{
+    /**
+     * Cualquier cuenta autenticada puede pedir un estimado: no hay ninguna
+     * decisión de negocio que resolver acá, la ruta ya exige `auth:api`.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Los límites de latitud/longitud repiten los que ya valida el
+     * constructor de `Coordinates`, a propósito: acá el rechazo llega como un
+     * 422 por campo, no como la `InvalidArgumentException` que lanzaría el DTO
+     * si se lo dejara validar a él.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'origin' => ['required', 'array'],
+            'origin.latitude' => ['required', 'numeric', 'between:-90,90'],
+            'origin.longitude' => ['required', 'numeric', 'between:-180,180'],
+            'destination' => ['required', 'array'],
+            'destination.latitude' => ['required', 'numeric', 'between:-90,90'],
+            'destination.longitude' => ['required', 'numeric', 'between:-180,180'],
+        ];
+    }
+
+    public function origin(): Coordinates
+    {
+        return new Coordinates(
+            latitude: $this->float('origin.latitude'),
+            longitude: $this->float('origin.longitude'),
+        );
+    }
+
+    public function destination(): Coordinates
+    {
+        return new Coordinates(
+            latitude: $this->float('destination.latitude'),
+            longitude: $this->float('destination.longitude'),
+        );
+    }
+}

--- a/app/Http/Resources/RideEstimateResource.php
+++ b/app/Http/Resources/RideEstimateResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\DTOs\RideEstimate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa una estimación de viaje según el schema `RideEstimate` de openapi.yaml.
+ *
+ * @property-read RideEstimate $resource
+ */
+class RideEstimateResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'distance_meters' => $this->resource->route->distanceMeters,
+            'duration_seconds' => $this->resource->route->durationSeconds,
+            'currency' => $this->resource->fare->currency,
+            'estimated_fare' => $this->resource->fare->total,
+            // No representa un cobro: el pasajero solo lo usa para decidir si
+            // continúa, el monto final se recalcula al completar el viaje
+            // (historia #24). Se declara acá en vez de dejar que el nombre del
+            // campo lo insinúe, porque el issue #14 lo pide explícito.
+            'is_estimate' => true,
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Exceptions\Auth\InvalidCredentialsException;
+use App\Exceptions\RouteEstimationFailed;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -68,6 +69,19 @@ return Application::configure(basePath: dirname(__DIR__))
             fn (InvalidCredentialsException $e) => new JsonResponse(
                 ['message' => $e->getMessage()],
                 JsonResponse::HTTP_UNAUTHORIZED,
+            ),
+        );
+
+        // El proveedor de mapas no pudo entregar una ruta utilizable (fuera de
+        // cobertura, no contactable, o una respuesta que no se pudo leer). Es
+        // 422 y no 502/503: para quien pidió la estimación es indistinguible
+        // de una entrada que su formulario no puede resolver, y el mensaje
+        // genérico no filtra cuál de los tres motivos fue (ver
+        // RouteEstimationFailed).
+        $exceptions->render(
+            fn (RouteEstimationFailed $e) => new JsonResponse(
+                ['message' => 'No fue posible calcular una ruta entre esas coordenadas. Puede que la zona no esté cubierta por el servicio.'],
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
             ),
         );
     })->create();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -803,6 +803,93 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/estimate:
+    post:
+      tags:
+        - Rides
+      operationId: estimateRide
+      summary: Ver la tarifa estimada de un viaje antes de solicitarlo
+      description: >-
+        Le muestra al pasajero cuánto costaría un viaje entre dos coordenadas
+        antes de pedirlo (historia #14). No crea nada — el modelo `Ride` todavía
+        no existe (historia #15) — así que es solo una consulta contra el
+        proveedor de mapas y el motor de tarifa configurados, con la misma
+        fórmula que se usa para cobrar el viaje real.
+
+        No cuelga de `/me` como el vehículo: no es un sub-recurso de la
+        cuenta, es una consulta puntual. Requiere un token vigente igual que
+        el resto de la API, y no solo el límite de tasa de los endpoints
+        anónimos, porque cada request golpea al proveedor de mapas, que se
+        paga por consulta.
+
+        `estimated_fare` no representa un cobro: la respuesta lo marca
+        explícitamente con `is_estimate: true`. El monto final del viaje se
+        recalcula al completarlo (historia #24) con el trayecto realmente
+        recorrido, no con este estimado.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RideEstimateRequest"
+            example:
+              origin:
+                latitude: 4.710989
+                longitude: -74.072092
+              destination:
+                latitude: 4.698
+                longitude: -74.061
+      responses:
+        "200":
+          description: Distancia, duración y tarifa estimadas del trayecto.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RideEstimate"
+              example:
+                data:
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  is_estimate: true
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "422":
+          description: >-
+            La entrada no pasó la validación (falta una coordenada o está
+            fuera de rango), o el proveedor de mapas no encontró una ruta
+            entre origen y destino (zona sin cobertura).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The origin.latitude field must be between -90 and 90.
+                errors:
+                  origin.latitude:
+                    - The origin.latitude field must be between -90 and 90.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -1222,6 +1309,74 @@ components:
             máximo es el año en curso más uno, por eso no se fija acá como
             número.
           example: 2023
+    Coordinates:
+      type: object
+      description: Un punto geográfico.
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+          example: 4.710989
+        longitude:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+          example: -74.072092
+    RideEstimateRequest:
+      type: object
+      description: Origen y destino entre los que se quiere estimar un viaje.
+      required:
+        - origin
+        - destination
+      properties:
+        origin:
+          $ref: "#/components/schemas/Coordinates"
+        destination:
+          $ref: "#/components/schemas/Coordinates"
+    RideEstimate:
+      type: object
+      description: >-
+        Distancia, duración y tarifa estimadas de un trayecto entre dos
+        coordenadas, calculadas con el proveedor de mapas y la tarifa
+        vigentes.
+      required:
+        - distance_meters
+        - duration_seconds
+        - currency
+        - estimated_fare
+        - is_estimate
+      properties:
+        distance_meters:
+          type: integer
+          description: Distancia del trayecto, en metros.
+          example: 7421
+        duration_seconds:
+          type: integer
+          description: Duración estimada del trayecto, en segundos.
+          example: 842
+        currency:
+          type: string
+          description: Código ISO 4217 de tres letras de la moneda del monto.
+          example: COP
+        estimated_fare:
+          type: integer
+          description: >-
+            Monto estimado del viaje, entero en la unidad mínima de
+            `currency` (ver la nota sobre dinero en config/fares.php).
+          example: 8850
+        is_estimate:
+          type: boolean
+          description: >-
+            Siempre `true`: este monto no representa un cobro y puede variar
+            en el monto final, que se recalcula al completar el viaje con el
+            trayecto realmente recorrido.
+          example: true
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
+use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
@@ -85,4 +86,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me/vehicle', UpdateVehicleController::class)
         ->name('vehicles.update');
+
+    // No cuelga de `me` como el vehículo: no es un sub-recurso de la cuenta,
+    // es una consulta puntual que no persiste nada (historia #14). Exige
+    // `auth:api` igual que el resto de la API y no solo `throttle:auth`
+    // porque cada request golpea al proveedor de mapas, que se paga por
+    // consulta — dejarlo anónimo abriría la puerta a agotar la cuota del
+    // proveedor sin que haya una cuenta a la que atribuírselo.
+    Route::middleware('auth:api')
+        ->post('rides/estimate', EstimateRideController::class)
+        ->name('rides.estimate');
 });

--- a/tests/Feature/Rides/EstimateRideTest.php
+++ b/tests/Feature/Rides/EstimateRideTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/estimate — ver openapi.yaml.
+ *
+ * Lo que fija esta suite: que la respuesta traiga distancia, duración y monto
+ * estimado calculados con el proveedor de mapas y la tarifa vigentes, que una
+ * zona sin ruta disponible responda 422 en vez de reventar, y que el endpoint
+ * exija un token vigente igual que el resto de la API.
+ */
+class EstimateRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/rides/estimate';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('maps.provider', 'google');
+        Config::set('maps.google.key', 'test-key');
+
+        Config::set('fares.currency', 'COP');
+        Config::set('fares.base', 1500);
+        Config::set('fares.per_kilometer', 800);
+        Config::set('fares.per_minute', 100);
+        Config::set('fares.per_waiting_minute', 60);
+        Config::set('fares.minimum', 3000);
+        Config::set('fares.rounding_step', 50);
+    }
+
+    public function test_devuelve_distancia_duracion_y_tarifa_estimada(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response([
+                'routes' => [['distanceMeters' => 7421, 'duration' => '842s']],
+            ]),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'distance_meters' => 7421,
+                    'duration_seconds' => 842,
+                    'currency' => 'COP',
+                    'estimated_fare' => 8850,
+                    'is_estimate' => true,
+                ],
+            ]);
+    }
+
+    public function test_indica_explicitamente_que_el_monto_es_un_estimado(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response([
+                'routes' => [['distanceMeters' => 1000, 'duration' => '120s']],
+            ]),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertOk()
+            ->assertJsonPath('data.is_estimate', true);
+    }
+
+    public function test_responde_422_cuando_no_hay_ruta_entre_las_coordenadas(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response(['routes' => []]),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        Http::fake();
+
+        $this->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_rechaza_coordenadas_faltantes(): void
+    {
+        Http::fake();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors([
+                'origin.latitude',
+                'origin.longitude',
+                'destination.latitude',
+                'destination.longitude',
+            ]);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_rechaza_una_latitud_fuera_de_rango(): void
+    {
+        Http::fake();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [
+                ...$this->datosValidos(),
+                'origin' => ['latitude' => 95.0, 'longitude' => -74.0],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('origin.latitude');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_rechaza_una_longitud_fuera_de_rango(): void
+    {
+        Http::fake();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [
+                ...$this->datosValidos(),
+                'destination' => ['latitude' => 4.7, 'longitude' => 200.0],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('destination.longitude');
+
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function datosValidos(): array
+    {
+        return [
+            'origin' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+            'destination' => ['latitude' => 4.698, 'longitude' => -74.061],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #14

## Qué hace

Agrega `POST /api/v1/rides/estimate`: dado un origen y un destino, devuelve la
distancia, la duración y la tarifa estimadas del trayecto, usando el
proveedor de mapas (`RouteEstimator`) y el motor de tarifa
(`CalculateFareAction`) ya existentes en el repo. No persiste nada — el
modelo `Ride` todavía no existe (historia #15) — así que es una consulta
pura.

- `RideEstimateRequest`: valida `origin`/`destination` como pares
  `{latitude, longitude}` dentro de rango.
- `EstimateRideController`: orquesta `RouteEstimator` + `CalculateFareAction`
  y responde vía `RideEstimateResource`.
- La respuesta marca explícitamente `is_estimate: true` (criterio de
  aceptación del issue: el monto no representa un cobro).
- `RouteEstimationFailed` (proveedor sin ruta disponible, es decir zona sin
  cobertura) se traduce a 422 en `bootstrap/app.php`, junto al resto de
  errores de dominio ya mapeados ahí.
- Requiere `auth:api` igual que el resto de la API — no es un endpoint
  anónimo, porque cada request golpea al proveedor de mapas, que se cobra
  por consulta.
- `openapi.yaml` actualizado primero (SDD) con el endpoint y los schemas
  `Coordinates`, `RideEstimateRequest`, `RideEstimate`.

## Cómo se probó

- `tests/Feature/Rides/EstimateRideTest.php` (7 tests), escritos antes de la
  implementación y confirmados en rojo (404) antes de escribir el código.
  Cubren: respuesta 200 con distancia/duración/tarifa correctas, el flag
  `is_estimate`, 422 cuando el proveedor no encuentra ruta, 401 sin token, y
  422 con `assertJsonValidationErrors` para coordenadas faltantes/fuera de
  rango.
- `php artisan test`: 298/298 en verde (suite completa, sin regresiones).
- `vendor/bin/pint --test`: sin errores.
- `phpstan analyse app routes --level=5`: sin errores.

## Decisiones y riesgos

- No agrego un role check (Policy): tanto pasajero como conductor pueden
  pedir un estimado, y el issue no pide restringirlo por rol.
- No valido que origen y destino sean distintos: ese criterio es de la
  historia #15 (crear el viaje), no de esta.
- No pude correr los scripts de conformidad de la skill
  `laravel-feature-workflow` (`static_conformance.py` /
  `dynamic_conformance.py`): este entorno no tiene un intérprete de Python
  real instalado (solo el alias de Microsoft Store, que no resuelve). Verifiqué
  el spec manualmente (estructura, referencias, indentación) contra el
  patrón ya usado en `/me/vehicle`, y los campos de `RideEstimateResource`
  coinciden 1:1 con el schema `RideEstimate` agregado. Si el REVISOR tiene
  Python disponible, vale la pena correr ambos scripts sobre esta rama antes
  de aprobar.

🤖 Generado con [Claude Code](https://claude.com/claude-code)