### PR TITLE
feat(#16): cancelar solicitud de viaje antes de ser aceptada

### DIFF
--- a/app/Actions/Rides/CancelRideAction.php
+++ b/app/Actions/Rides/CancelRideAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+
+/**
+ * Cancela un viaje que un pasajero todavía no ha visto aceptado (historia #16).
+ *
+ * El viaje llega ya resuelto y ya validado: que siga en `requested` lo
+ * garantiza `CancelRideRequest` antes de invocar esta Action, así que acá no
+ * queda ninguna decisión de negocio, solo el cambio de estado.
+ *
+ * No hace falta tocar `driver_id` ni `active_passenger_id`: el viaje nunca
+ * tuvo conductor asignado en este estado, y `active_passenger_id` es una
+ * columna generada por la base que se recalcula sola al salir de los estados
+ * activos (ver la migración de `rides`).
+ */
+final readonly class CancelRideAction
+{
+    public function handle(Ride $ride): Ride
+    {
+        $ride->update(['status' => RideStatus::Cancelled]);
+
+        return $ride;
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\CancelRideAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\CancelRideRequest;
+use App\Http\Resources\RideResource;
+use App\Models\Ride;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/{ride}/cancel
+ *
+ * Cancela la solicitud de viaje del pasajero autenticado mientras sigue en
+ * `requested`, sin generar ningún cargo (historia #16). El viaje ya llega
+ * validado desde `CancelRideRequest`, así que acá no queda ninguna decisión.
+ *
+ * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
+ * implícito de la ruta (`{ride}`): la reflexión de esta firma es lo que usa
+ * `SubstituteBindings` para saber qué modelo cargar, y corre antes de que se
+ * resuelva `CancelRideRequest`, así que `authorize()` ya encuentra el modelo
+ * y no el id crudo.
+ */
+class CancelRideController extends Controller
+{
+    public function __invoke(
+        CancelRideRequest $request,
+        CancelRideAction $cancelRide,
+        Ride $ride,
+    ): JsonResponse {
+        $ride = $cancelRide->handle($ride);
+
+        return (new RideResource($ride))->response();
+    }
+}

--- a/app/Http/Requests/Rides/CancelRideRequest.php
+++ b/app/Http/Requests/Rides/CancelRideRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/{ride}/cancel — ver openapi.yaml.
+ */
+class CancelRideRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta —el
+     * `SubstituteBindings` de la ruta corre antes de que el controller
+     * resuelva este Form Request—, así que un id inexistente nunca llega
+     * hasta acá: sale como 404 antes de que se evalúe `authorize()`.
+     *
+     * Que el viaje sea del pasajero autenticado se resuelve acá y no en el
+     * controller, igual que en `CreateRideRequest`, para que el 403 se
+     * resuelva antes que la validación de estado.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('cancel', $this->ride()) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * viaje de la ruta y quién lo pide.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectAlreadyAccepted(...),
+        ];
+    }
+
+    /**
+     * Que el viaje ya no esté en `requested` no es un problema de permisos
+     * —el pasajero sigue siendo dueño del viaje— sino de en qué punto del
+     * ciclo de vida está: por eso es 422 y no 403, y por eso vive acá y no en
+     * `RidePolicy::cancel()`. Mismo criterio que "ya tiene un viaje activo"
+     * en `CreateRideRequest`, con el error bajo la clave `ride`, que tampoco
+     * es un campo de la entrada.
+     */
+    private function rejectAlreadyAccepted(Validator $validator): void
+    {
+        if ($this->ride()->status !== RideStatus::Requested) {
+            $validator->errors()->add(
+                'ride',
+                'El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.',
+            );
+        }
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Ride;
 use App\Models\User;
 
 /**
@@ -31,5 +32,22 @@ class RidePolicy
     public function create(User $user): bool
     {
         return $user->isPassenger();
+    }
+
+    /**
+     * Cancelar un viaje es del pasajero **dueño** de ese viaje (historia #16).
+     *
+     * Que el viaje ya no esté en `requested` **no** se decide acá: eso
+     * responde 422, porque el permiso de cancelar lo tiene y lo que cambia es
+     * el flujo a seguir (ver `CancelRideRequest`). Un 403 le diría que el
+     * permiso le falta, que es otra cosa.
+     *
+     * El rol se comprueba además de la propiedad, mismo criterio que
+     * `VehiclePolicy::update()`: nada impide que una fila apunte a una cuenta
+     * que dejó de ser pasajero.
+     */
+    public function cancel(User $user, Ride $ride): bool
+    {
+        return $user->isPassenger() && $ride->passenger_id === $user->getKey();
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -999,6 +999,106 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/{id}/cancel:
+    post:
+      tags:
+        - Rides
+      operationId: cancelRide
+      summary: Cancelar una solicitud de viaje antes de que un conductor la acepte
+      description: >-
+        Cancela el viaje del pasajero autenticado mientras sigue en
+        `requested`, sin que se genere ningún cargo (historia #16). Es la
+        ventana entre pedir el viaje y que algún conductor lo acepte; una vez
+        que el viaje pasa a `accepted` o más adelante, este endpoint ya no
+        aplica — esa cancelación tiene sus propias reglas (penalización,
+        liberar al conductor) y es una historia aparte (#22, #23).
+
+        Solo el pasajero dueño del viaje puede cancelarlo: cualquier otra
+        cuenta recibe **403**. Que el viaje ya no esté en `requested` es en
+        cambio **422**, porque no es un problema de permisos sino de en qué
+        punto del ciclo de vida está el viaje.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje a cancelar.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El viaje quedó cancelado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: cancelled
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  requested_at: "2026-07-31T14:03:21+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: El viaje no pertenece al pasajero autenticado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "422":
+          description: >-
+            El viaje ya no está en `requested` (fue aceptado, está en curso,
+            ya se completó o ya se había cancelado antes).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.
+                errors:
+                  ride:
+                    - El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -1536,7 +1636,7 @@ components:
           description: >-
             Estado del viaje. Nace en `requested`; el resto de los valores los
             producen las historias de aceptar (#18), iniciar (#19), completar
-            (#24) y cancelar (#22, #23).
+            (#24) y cancelar (#16 antes de aceptar, #22/#23 después).
           enum:
             - requested
             - accepted

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
+use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
@@ -106,4 +107,15 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/estimate', EstimateRideController::class)
         ->name('rides.estimate');
+
+    // Cancelar antes de que un conductor acepte (historia #16). Es el primer
+    // endpoint del proyecto que direcciona por id de ruta: `{ride}` se
+    // resuelve por binding implícito de Eloquent, así que un id inexistente
+    // responde 404 antes de que `CancelRideRequest` se evalúe. Que el viaje
+    // ya no esté en `requested` no es este endpoint: esa cancelación tiene
+    // sus propias reglas (penalización, liberar al conductor) y es la
+    // historia #22/#23.
+    Route::middleware('auth:api')
+        ->post('rides/{ride}/cancel', CancelRideController::class)
+        ->name('rides.cancel');
 });

--- a/tests/Feature/Rides/CancelRideTest.php
+++ b/tests/Feature/Rides/CancelRideTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/{id}/cancel — ver openapi.yaml.
+ *
+ * Cubre la ventana entre pedir el viaje y que algún conductor lo acepte
+ * (historia #16): no genera cargo porque hoy no existe nada que cobrar en
+ * `requested` (el motor de tarifa solo entra al completar el viaje, historia
+ * #24), así que basta con que el viaje quede `cancelled` sin dejar rastro
+ * adicional.
+ */
+class CancelRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_cancela_su_viaje_todavia_no_aceptado(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'cancelled');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Cancelled->value,
+        ]);
+    }
+
+    public function test_cancelar_no_borra_el_viaje_ni_crea_otro(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertDatabaseCount('rides', 1);
+    }
+
+    #[DataProvider('estadosYaNoRequested')]
+    public function test_rechaza_cancelar_un_viaje_que_ya_no_esta_requested(RideStatus $estado): void
+    {
+        // Es 422 y no 403: el pasajero sigue siendo dueño del viaje, lo que
+        // cambia es el flujo a seguir (historia #22/#23 para viajes
+        // aceptados en adelante).
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['status' => $estado]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => $estado->value]);
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosYaNoRequested(): array
+    {
+        return array_reduce(
+            array_filter(RideStatus::cases(), static fn (RideStatus $estado): bool => $estado !== RideStatus::Requested),
+            static fn (array $casos, RideStatus $estado): array => [...$casos, $estado->value => [$estado]],
+            [],
+        );
+    }
+
+    public function test_rechaza_cancelar_el_viaje_de_otro_pasajero(): void
+    {
+        $dueno = User::factory()->create();
+        $otro = User::factory()->create();
+        $viaje = Ride::factory()->for($dueno, 'passenger')->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($otro))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson('/api/v1/rides/999999/cancel')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->postJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/cancel";
+    }
+}

--- a/tests/Unit/Actions/Rides/CancelRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CancelRideActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\CancelRideAction;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver
+ * .claude/STANDARDS.md).
+ */
+class CancelRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pasa_el_viaje_a_cancelled(): void
+    {
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertSame(RideStatus::Cancelled, $resultado->status);
+        $this->assertSame(RideStatus::Cancelled, $viaje->refresh()->status);
+    }
+
+    public function test_libera_el_slot_de_viaje_activo_del_pasajero(): void
+    {
+        // `active_passenger_id` es una columna generada por la base (ver la
+        // migración de `rides`): confirmar que se libera es lo que garantiza
+        // que el pasajero pueda volver a solicitar un viaje después.
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_passenger_id' => null,
+        ]);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -28,4 +28,27 @@ class RidePolicyTest extends TestCase
     {
         $this->assertFalse(User::factory()->driver()->create()->can('create', Ride::class));
     }
+
+    public function test_el_pasajero_dueno_puede_cancelar_su_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $this->assertTrue($pasajero->can('cancel', $viaje));
+    }
+
+    public function test_otro_pasajero_no_puede_cancelar_un_viaje_ajeno(): void
+    {
+        $viaje = Ride::factory()->create();
+
+        $this->assertFalse(User::factory()->create()->can('cancel', $viaje));
+    }
+
+    public function test_un_conductor_no_puede_cancelar_un_viaje_aunque_la_fila_apunte_a_su_cuenta(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->for($conductor, 'passenger')->create();
+
+        $this->assertFalse($conductor->can('cancel', $viaje));
+    }
 }


