### PR TITLE
feat(#15): solicitar un viaje

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -391,13 +391,17 @@ personas concretas.
   sin levantar HTTP. Los canales se registran en `App\Providers\BroadcastServiceProvider`.
 - Todos los canales declaran `['guards' => ['api']]` de forma explícita: la API es
   stateless con JWT y no existe el guard `web`.
-- El canal `ride.{id}` ya tiene su regla definitiva, pero el modelo `Ride` llega con
-  la historia #15. Hasta entonces resuelve los participantes contra
+- El canal `ride.{id}` ya tiene su regla definitiva y resuelve los participantes contra
   `App\Services\Realtime\RideParticipants`, cuya implementación registrada
   (`PendingRideParticipants`) no conoce ningún viaje y por lo tanto **deniega todo**.
   Fallar cerrado es la única opción aceptable acá: un canal abierto "provisionalmente"
-  expone posiciones en vivo a cualquier usuario autenticado que adivine un id. Cuando
-  exista la tabla, se cambia el binding en `AppServiceProvider` y nada más.
+  expone posiciones en vivo a cualquier usuario autenticado que adivine un id.
+  La tabla `rides` ya existe (#15), así que lo único que falta es cambiar el binding en
+  `AppServiceProvider` por una implementación con Eloquent — ni el canal ni
+  `routes/channels.php` se tocan. Ese cambio **no** se hizo en #15: abrir el canal es
+  lo que consumen las historias de tracking (#20, #21), y son ellas las que tienen los
+  criterios de aceptación de qué se emite y quién lo escucha. Mientras tanto el canal
+  sigue denegando todo, que es el estado seguro.
 
 ### La ruta de autorización es una ruta de la API
 
@@ -653,6 +657,63 @@ tiene criterio de aceptación para ellos y almacenarlos exige decidir antes dón
 los archivos y quién los verifica — la verificación administrativa está declarada fuera
 de alcance en el propio issue); actualizar el vehículo (#13); y que un conductor tenga
 más de una moto.
+
+## Solicitud de viaje (decidido en #15)
+
+`POST /api/v1/rides` crea la solicitud del pasajero autenticado entre dos coordenadas.
+Responde **201** con el schema `Ride`. El viaje nace en `requested` y espera a que un
+conductor lo acepte: la API **no asigna conductor** por su cuenta (explícitamente fuera
+de alcance en la historia).
+
+- **Es un recurso propio y no un sub-recurso de `/me`**, al revés que el vehículo. La
+  diferencia no es de gusto: al viaje se llega por su id —es el `{rideId}` del canal
+  privado `ride.{id}`— y del otro lado lo van a operar dos cuentas distintas, el
+  pasajero y el conductor asignado. Por eso `RideResource` **sí** publica el `id`,
+  aunque siga sin publicar el `passenger_id`.
+- **Solicitar un viaje es del rol pasajero, y lo decide `RidePolicy`**: una cuenta de
+  conductor recibe **403**, no 422, por el mismo criterio que el pasajero que intenta
+  registrar una moto. La Policy se invoca desde `authorize()` del Form Request para
+  que el 403 se resuelva antes que la validación. El conductor no queda afuera del
+  producto: consigue viajes aceptando los que ya existen (#18).
+- **El trayecto y la tarifa se calculan al crear el viaje y se guardan con él.** Salen
+  del mismo `RouteEstimator` y de la misma `CalculateFareAction` que `POST
+  /rides/estimate`, que es lo que garantiza que el número de antes de pedir el viaje y
+  el de después sean el mismo. Quedan persistidos en vez de recalcularse al consultar
+  el viaje por dos motivos: es el monto que el pasajero aceptó, y cada consulta al
+  proveedor de mapas se paga. El cobro final se recalcula al completarlo (#24).
+- **Si el proveedor no entrega una ruta, no se crea ningún viaje.** La excepción sale
+  antes del INSERT, así que no queda un viaje sin tarifa —que además le dejaría al
+  pasajero un viaje activo que nunca llegó a pedir, bloqueándole el siguiente.
+- **Un viaje activo por pasajero (`requested`, `accepted` o `in_progress`), garantizado
+  por la tabla y no por la validación.** El Form Request lo comprueba para responder
+  **422** bajo la clave `ride` —que no es un campo de la entrada, igual que `vehicle` en
+  el alta de moto—, pero entre esa consulta y el INSERT caben dos solicitudes
+  simultáneas, y en un móvil basta un doble toque. Lo que queda en pie ahí es un índice
+  único sobre `rides.active_passenger_id`, una **columna generada** que vale
+  `passenger_id` mientras el viaje está activo y `NULL` cuando terminó. Es una columna
+  generada y no un índice parcial (`WHERE ...`) porque MySQL no los tiene: así la misma
+  definición vale en SQLite y en MySQL, y como los índices únicos ignoran los `NULL` en
+  ambos, el pasajero acumula viajes terminados sin límite.
+  La lista de estados activos se escribe literal en la migración en vez de leerla de
+  `App\Enums\RideStatus`: una migración ya corrida no vuelve a ejecutarse, así que
+  depender del enum dejaría distintas una base creada hoy y otra creada después de
+  renombrar un caso. `RideSchemaTest` recorre el enum contra la tabla para que esa
+  divergencia falle en la suite y no en producción.
+- **El destino no puede ser el mismo punto que el origen** (422). La comparación es por
+  igualdad exacta: "demasiado cerca para pedir un viaje" es una decisión de producto con
+  un umbral que alguien tiene que fijar, y no es lo que pide la historia.
+- **Las coordenadas se guardan en `decimal`, no en `float`**: la posición de recogida es
+  la que el conductor tiene que encontrar. Los montos siguen siendo enteros en la unidad
+  mínima de la moneda, como todo el dinero del proyecto.
+- **`driver_id` es `nullOnDelete` y `passenger_id` es `cascadeOnDelete`.** Un viaje sin
+  pasajero no es nada que se pueda consultar ni cobrar; borrar al conductor, en cambio,
+  no puede llevarse el viaje del pasajero, que ya ocurrió y tiene un cobro asociado.
+
+Queda **fuera** de #15: la asignación automática de conductor y el aviso a los
+conductores cercanos (#17, que es quien tiene el criterio de aceptación de a quién se
+notifica); aceptar, iniciar, cancelar y completar el viaje (#18, #19, #22, #23, #24);
+consultar un viaje ya creado; y abrir el canal `ride.{id}`, que sigue denegando todo
+hasta que lo necesiten las historias de tracking (ver la sección de Reverb).
 
 ## Proveedor de mapas/geocoding (decidido en #3)
 

--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -129,3 +129,30 @@ es del backend, no del script (que `shouldRenderJsonWhen` aplique también a la 
 protegidos a la vez: merece su propio issue en vez de colarse en el PR de una historia.
 Si se arregla, agregar al script una request de control sin `Accept` para que no
 vuelva a pasar inadvertido.
+
+### 2026-07-31 — Un segundo camino de "verde por omisión": el proveedor de mapas sin configurar
+
+**Qué pasó:** implementando `POST /rides` (#15), el chequeo dinámico habría dado verde
+sin ejecutar nunca el 201, por dos causas independientes que se suman. La conocida (el
+token compartido que `POST /auth/logout` invalida antes) y una nueva: los endpoints que
+llaman al proveedor de mapas responden **422 documentado** cuando no hay
+`GOOGLE_MAPS_API_KEY` en el entorno, porque `RouteEstimationFailed` está mapeada a 422.
+Ese 422 valida contra el schema `Error` y el resultado global es verde — aunque el
+endpoint no haya creado ni un solo viaje. Le pasa igual a `POST /rides/estimate` (#14).
+
+**Por qué pasó:** el spec documenta a propósito el 422 de "zona sin cobertura", así que
+cualquier fallo del proveedor —incluida su ausencia de configuración— cae en una
+respuesta que el contrato permite. No es un bug del script: es que "no hubo fallos" y
+"se probó el camino de éxito" son cosas distintas, y el script solo reporta la primera.
+
+**Cómo evitarlo:** para una feature que dependa del proveedor de mapas, apuntar
+`GOOGLE_MAPS_ROUTES_ENDPOINT` a un stub local (config/maps.php lo permite
+explícitamente para esto) y fijar cualquier `GOOGLE_MAPS_API_KEY` antes de correr el
+servidor; así el 201 se ejecuta de verdad. Después validar ese cuerpo real contra el
+schema del spec con `jsonschema`, **incluyendo la contra-prueba** de que el schema
+rechaza cuerpos inválidos, como ya indican las dos entradas anteriores. Conviene además
+usar una `DB_DATABASE` aparte: el chequeo dinámico escribe filas reales, y contra la
+base de desarrollo dejaría un viaje activo que después bloquea al mismo pasajero.
+La corrección de fondo del script sigue siendo la ya anotada (no compartir un token que
+una operación invalida); esta entrada agrega que, además, el reporte debería decir **qué
+código de estado** respondió cada operación.

--- a/app/Actions/Rides/CreateRideAction.php
+++ b/app/Actions/Rides/CreateRideAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\RideRequest;
+use App\Enums\RideStatus;
+use App\Exceptions\RouteEstimationFailed;
+use App\Models\Ride;
+use App\Models\User;
+use App\Services\Maps\RouteEstimator;
+
+/**
+ * Crea la solicitud de viaje de un pasajero.
+ *
+ * El pasajero llega como parámetro y no dentro del DTO: es lo que garantiza que
+ * el viaje sea siempre de quien invoca el caso de uso (el usuario que resolvió
+ * el guard) y nunca de lo que venga en la entrada.
+ *
+ * El trayecto y la tarifa se calculan acá y se guardan con el viaje, con el
+ * mismo estimador y el mismo motor que usa `POST /rides/estimate`: si cada lado
+ * calculara lo suyo, el pasajero podría ver un número antes de pedir el viaje y
+ * otro después de pedirlo. Quedan guardados en vez de recalcularse al consultar
+ * el viaje porque es el número que el pasajero aceptó —y porque cada consulta al
+ * proveedor de mapas se paga.
+ *
+ * No hay transacción: se escribe una sola fila. Y si el proveedor no entrega una
+ * ruta, la excepción sale antes del INSERT, así que tampoco queda un viaje sin
+ * tarifa —que además dejaría al pasajero con un activo que no llegó a pedir.
+ *
+ * El aviso a los conductores cercanos es de la historia #17; acá el viaje solo
+ * queda disponible.
+ */
+final readonly class CreateRideAction
+{
+    public function __construct(
+        private RouteEstimator $routeEstimator,
+        private CalculateFareAction $calculateFare,
+    ) {}
+
+    /**
+     * @throws RouteEstimationFailed si el proveedor de mapas no encuentra una
+     *                               ruta entre el origen y el destino.
+     */
+    public function handle(User $passenger, RideRequest $request): Ride
+    {
+        $route = $this->routeEstimator->estimate($request->origin, $request->destination);
+        $fare = $this->calculateFare->handle($route);
+
+        return Ride::create([
+            'passenger_id' => $passenger->getKey(),
+            'status' => RideStatus::Requested,
+            'origin_latitude' => $request->origin->latitude,
+            'origin_longitude' => $request->origin->longitude,
+            'destination_latitude' => $request->destination->latitude,
+            'destination_longitude' => $request->destination->longitude,
+            'estimated_distance_meters' => $route->distanceMeters,
+            'estimated_duration_seconds' => $route->durationSeconds,
+            'currency' => $fare->currency,
+            'estimated_fare' => $fare->total,
+        ]);
+    }
+}

--- a/app/DTOs/RideRequest.php
+++ b/app/DTOs/RideRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Lo que un pasajero pide cuando solicita un viaje: de dónde a dónde.
+ *
+ * No lleva pasajero, por la misma razón por la que `VehicleRegistration` no
+ * lleva dueño: quién pide el viaje lo decide quien invoca la Action —el guard,
+ * en el caso del endpoint— y no los datos que manda el cliente. Tampoco lleva
+ * estado ni tarifa: el viaje nace siempre en `requested` y el monto sale del
+ * motor de tarifa, así que ninguno de los dos es una entrada.
+ */
+final readonly class RideRequest
+{
+    public function __construct(
+        public Coordinates $origin,
+        public Coordinates $destination,
+    ) {}
+}

--- a/app/Enums/RideStatus.php
+++ b/app/Enums/RideStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Ciclo de vida de un viaje.
+ *
+ * Los valores viajan tal cual a `rides.status` y al campo `status` del schema
+ * `Ride` de openapi.yaml, así que renombrar uno rompe la base y el contrato
+ * publicado a la vez.
+ */
+enum RideStatus: string
+{
+    case Requested = 'requested';
+    case Accepted = 'accepted';
+    case InProgress = 'in_progress';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+
+    /**
+     * Los estados en los que el viaje todavía ocupa al pasajero y al conductor.
+     *
+     * Es lo que decide si un pasajero puede solicitar otro viaje. La tabla
+     * `rides` repite esta lista en la columna generada que sostiene el índice de
+     * "un viaje activo por pasajero": si acá se agrega un estado activo y allá
+     * no, la regla se cae en silencio. `RideSchemaTest` recorre estos casos
+     * contra la base justamente para que esa divergencia falle en la suite.
+     *
+     * @return array<int, self>
+     */
+    public static function active(): array
+    {
+        return [self::Requested, self::Accepted, self::InProgress];
+    }
+
+    public function isActive(): bool
+    {
+        return in_array($this, self::active(), strict: true);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/CreateRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/CreateRideController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\CreateRideAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\CreateRideRequest;
+use App\Http\Resources\RideResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides
+ *
+ * Crea la solicitud de viaje del pasajero autenticado. El viaje nace en
+ * `requested` y queda esperando a que un conductor lo acepte (historia #18):
+ * esta API no asigna conductor por su cuenta.
+ *
+ * El pasajero sale del guard y no de la entrada, igual que el dueño del
+ * vehículo. La autorización (solo pasajeros) la resuelve `RidePolicy` desde el
+ * Form Request, así que acá no queda ninguna decisión.
+ */
+class CreateRideController extends Controller
+{
+    public function __invoke(
+        CreateRideRequest $request,
+        CreateRideAction $createRide,
+    ): JsonResponse {
+        $ride = $createRide->handle($request->user(), $request->toRideRequest());
+
+        return (new RideResource($ride))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Rides/CreateRideRequest.php
+++ b/app/Http/Requests/Rides/CreateRideRequest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\DTOs\Coordinates;
+use App\DTOs\RideRequest;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides — ver openapi.yaml.
+ */
+class CreateRideRequest extends FormRequest
+{
+    /**
+     * Solicitar un viaje es una operación del rol pasajero: lo decide
+     * `RidePolicy`, no un `isPassenger()` suelto acá.
+     *
+     * Va en el Form Request y no en el controller para que el 403 se resuelva
+     * **antes** que la validación, igual que en el alta de vehículo: al revés,
+     * una cuenta de conductor recibiría un 422 detallándole qué forma tiene que
+     * tener la entrada de un endpoint que de todos modos no puede usar.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create', Ride::class) ?? false;
+    }
+
+    /**
+     * Los límites de latitud/longitud repiten los que ya valida el constructor
+     * de `Coordinates`, igual que en la estimación: acá el rechazo llega como un
+     * 422 por campo y no como la `InvalidArgumentException` del DTO.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'origin' => ['required', 'array'],
+            'origin.latitude' => ['required', 'numeric', 'between:-90,90'],
+            'origin.longitude' => ['required', 'numeric', 'between:-180,180'],
+            'destination' => ['required', 'array'],
+            'destination.latitude' => ['required', 'numeric', 'between:-90,90'],
+            'destination.longitude' => ['required', 'numeric', 'between:-180,180'],
+        ];
+    }
+
+    /**
+     * Las dos reglas que no dependen de un campo suelto.
+     *
+     * Ambas corren antes de que el controller invoque al proveedor de mapas, que
+     * se paga por consulta: un viaje que se va a rechazar no debería gastar una.
+     *
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectRepeatedPoint(...),
+            $this->rejectSecondActiveRide(...),
+        ];
+    }
+
+    /**
+     * Un viaje que empieza y termina en el mismo punto no es un viaje: el
+     * proveedor de mapas devolvería un trayecto de cero metros y el pasajero
+     * pagaría la tarifa mínima por quedarse donde está.
+     *
+     * La comparación es por igualdad exacta y no por cercanía: "demasiado cerca
+     * para pedir un viaje" es una decisión de producto con un umbral que alguien
+     * tiene que fijar, y no es lo que pide la historia.
+     */
+    private function rejectRepeatedPoint(Validator $validator): void
+    {
+        if ($validator->errors()->isNotEmpty()) {
+            return;
+        }
+
+        $sameLatitude = $this->float('origin.latitude') === $this->float('destination.latitude');
+        $sameLongitude = $this->float('origin.longitude') === $this->float('destination.longitude');
+
+        if ($sameLatitude && $sameLongitude) {
+            $validator->errors()->add(
+                'destination',
+                'El destino no puede ser el mismo punto que el origen.',
+            );
+        }
+    }
+
+    /**
+     * El "un viaje activo por pasajero" se comprueba acá y no con una regla
+     * sobre un campo, por el mismo motivo que el segundo vehículo de un
+     * conductor: no lo decide nada de lo que el cliente manda sino el estado de
+     * su cuenta. Por eso el error viaja bajo la clave `ride`, que no es un campo
+     * de la entrada.
+     *
+     * Es 422 y no 409 por la misma razón que allá: para el cliente móvil es el
+     * mismo camino que cualquier otro rechazo del formulario.
+     *
+     * Lo que garantiza la regla cuando dos solicitudes llegan a la vez no es
+     * esta consulta sino el índice único de `rides` (ver la migración); esto
+     * existe para poder responder 422 en vez de 500 en el caso normal.
+     */
+    private function rejectSecondActiveRide(Validator $validator): void
+    {
+        $passenger = $this->user();
+
+        if (! $passenger instanceof User) {
+            return;
+        }
+
+        $hasActiveRide = Ride::query()
+            ->where('passenger_id', $passenger->getKey())
+            ->whereIn('status', RideStatus::active())
+            ->exists();
+
+        if ($hasActiveRide) {
+            $validator->errors()->add(
+                'ride',
+                'Ya tienes un viaje en curso; termínalo o cancélalo antes de solicitar otro.',
+            );
+        }
+    }
+
+    /**
+     * Traduce la entrada validada al DTO que consume la Action, que no conoce
+     * HTTP (ver .claude/STANDARDS.md).
+     */
+    public function toRideRequest(): RideRequest
+    {
+        return new RideRequest(
+            origin: new Coordinates(
+                latitude: $this->float('origin.latitude'),
+                longitude: $this->float('origin.longitude'),
+            ),
+            destination: new Coordinates(
+                latitude: $this->float('destination.latitude'),
+                longitude: $this->float('destination.longitude'),
+            ),
+        );
+    }
+}

--- a/app/Http/Resources/RideResource.php
+++ b/app/Http/Resources/RideResource.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Ride;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa un viaje según el schema `Ride` de openapi.yaml.
+ *
+ * Publica el `id` —al revés que el vehículo y el perfil del conductor— porque
+ * el viaje sí se direcciona por él: es el `{rideId}` del canal privado
+ * `ride.{rideId}` y el que van a llevar los endpoints de aceptar, iniciar y
+ * completar. No publica el `passenger_id`: el viaje se solicita siempre desde la
+ * cuenta que manda el token.
+ *
+ * @property-read Ride $resource
+ */
+class RideResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'status' => $this->resource->status->value,
+            'origin' => [
+                'latitude' => $this->resource->origin_latitude,
+                'longitude' => $this->resource->origin_longitude,
+            ],
+            'destination' => [
+                'latitude' => $this->resource->destination_latitude,
+                'longitude' => $this->resource->destination_longitude,
+            ],
+            'distance_meters' => $this->resource->estimated_distance_meters,
+            'duration_seconds' => $this->resource->estimated_duration_seconds,
+            'currency' => $this->resource->currency,
+            'estimated_fare' => $this->resource->estimated_fare,
+            // ISO-8601 explícito en vez del formato por defecto de Eloquent:
+            // el contrato publica `format: date-time` y el default trae
+            // microsegundos que nadie usa acá.
+            'requested_at' => $this->resource->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\RideStatus;
+use App\Policies\RidePolicy;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Un viaje solicitado por un pasajero.
+ *
+ * Guarda el trayecto y la tarifa que se estimaron al crearlo: el pasajero
+ * aceptó esos números, así que son parte del viaje y no algo que se recalcule
+ * al consultarlo. El cobro final se resuelve al completarlo (historia #24).
+ *
+ * `active_passenger_id` no aparece acá a propósito: es una columna generada por
+ * la base (ver la migración) y escribirla desde la aplicación no tendría efecto
+ * más que romper el INSERT.
+ *
+ * Los atributos con cast se declaran en el docblock porque su tipo real no es
+ * el de la columna (ver .claude/STANDARDS.md).
+ *
+ * @property RideStatus $status
+ * @property int $passenger_id
+ * @property int|null $driver_id
+ * @property float $origin_latitude
+ * @property float $origin_longitude
+ * @property float $destination_latitude
+ * @property float $destination_longitude
+ * @property int $estimated_distance_meters
+ * @property int $estimated_duration_seconds
+ * @property int $estimated_fare
+ */
+#[Fillable([
+    'passenger_id',
+    'driver_id',
+    'status',
+    'origin_latitude',
+    'origin_longitude',
+    'destination_latitude',
+    'destination_longitude',
+    'estimated_distance_meters',
+    'estimated_duration_seconds',
+    'currency',
+    'estimated_fare',
+])]
+#[UsePolicy(RidePolicy::class)]
+class Ride extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'status' => RideStatus::class,
+            'origin_latitude' => 'float',
+            'origin_longitude' => 'float',
+            'destination_latitude' => 'float',
+            'destination_longitude' => 'float',
+            'estimated_distance_meters' => 'integer',
+            'estimated_duration_seconds' => 'integer',
+            'estimated_fare' => 'integer',
+        ];
+    }
+
+    /**
+     * Quien pidió el viaje.
+     *
+     * La relación se llama `passenger` y no `user` porque del otro lado hay dos
+     * cuentas distintas —el pasajero y el conductor asignado— y ambas son
+     * `users`: un nombre genérico acá haría ambigua cualquier consulta.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function passenger(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'passenger_id');
+    }
+
+    /**
+     * El conductor asignado, o `null` mientras nadie haya aceptado el viaje.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function driver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'driver_id');
+    }
+}

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Quién puede operar sobre un viaje.
+ *
+ * Como en `VehiclePolicy`, la autorización de negocio vive acá y no en los
+ * claims del token: el `role` del JWT quedó congelado al emitirse, y una cuenta
+ * que pasó a ser conductor seguiría solicitando viajes como pasajero hasta que
+ * su token venciera.
+ */
+class RidePolicy
+{
+    /**
+     * Solicitar un viaje es una operación del rol pasajero.
+     *
+     * El conductor no queda afuera del producto por esto: consigue viajes
+     * aceptando los que ya existen (historia #18), que es otra operación con su
+     * propia regla.
+     *
+     * Que el pasajero ya tenga un viaje activo **no** se decide acá: eso
+     * responde 422, porque el permiso lo tiene y lo que le falta es terminar o
+     * cancelar el viaje que ya pidió. Mismo criterio que el segundo vehículo de
+     * un conductor en `VehiclePolicy`.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isPassenger();
+    }
+}

--- a/database/factories/RideFactory.php
+++ b/database/factories/RideFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ride>
+ */
+class RideFactory extends Factory
+{
+    /**
+     * Por defecto un viaje recién solicitado y sin conductor: es el único
+     * estado que esta API sabe crear hoy (historia #15), y el punto de partida
+     * del resto del ciclo de vida.
+     *
+     * Las coordenadas caen alrededor de Bogotá para que los datos de prueba se
+     * parezcan a los reales; nada del dominio depende de la ciudad.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'passenger_id' => User::factory(),
+            'driver_id' => null,
+            'status' => RideStatus::Requested,
+            'origin_latitude' => fake()->randomFloat(6, 4.60, 4.78),
+            'origin_longitude' => fake()->randomFloat(6, -74.15, -74.03),
+            'destination_latitude' => fake()->randomFloat(6, 4.60, 4.78),
+            'destination_longitude' => fake()->randomFloat(6, -74.15, -74.03),
+            'estimated_distance_meters' => fake()->numberBetween(500, 20000),
+            'estimated_duration_seconds' => fake()->numberBetween(120, 3600),
+            'currency' => 'COP',
+            // Múltiplo del paso de redondeo, igual que cualquier monto que
+            // salga del motor de tarifa (ver config/fares.php).
+            'estimated_fare' => fake()->numberBetween(60, 600) * 50,
+        ];
+    }
+}

--- a/database/migrations/2026_07_31_000002_create_rides_table.php
+++ b/database/migrations/2026_07_31_000002_create_rides_table.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rides', function (Blueprint $table) {
+            $table->id();
+
+            // Quien pide el viaje. Se borra con la cuenta: un viaje sin
+            // pasajero no es nada que se pueda consultar ni cobrar.
+            $table->foreignId('passenger_id')->constrained('users')->cascadeOnDelete();
+
+            // El conductor llega después: el viaje nace sin asignar y son los
+            // conductores quienes aceptan la solicitud disponible (historia
+            // #18). Es `nullOnDelete` y no `cascade` porque borrar al conductor
+            // no puede llevarse el viaje del pasajero, que ya ocurrió y tiene
+            // un cobro asociado.
+            $table->foreignId('driver_id')->nullable()->constrained('users')->nullOnDelete();
+
+            $table->string('status', 20)->index();
+
+            // Coordenadas del trayecto pedido. `decimal` y no `float`: la
+            // posición de recogida es la que el conductor tiene que encontrar,
+            // y siete decimales dan poco más de un centímetro de resolución.
+            $table->decimal('origin_latitude', 9, 7);
+            $table->decimal('origin_longitude', 10, 7);
+            $table->decimal('destination_latitude', 9, 7);
+            $table->decimal('destination_longitude', 10, 7);
+
+            // Lo que el proveedor de mapas y el motor de tarifa dijeron al
+            // solicitar el viaje. Se guarda con el viaje y no se recalcula al
+            // consultarlo: el pasajero aceptó *este* número, y volver a pedirle
+            // una ruta al proveedor por cada lectura se paga por consulta.
+            $table->unsignedInteger('estimated_distance_meters');
+            $table->unsignedInteger('estimated_duration_seconds');
+            $table->string('currency', 3);
+            // Entero en la unidad mínima de la moneda, nunca float: ver la nota
+            // sobre dinero en .claude/STANDARDS.md.
+            $table->unsignedInteger('estimated_fare');
+
+            $table->timestamps();
+
+            // "Un viaje activo por pasajero", garantizado por el motor y no por
+            // la validación. El Form Request lo adelanta para poder responder
+            // 422 en vez de 500, pero entre su consulta y el INSERT caben dos
+            // solicitudes simultáneas —un doble toque en el móvil alcanza—, y
+            // ahí lo único que queda en pie es el índice.
+            //
+            // Es una columna generada y no un índice parcial (`WHERE ...`)
+            // porque MySQL no los tiene: así la misma definición vale en SQLite
+            // y en MySQL. Vale `passenger_id` mientras el viaje está activo y
+            // NULL cuando terminó, y los índices únicos ignoran los NULL en
+            // ambos motores, así que un pasajero acumula viajes terminados sin
+            // límite y solo puede tener uno vivo.
+            //
+            // La lista de estados se escribe literal en vez de leerla de
+            // `App\Enums\RideStatus`: una migración ya corrida no se vuelve a
+            // ejecutar, así que depender del enum haría que una base creada hoy
+            // y otra creada después de renombrar un caso quedaran distintas.
+            // `RideSchemaTest` recorre el enum contra esta tabla para que la
+            // divergencia falle en la suite y no en producción.
+            $table->unsignedBigInteger('active_passenger_id')
+                ->nullable()
+                ->storedAs("case when status in ('requested', 'accepted', 'in_progress') then passenger_id end");
+
+            $table->unique('active_passenger_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rides');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -803,6 +803,114 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides:
+    post:
+      tags:
+        - Rides
+      operationId: requestRide
+      summary: Solicitar un viaje
+      description: >-
+        Crea la solicitud de viaje del pasajero autenticado entre dos
+        coordenadas (historia #15). El viaje nace en estado `requested` y queda
+        esperando a que un conductor lo acepte (historia #18): la API no asigna
+        conductor por su cuenta.
+
+        Es una operación del rol pasajero y la resuelve `RidePolicy`: una cuenta
+        de conductor recibe **403**, no 422, porque no es una entrada que se
+        pueda corregir mandando otros datos.
+
+        La distancia, la duración y la tarifa se calculan al crear el viaje con
+        el mismo proveedor de mapas y el mismo motor de tarifa que
+        `POST /rides/estimate`, y quedan guardadas con el viaje. `estimated_fare`
+        sigue siendo un estimado: el monto final se recalcula al completarlo
+        (historia #24) con el trayecto realmente recorrido.
+
+        Un pasajero solo puede tener **un viaje activo a la vez** (`requested`,
+        `accepted` o `in_progress`); pedir otro mientras tanto responde 422.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RideRequest"
+            example:
+              origin:
+                latitude: 4.710989
+                longitude: -74.072092
+              destination:
+                latitude: 4.698
+                longitude: -74.061
+      responses:
+        "201":
+          description: El viaje quedó solicitado y espera a que un conductor lo acepte.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: requested
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  requested_at: "2026-07-31T14:03:21+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta no es de pasajero. Solicitar un viaje es una operación del
+            rol pasajero; un conductor consigue viajes aceptando los que ya
+            existen (historia #18).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: >-
+            La entrada no pasó la validación (falta una coordenada, está fuera
+            de rango, o el destino es el mismo punto que el origen), el pasajero
+            ya tiene un viaje activo, o el proveedor de mapas no encontró una
+            ruta entre origen y destino (zona sin cobertura).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Ya tienes un viaje en curso; termínalo o cancélalo antes de solicitar otro.
+                errors:
+                  ride:
+                    - Ya tienes un viaje en curso; termínalo o cancélalo antes de solicitar otro.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /rides/estimate:
     post:
       tags:
@@ -811,10 +919,11 @@ paths:
       summary: Ver la tarifa estimada de un viaje antes de solicitarlo
       description: >-
         Le muestra al pasajero cuánto costaría un viaje entre dos coordenadas
-        antes de pedirlo (historia #14). No crea nada — el modelo `Ride` todavía
-        no existe (historia #15) — así que es solo una consulta contra el
-        proveedor de mapas y el motor de tarifa configurados, con la misma
-        fórmula que se usa para cobrar el viaje real.
+        antes de pedirlo (historia #14). No crea nada: es solo una consulta
+        contra el proveedor de mapas y el motor de tarifa configurados, con la
+        misma fórmula que se usa para cobrar el viaje real. Para solicitar el
+        viaje de verdad está `POST /rides` (historia #15), que vuelve a calcular
+        estos mismos números y los guarda con el viaje.
 
         No cuelga de `/me` como el vehículo: no es un sub-recurso de la
         cuenta, es una consulta puntual. Requiere un token vigente igual que
@@ -1377,6 +1486,93 @@ components:
             en el monto final, que se recalcula al completar el viaje con el
             trayecto realmente recorrido.
           example: true
+    RideRequest:
+      type: object
+      description: >-
+        Origen y destino del viaje que el pasajero quiere solicitar.
+
+        Tiene la misma forma que `RideEstimateRequest` a propósito, para que la
+        app pueda mandar el mismo cuerpo con el que estimó la tarifa. Son dos
+        schemas y no uno porque son la entrada de dos operaciones distintas y
+        pueden divergir (un método de pago o una nota para el conductor tendrían
+        sentido acá y no en la estimación).
+      required:
+        - origin
+        - destination
+      properties:
+        origin:
+          $ref: "#/components/schemas/Coordinates"
+        destination:
+          $ref: "#/components/schemas/Coordinates"
+    Ride:
+      type: object
+      description: >-
+        Un viaje solicitado por un pasajero, con el trayecto y la tarifa que se
+        estimaron al crearlo.
+
+        No publica el `passenger_id`: el viaje se solicita siempre desde la
+        cuenta que manda el token, igual que el vehículo del conductor. Tampoco
+        trae al conductor asignado, que todavía no existe cuando el viaje nace
+        (lo asigna la historia #18).
+      required:
+        - id
+        - status
+        - origin
+        - destination
+        - distance_meters
+        - duration_seconds
+        - currency
+        - estimated_fare
+        - requested_at
+      properties:
+        id:
+          type: integer
+          description: >-
+            Identificador del viaje. Es el `{rideId}` del canal privado
+            `ride.{rideId}` por el que viajan sus cambios de estado.
+          example: 1
+        status:
+          type: string
+          description: >-
+            Estado del viaje. Nace en `requested`; el resto de los valores los
+            producen las historias de aceptar (#18), iniciar (#19), completar
+            (#24) y cancelar (#22, #23).
+          enum:
+            - requested
+            - accepted
+            - in_progress
+            - completed
+            - cancelled
+          example: requested
+        origin:
+          $ref: "#/components/schemas/Coordinates"
+        destination:
+          $ref: "#/components/schemas/Coordinates"
+        distance_meters:
+          type: integer
+          description: Distancia estimada del trayecto al solicitarlo, en metros.
+          example: 7421
+        duration_seconds:
+          type: integer
+          description: Duración estimada del trayecto al solicitarlo, en segundos.
+          example: 842
+        currency:
+          type: string
+          description: Código ISO 4217 de tres letras de la moneda del monto.
+          example: COP
+        estimated_fare:
+          type: integer
+          description: >-
+            Monto estimado del viaje al solicitarlo, entero en la unidad mínima
+            de `currency` (ver la nota sobre dinero en config/fares.php). No es
+            un cobro: el monto final se recalcula al completar el viaje con el
+            trayecto realmente recorrido.
+          example: 8850
+        requested_at:
+          type: string
+          format: date-time
+          description: Momento en que se creó la solicitud.
+          example: "2026-07-31T14:03:21+00:00"
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
+use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
@@ -86,6 +87,15 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me/vehicle', UpdateVehicleController::class)
         ->name('vehicles.update');
+
+    // La solicitud de viaje (historia #15). Es un recurso propio y no un
+    // sub-recurso de `me`: se direcciona por su id —es el `{rideId}` del canal
+    // privado `ride.{id}`— y del otro lado lo van a operar tanto el pasajero
+    // como el conductor asignado. Que solo los pasajeros puedan crearlo lo
+    // decide `RidePolicy`, no un middleware de rol acá.
+    Route::middleware('auth:api')
+        ->post('rides', CreateRideController::class)
+        ->name('rides.store');
 
     // No cuelga de `me` como el vehículo: no es un sub-recurso de la cuenta,
     // es una consulta puntual que no persiste nada (historia #14). Exige

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides — ver openapi.yaml.
+ *
+ * Es el núcleo del producto: lo que fija esta suite es que el viaje nazca en
+ * `requested` con su trayecto y su tarifa ya calculados, que sea del pasajero
+ * que manda el token y no de quien venga en la entrada, y que un pasajero no
+ * pueda tener dos viajes activos a la vez.
+ */
+class RequestRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/rides';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('maps.provider', 'google');
+        Config::set('maps.google.key', 'test-key');
+
+        Config::set('fares.currency', 'COP');
+        Config::set('fares.base', 1500);
+        Config::set('fares.per_kilometer', 800);
+        Config::set('fares.per_minute', 100);
+        Config::set('fares.per_waiting_minute', 60);
+        Config::set('fares.minimum', 3000);
+        Config::set('fares.rounding_step', 50);
+    }
+
+    public function test_crea_el_viaje_en_estado_requested_con_su_id_y_tarifa_estimada(): void
+    {
+        $this->fakeRuta(distanciaMetros: 7421, duracionSegundos: 842);
+        $pasajero = User::factory()->create();
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $viaje = Ride::sole();
+
+        $respuesta->assertExactJson([
+            'data' => [
+                'id' => $viaje->id,
+                'status' => 'requested',
+                'origin' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+                'destination' => ['latitude' => 4.698, 'longitude' => -74.061],
+                'distance_meters' => 7421,
+                'duration_seconds' => 842,
+                'currency' => 'COP',
+                'estimated_fare' => 8850,
+                'requested_at' => $viaje->created_at?->toIso8601String(),
+            ],
+        ]);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'passenger_id' => $pasajero->id,
+            'status' => RideStatus::Requested->value,
+            'estimated_distance_meters' => 7421,
+            'estimated_duration_seconds' => 842,
+            'estimated_fare' => 8850,
+            'currency' => 'COP',
+        ]);
+    }
+
+    public function test_el_viaje_nace_sin_conductor_asignado(): void
+    {
+        // La asignación automática está fuera de alcance: son los conductores
+        // quienes aceptan la solicitud disponible (historia #18).
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated()
+            ->assertJsonMissingPath('data.driver_id');
+
+        $this->assertNull(Ride::sole()->driver_id);
+    }
+
+    public function test_el_viaje_queda_del_pasajero_del_token_y_no_de_otra_cuenta(): void
+    {
+        $this->fakeRuta();
+        $otro = User::factory()->create();
+        $propio = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($propio))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertDatabaseHas('rides', ['passenger_id' => $propio->id]);
+        $this->assertDatabaseMissing('rides', ['passenger_id' => $otro->id]);
+    }
+
+    public function test_ignora_el_pasajero_el_estado_y_la_tarifa_que_vengan_en_la_entrada(): void
+    {
+        // Nada de lo que manda el cliente puede decidir de quién es el viaje,
+        // en qué estado nace ni cuánto cuesta: el dueño sale del guard y los
+        // números del proveedor de mapas más el motor de tarifa.
+        $this->fakeRuta(distanciaMetros: 7421, duracionSegundos: 842);
+        $victima = User::factory()->create();
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, [
+                ...$this->datosValidos(),
+                'passenger_id' => $victima->id,
+                'status' => RideStatus::Completed->value,
+                'estimated_fare' => 1,
+            ])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('rides', [
+            'passenger_id' => $pasajero->id,
+            'status' => RideStatus::Requested->value,
+            'estimated_fare' => 8850,
+        ]);
+        $this->assertDatabaseMissing('rides', ['passenger_id' => $victima->id]);
+    }
+
+    #[DataProvider('estadosActivos')]
+    public function test_rechaza_un_segundo_viaje_cuando_ya_tiene_uno_activo(RideStatus $estado): void
+    {
+        $this->fakeRuta();
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => $estado]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseCount('rides', 1);
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosActivos(): array
+    {
+        return array_reduce(
+            RideStatus::active(),
+            static fn (array $casos, RideStatus $estado): array => [...$casos, $estado->value => [$estado]],
+            [],
+        );
+    }
+
+    public function test_no_consulta_al_proveedor_de_mapas_si_el_pasajero_ya_tiene_un_viaje_activo(): void
+    {
+        // Cada consulta al proveedor se paga: el rechazo tiene que resolverse
+        // antes de gastarla, igual que el 403 del conductor.
+        $this->fakeRuta();
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable();
+
+        Http::assertNothingSent();
+    }
+
+    public function test_permite_solicitar_otro_viaje_cuando_el_anterior_ya_termino(): void
+    {
+        $this->fakeRuta();
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Completed]);
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Cancelled]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertDatabaseCount('rides', 3);
+    }
+
+    public function test_el_viaje_activo_de_otro_pasajero_no_bloquea_la_solicitud(): void
+    {
+        $this->fakeRuta();
+        Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    public function test_rechaza_un_destino_igual_al_origen(): void
+    {
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [
+                'origin' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+                'destination' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('destination');
+
+        $this->assertDatabaseCount('rides', 0);
+        Http::assertNothingSent();
+    }
+
+    #[DataProvider('coordenadasInvalidas')]
+    public function test_rechaza_coordenadas_invalidas(array $entrada, array $camposConError): void
+    {
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $entrada)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors($camposConError);
+
+        $this->assertDatabaseCount('rides', 0);
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, array<int, string>}>
+     */
+    public static function coordenadasInvalidas(): array
+    {
+        $validas = [
+            'origin' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+            'destination' => ['latitude' => 4.698, 'longitude' => -74.061],
+        ];
+
+        return [
+            'cuerpo vacío' => [[], [
+                'origin.latitude', 'origin.longitude',
+                'destination.latitude', 'destination.longitude',
+            ]],
+            'sin destino' => [['origin' => $validas['origin']], [
+                'destination.latitude', 'destination.longitude',
+            ]],
+            'latitud de origen fuera de rango' => [
+                [...$validas, 'origin' => ['latitude' => 95.0, 'longitude' => -74.0]],
+                ['origin.latitude'],
+            ],
+            'longitud de destino fuera de rango' => [
+                [...$validas, 'destination' => ['latitude' => 4.7, 'longitude' => 200.0]],
+                ['destination.longitude'],
+            ],
+            'coordenada no numérica' => [
+                [...$validas, 'origin' => ['latitude' => 'norte', 'longitude' => -74.0]],
+                ['origin.latitude'],
+            ],
+        ];
+    }
+
+    public function test_responde_422_cuando_no_hay_ruta_entre_las_coordenadas(): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response(['routes' => []]),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnprocessable()
+            ->assertJsonStructure(['message']);
+
+        // Sin trayecto no hay tarifa, y sin tarifa no hay viaje que guardar:
+        // un viaje a medias dejaría al pasajero con un activo que no pidió.
+        $this->assertDatabaseCount('rides', 0);
+    }
+
+    public function test_la_cuenta_de_conductor_no_puede_solicitar_un_viaje(): void
+    {
+        // 403 y no 422: no es una entrada que se pueda corregir mandando otros
+        // datos, es una operación que el rol no tiene. Un conductor consigue
+        // viajes aceptando los que ya existen (historia #18).
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('rides', 0);
+        Http::assertNothingSent();
+    }
+
+    public function test_al_conductor_le_responde_403_aunque_los_datos_sean_invalidos(): void
+    {
+        // La autorización corre antes que la validación: si no, el 422 le
+        // diría a una cuenta sin permiso qué forma tiene que tener la entrada.
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson(self::URI, [])
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $this->fakeRuta();
+
+        $this->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('rides', 0);
+        Http::assertNothingSent();
+    }
+
+    public function test_rechaza_la_solicitud_con_un_token_ilegible(): void
+    {
+        $this->fakeRuta();
+
+        $this->withToken('no-es-un-jwt')
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('rides', 0);
+    }
+
+    public function test_rechaza_la_solicitud_con_un_token_expirado(): void
+    {
+        $this->fakeRuta();
+        $token = JWTAuth::fromUser(User::factory()->create());
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseCount('rides', 0);
+    }
+
+    private function fakeRuta(int $distanciaMetros = 7421, int $duracionSegundos = 842): void
+    {
+        Http::fake([
+            'routes.googleapis.com/*' => Http::response([
+                'routes' => [[
+                    'distanceMeters' => $distanciaMetros,
+                    'duration' => "{$duracionSegundos}s",
+                ]],
+            ]),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function datosValidos(): array
+    {
+        return [
+            'origin' => ['latitude' => 4.710989, 'longitude' => -74.072092],
+            'destination' => ['latitude' => 4.698, 'longitude' => -74.061],
+        ];
+    }
+}

--- a/tests/Feature/Rides/RideSchemaTest.php
+++ b/tests/Feature/Rides/RideSchemaTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Throwable;
+
+/**
+ * Lo que garantiza la tabla `rides`, no la validación.
+ *
+ * El "un viaje activo por pasajero" lo sostiene un índice único sobre una
+ * columna generada, y esa columna repite la lista de estados activos en SQL. Si
+ * el enum gana un estado activo y la migración no, la regla se cae en silencio:
+ * estos tests recorren `RideStatus::cases()` justamente para que esa divergencia
+ * falle acá y no en producción.
+ */
+class RideSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('estadosActivos')]
+    public function test_el_pasajero_no_puede_tener_dos_viajes_activos(RideStatus $estado): void
+    {
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => $estado]);
+
+        $this->expectException(QueryException::class);
+
+        try {
+            Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+        } finally {
+            $this->assertDatabaseCount('rides', 1);
+        }
+    }
+
+    #[DataProvider('estadosTerminados')]
+    public function test_el_viaje_terminado_no_bloquea_una_solicitud_nueva(RideStatus $estado): void
+    {
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => $estado]);
+
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    #[DataProvider('estadosTerminados')]
+    public function test_el_pasajero_acumula_viajes_terminados_sin_limite(RideStatus $estado): void
+    {
+        $pasajero = User::factory()->create();
+
+        Ride::factory()->count(3)->for($pasajero, 'passenger')->create(['status' => $estado]);
+
+        $this->assertDatabaseCount('rides', 3);
+    }
+
+    public function test_el_viaje_activo_de_otro_pasajero_no_choca(): void
+    {
+        Ride::factory()->create(['status' => RideStatus::Requested]);
+        Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    public function test_liberar_el_viaje_activo_habilita_al_pasajero_de_nuevo(): void
+    {
+        // La columna generada se recalcula sola al cambiar el estado: no hace
+        // falta que ninguna Action se acuerde de liberar nada.
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $viaje->update(['status' => RideStatus::Completed]);
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    public function test_borrar_al_pasajero_se_lleva_sus_viajes(): void
+    {
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $pasajero->delete();
+
+        $this->assertDatabaseCount('rides', 0);
+    }
+
+    public function test_el_conductor_asignado_es_opcional(): void
+    {
+        $viaje = Ride::factory()->create();
+
+        $this->assertNull($viaje->driver_id);
+    }
+
+    public function test_el_viaje_conoce_a_su_pasajero(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $this->assertTrue($viaje->passenger->is($pasajero));
+    }
+
+    public function test_rechaza_un_estado_que_no_es_del_enum(): void
+    {
+        // La columna generada compara contra una lista fija de valores; un
+        // estado escrito a mano quedaría fuera de ella y se saltaría el índice
+        // sin que nadie se entere.
+        $this->expectException(Throwable::class);
+
+        Ride::factory()->create(['status' => 'esperando-al-mecanico']);
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosActivos(): array
+    {
+        return self::casosPorValor(array_filter(
+            RideStatus::cases(),
+            static fn (RideStatus $estado): bool => $estado->isActive(),
+        ));
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosTerminados(): array
+    {
+        return self::casosPorValor(array_filter(
+            RideStatus::cases(),
+            static fn (RideStatus $estado): bool => ! $estado->isActive(),
+        ));
+    }
+
+    /**
+     * @param  array<int, RideStatus>  $estados
+     * @return array<string, array{RideStatus}>
+     */
+    private static function casosPorValor(array $estados): array
+    {
+        return array_reduce(
+            $estados,
+            static fn (array $casos, RideStatus $estado): array => [...$casos, $estado->value => [$estado]],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Actions/Rides/CreateRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CreateRideActionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\CreateRideAction;
+use App\DTOs\Coordinates;
+use App\DTOs\RideRequest;
+use App\DTOs\RouteEstimate;
+use App\Enums\RideStatus;
+use App\Exceptions\RouteEstimationFailed;
+use App\Models\Ride;
+use App\Models\User;
+use App\Services\Maps\RouteEstimator;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP: es lo que garantiza que el
+ * caso de uso sirva igual desde un comando o un job (ver .claude/STANDARDS.md).
+ */
+class CreateRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('fares.currency', 'COP');
+        Config::set('fares.base', 1500);
+        Config::set('fares.per_kilometer', 800);
+        Config::set('fares.per_minute', 100);
+        Config::set('fares.per_waiting_minute', 60);
+        Config::set('fares.minimum', 3000);
+        Config::set('fares.rounding_step', 50);
+    }
+
+    public function test_crea_el_viaje_en_requested_con_el_trayecto_y_la_tarifa_estimados(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $viaje = $this->action(new RouteEstimate(7421, 842))->handle($pasajero, $this->solicitud());
+
+        $this->assertTrue($viaje->exists);
+        $this->assertSame(RideStatus::Requested, $viaje->status);
+        $this->assertSame(7421, $viaje->estimated_distance_meters);
+        $this->assertSame(842, $viaje->estimated_duration_seconds);
+        $this->assertSame(8850, $viaje->estimated_fare);
+        $this->assertSame('COP', $viaje->currency);
+    }
+
+    public function test_guarda_el_origen_y_el_destino_recibidos(): void
+    {
+        $viaje = $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        $this->assertSame(4.710989, $viaje->origin_latitude);
+        $this->assertSame(-74.072092, $viaje->origin_longitude);
+        $this->assertSame(4.698, $viaje->destination_latitude);
+        $this->assertSame(-74.061, $viaje->destination_longitude);
+    }
+
+    public function test_el_pasajero_sale_del_parametro_y_no_del_dto(): void
+    {
+        // `RideRequest` no tiene campo de pasajero a propósito, igual que el DTO
+        // del alta de vehículo: quién pide el viaje lo decide quien invoca el
+        // caso de uso (el guard, en el endpoint), no la entrada del cliente.
+        $pasajero = User::factory()->create();
+
+        $viaje = $this->action()->handle($pasajero, $this->solicitud());
+
+        $this->assertSame($pasajero->id, $viaje->passenger_id);
+        $this->assertNull($viaje->driver_id);
+    }
+
+    public function test_estima_el_trayecto_entre_el_origen_y_el_destino_recibidos(): void
+    {
+        $estimador = new class implements RouteEstimator
+        {
+            public ?Coordinates $origin = null;
+
+            public ?Coordinates $destination = null;
+
+            public function estimate(Coordinates $origin, Coordinates $destination): RouteEstimate
+            {
+                $this->origin = $origin;
+                $this->destination = $destination;
+
+                return new RouteEstimate(1000, 120);
+            }
+        };
+
+        $this->app->instance(RouteEstimator::class, $estimador);
+        $this->app->make(CreateRideAction::class)->handle(User::factory()->create(), $this->solicitud());
+
+        $this->assertSame(4.710989, $estimador->origin?->latitude);
+        $this->assertSame(-74.061, $estimador->destination?->longitude);
+    }
+
+    public function test_no_deja_ningun_viaje_si_el_proveedor_no_entrega_una_ruta(): void
+    {
+        $estimador = new class implements RouteEstimator
+        {
+            public function estimate(Coordinates $origin, Coordinates $destination): RouteEstimate
+            {
+                throw RouteEstimationFailed::noRouteAvailable('google');
+            }
+        };
+
+        $this->app->instance(RouteEstimator::class, $estimador);
+
+        $this->expectException(RouteEstimationFailed::class);
+
+        try {
+            $this->app->make(CreateRideAction::class)->handle(User::factory()->create(), $this->solicitud());
+        } finally {
+            $this->assertDatabaseCount('rides', 0);
+        }
+    }
+
+    public function test_el_pasajero_con_un_viaje_activo_no_puede_abrir_otro(): void
+    {
+        // El Form Request ya lo valida para responder 422, pero entre esa
+        // consulta y este INSERT caben dos solicitudes simultáneas: lo que
+        // garantiza que no queden dos activos es el índice de la tabla.
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->expectException(QueryException::class);
+
+        try {
+            $this->action()->handle($pasajero, $this->solicitud());
+        } finally {
+            $this->assertDatabaseCount('rides', 1);
+        }
+    }
+
+    private function action(?RouteEstimate $trayecto = null): CreateRideAction
+    {
+        $estimacion = $trayecto ?? new RouteEstimate(7421, 842);
+
+        $this->app->instance(RouteEstimator::class, new class($estimacion) implements RouteEstimator
+        {
+            public function __construct(private RouteEstimate $estimacion) {}
+
+            public function estimate(Coordinates $origin, Coordinates $destination): RouteEstimate
+            {
+                return $this->estimacion;
+            }
+        });
+
+        return $this->app->make(CreateRideAction::class);
+    }
+
+    private function solicitud(): RideRequest
+    {
+        return new RideRequest(
+            origin: new Coordinates(4.710989, -74.072092),
+            destination: new Coordinates(4.698, -74.061),
+        );
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Policy invocada directo, sin pasar por HTTP.
+ *
+ * Solicitar un viaje es del rol pasajero: el conductor consigue viajes
+ * aceptando los que ya existen (historia #18), no creándolos.
+ */
+class RidePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_puede_solicitar_un_viaje(): void
+    {
+        $this->assertTrue(User::factory()->create()->can('create', Ride::class));
+    }
+
+    public function test_el_conductor_no_puede_solicitar_un_viaje(): void
+    {
+        $this->assertFalse(User::factory()->driver()->create()->can('create', Ride::class));
+    }
+}

--- a/tests/Unit/RideStatusTest.php
+++ b/tests/Unit/RideStatusTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Enums\RideStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Los valores del enum son parte del contrato publicado (`status` del schema
+ * `Ride` en openapi.yaml) y además viajan tal cual a la columna `rides.status`,
+ * así que renombrar uno rompe los dos lados a la vez.
+ */
+class RideStatusTest extends TestCase
+{
+    public function test_los_valores_son_los_publicados_en_el_contrato(): void
+    {
+        $this->assertSame(
+            ['requested', 'accepted', 'in_progress', 'completed', 'cancelled'],
+            array_column(RideStatus::cases(), 'value'),
+        );
+    }
+
+    public function test_activo_es_el_viaje_que_todavia_ocupa_al_pasajero(): void
+    {
+        // Es lo que decide si puede pedir otro: mientras el viaje siga en
+        // alguno de estos estados, hay uno en curso.
+        $this->assertSame(
+            [RideStatus::Requested, RideStatus::Accepted, RideStatus::InProgress],
+            RideStatus::active(),
+        );
+    }
+
+    public function test_el_viaje_terminado_ya_no_esta_activo(): void
+    {
+        $this->assertTrue(RideStatus::Requested->isActive());
+        $this->assertTrue(RideStatus::Accepted->isActive());
+        $this->assertTrue(RideStatus::InProgress->isActive());
+        $this->assertFalse(RideStatus::Completed->isActive());
+        $this->assertFalse(RideStatus::Cancelled->isActive());
+    }
+}


### PR DESCRIPTION
Closes #15

## Qué hace

`POST /api/v1/rides` crea la solicitud de viaje del pasajero autenticado entre dos
coordenadas. Responde **201** con el schema `Ride`; el viaje nace en `requested` y
espera a que un conductor lo acepte (#18) — la API no asigna conductor por su cuenta.

Piezas nuevas: enum `RideStatus`, tabla y modelo `Ride` (+ factory), `RidePolicy`,
`CreateRideAction`, `CreateRideRequest`, `RideResource` y el controller/ruta. El spec
`openapi.yaml` se actualizó primero (SDD) con los schemas `RideRequest` y `Ride`.

Cubre los tres criterios de aceptación:

1. Pasajero sin viajes activos → 201 con id y tarifa estimada, viaje en `requested`.
2. Pasajero con un viaje `requested`/`accepted`/`in_progress` → 422 bajo la clave `ride`.
3. Coordenadas inválidas, o destino igual al origen → 422 con el error de validación.

## Decisiones y riesgos

Están todas justificadas en `.claude/STANDARDS.md` § "Solicitud de viaje (decidido en
#15)". Las que más conviene mirar en la revisión:

- **Recurso propio (`/rides`) y no sub-recurso de `/me`**, al revés que el vehículo: al
  viaje se llega por su id (es el `{rideId}` del canal `ride.{id}`) y lo operan dos
  cuentas distintas. Por eso `RideResource` sí publica el `id`, pero no el `passenger_id`.
- **403 y no 422 para una cuenta de conductor**, resuelto con `RidePolicy` desde
  `authorize()` del Form Request, para que la autorización corra antes que la validación
  (mismo criterio que #12).
- **"Un viaje activo por pasajero" lo garantiza la tabla, no la validación.** El Form
  Request lo comprueba para responder 422 en el caso normal, pero entre esa consulta y
  el INSERT caben dos solicitudes simultáneas —un doble toque en el móvil alcanza—. Lo
  que queda en pie es un índice único sobre `rides.active_passenger_id`, una columna
  generada que vale `passenger_id` mientras el viaje está activo y `NULL` cuando
  terminó. Es columna generada y no índice parcial (`WHERE ...`) porque MySQL no los
  tiene, y los índices únicos ignoran `NULL` en ambos motores.
  La lista de estados activos va literal en la migración y no leída de `RideStatus`: una
  migración ya corrida no se re-ejecuta, así que depender del enum dejaría distintas una
  base creada hoy y otra creada tras renombrar un caso. `RideSchemaTest` recorre el enum
  contra la tabla para que esa divergencia falle en la suite.
- **Si el proveedor de mapas no entrega ruta, no se crea ningún viaje**: la excepción
  sale antes del INSERT. Un viaje sin tarifa además le dejaría al pasajero un activo que
  nunca pidió, bloqueándole el siguiente.
- **La tarifa se guarda con el viaje** en vez de recalcularse al leerlo: es el monto que
  el pasajero aceptó, y cada consulta al proveedor se paga. Sale de la misma
  `CalculateFareAction` que `/rides/estimate`, así que estimado y viaje no pueden diverger.
- **Destino igual al origen se compara por igualdad exacta.** "Demasiado cerca para pedir
  un viaje" es una decisión de producto con un umbral que alguien tiene que fijar, y no
  es lo que pide la historia.

## Cómo se probó

- **Suite completa: 388 tests, 1171 assertions, en verde.** 46 son nuevos: `RequestRideTest`
  (contrato del endpoint, un test por criterio de aceptación más 403/401/token expirado y
  los intentos de mandar `passenger_id`/`status`/`estimated_fare` en el cuerpo),
  `RideSchemaTest` (lo que garantiza la tabla, recorriendo `RideStatus::cases()`),
  `CreateRideActionTest`, `RidePolicyTest` y `RideStatusTest`.
  Los tests se escribieron antes de la implementación y se confirmó que fallaban.
- `./vendor/bin/pint --test`, `phpstan` (nivel 5) y los checks de complejidad y
  arquitectura: sin hallazgos.
- **Conformidad OpenAPI**: estática sin avisos (12 rutas). La dinámica corrió contra un
  servidor real con el proveedor de mapas apuntado a un stub local y una BD aparte, para
  ejecutar de verdad el 201 y no el "verde por omisión" que ya está documentado en
  `KNOWN_ERRORS.md`; el cuerpo real del 201 se validó con `jsonschema` contra el schema
  `Ride`, con contra-pruebas de que el schema rechaza cuerpos inválidos. Se verificaron
  a mano los cuatro caminos: 201, 422 por viaje activo, 422 por destino igual al origen
  y 403 del conductor.

## Fuera de alcance (deliberado)

- **El aviso a los conductores cercanos es de #17**, que es la historia con el criterio
  de aceptación de a quién se notifica y qué se emite. Acá el viaje solo queda disponible.
- **El canal `ride.{id}` sigue denegando todo.** `AppServiceProvider` mantiene el binding
  a `PendingRideParticipants`. La tabla ya existe, así que el cambio es de una línea,
  pero abrir un canal que transporta ubicación en vivo es lo que consumen #20/#21 y son
  ellas las que definen quién escucha qué; cambiarlo acá implicaba además reescribir
  `RideChannelTest`. El estado actual es el seguro (falla cerrado). Anotado en STANDARDS.md.
- **Bug preexistente, no introducido acá**: los endpoints protegidos responden **500** en
  vez del 401 documentado cuando el cliente no manda `Accept: application/json`
  (`Route [login] not defined.`). Lo comprobé y le pasa igual a `GET /me`; ya está
  registrado en `KNOWN_ERRORS.md` como algo que toca a todos los endpoints protegidos a
  la vez y merece su propio issue en vez de colarse en el PR de una historia.