### PR DESCRIPTION
Closes #16

## Qué hace

`POST /api/v1/rides/{id}/cancel`: el pasajero dueño de un viaje en estado
`requested` lo cancela, sin generar ningún cargo. Es la ventana entre pedir
el viaje y que un conductor lo acepte; una vez que pasa a `accepted` o más
adelante, este endpoint ya no aplica (esa cancelación es #22/#23, con sus
propias reglas de penalización).

Piezas nuevas: `CancelRideAction`, `CancelRideController`,
`CancelRideRequest`, método `RidePolicy::cancel()`. Es el primer endpoint del
proyecto que direcciona por id de ruta (`{ride}`) con binding implícito de
Eloquent — un id inexistente responde 404 antes de que se evalúe cualquier
autorización.

## Decisiones y riesgos

- **403 vs 422**: `RidePolicy::cancel()` solo decide si el pasajero es dueño
  del viaje (403 si no). Que el viaje ya no esté en `requested` es 422 y se
  resuelve en `CancelRideRequest::after()`, bajo la clave `ride` (no es un
  campo de la entrada) — mismo criterio que "ya tiene un viaje activo" en
  `CreateRideRequest`. Un 403 ahí le diría al pasajero que perdió el permiso,
  cuando en realidad lo sigue teniendo y lo que cambia es el flujo a seguir.
- **Route model binding**: para que `SubstituteBindings` resuelva `{ride}`
  antes de que `CancelRideRequest::authorize()` se evalúe, el controller
  necesita `Ride $ride` en su propia firma (la reflexión que usa Laravel para
  el binding implícito mira la firma del controller, no la del Form
  Request). Sin eso, `$this->route('ride')` llega como el id crudo en vez del
  modelo.
- **`active_passenger_id`** es una columna generada en la base (ver la
  migración de `rides`): el `UPDATE` de `status` ya la libera sola, no hace
  falta tocar nada más en la Action para que el pasajero pueda volver a
  solicitar un viaje. Verificado en `CancelRideActionTest`.
- **Sin cargo**: no existe todavía ningún modelo de pagos en el proyecto, así
  que "no genera cargo" queda satisfecho por construcción — no hay nada que
  cobrar en `requested`.
- **Fuera de alcance** (igual que en el issue): la cancelación de un viaje ya
  aceptado, con su penalización y liberación del conductor — es #22/#23.

## Cómo se probó

Flujo SDD → TDD del proyecto: primero el contrato en `openapi.yaml` (nuevo
path `/rides/{id}/cancel`), después los tests, después el código.

- Tests nuevos: `CancelRideTest` (Feature, 6 casos: cancelación propia, no
  borra ni duplica filas, rechaza los 4 estados que no son `requested` con
  422, rechaza el viaje de otro pasajero con 403, 404 si no existe, 401 sin
  token), `CancelRideActionTest` (Unit, incluye verificar que
  `active_passenger_id` se libera), y 3 casos nuevos en `RidePolicyTest`
  (dueño puede, otro pasajero no puede, un conductor tampoco aunque la fila
  apunte a su cuenta).
- Suite completa en verde: **402 tests, 1206 assertions**.
- `./vendor/bin/pint --test` limpio.
- `phpstan analyse --memory-limit=512M` (nivel 5): 0 errores. `composer stan`
  tal cual está configurado se queda sin memoria en este entorno (128M) antes
  de terminar; con `--memory-limit=512M` pasa limpio.
- **No pude correr** `scripts/static_conformance.py` /
  `scripts/dynamic_conformance.py` de `laravel-feature-workflow`, ni
  `complexity_check.py` / `architecture_check.py` de `laravel-api-review`, ni
  `security_check.py` de `laravel-security-review`: este entorno no tiene un
  intérprete de Python real instalado (solo el stub de Microsoft Store).
  Hice en su lugar una revisión manual de arquitectura (Controller delgado
  que delega a la Action, Action sin conocimiento de HTTP, Policy que solo
  decide permiso) y de seguridad (autorización por ownership vía Policy, sin
  mass assignment más allá de `status`, sin datos sensibles expuestos, ruta
  nueva bajo `auth:api`) contra el mismo patrón que ya usa `POST /rides`.
  Vale la pena correr esos tres scripts en un entorno con Python antes de
  mergear, si el REVISOR lo tiene disponible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)