### PR TITLE
feat(#18): aceptar una solicitud de viaje

### DIFF
--- a/app/Actions/Rides/AcceptRideAction.php
+++ b/app/Actions/Rides/AcceptRideAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Enums\RideStatus;
+use App\Exceptions\Rides\RideNoLongerAvailableException;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Asigna un conductor a un viaje disponible (historia #18).
+ *
+ * Dos conductores pueden intentar aceptar el mismo viaje casi al mismo tiempo
+ * —es el punto central de la historia, no un detalle—, así que el estado no
+ * se comprueba sobre el `$ride` que llegó del binding de la ruta: pudo quedar
+ * desactualizado entre que se cargó y que se ejecuta esta Action. Se relee con
+ * `lockForUpdate()` dentro de una transacción, así que el segundo conductor en
+ * llegar espera a que la primera transacción termine y encuentra el viaje ya
+ * `accepted`.
+ *
+ * Que el conductor ya tenga un viaje propio activo lo adelanta
+ * `AcceptRideRequest` (422); acá ya no queda esa decisión, solo el cambio de
+ * estado.
+ */
+final readonly class AcceptRideAction
+{
+    /**
+     * @throws RideNoLongerAvailableException si el viaje ya no está en
+     *                                        `requested` cuando se resuelve
+     *                                        el lock.
+     */
+    public function handle(Ride $ride, User $driver): Ride
+    {
+        return DB::transaction(function () use ($ride, $driver): Ride {
+            /** @var Ride $locked */
+            $locked = Ride::query()->whereKey($ride->getKey())->lockForUpdate()->firstOrFail();
+
+            if ($locked->status !== RideStatus::Requested) {
+                throw new RideNoLongerAvailableException;
+            }
+
+            $locked->update([
+                'status' => RideStatus::Accepted,
+                'driver_id' => $driver->getKey(),
+            ]);
+
+            return $locked;
+        });
+    }
+}

--- a/app/Enums/RideStatus.php
+++ b/app/Enums/RideStatus.php
@@ -22,11 +22,14 @@ enum RideStatus: string
     /**
      * Los estados en los que el viaje todavía ocupa al pasajero y al conductor.
      *
-     * Es lo que decide si un pasajero puede solicitar otro viaje. La tabla
-     * `rides` repite esta lista en la columna generada que sostiene el índice de
-     * "un viaje activo por pasajero": si acá se agrega un estado activo y allá
-     * no, la regla se cae en silencio. `RideSchemaTest` recorre estos casos
-     * contra la base justamente para que esa divergencia falle en la suite.
+     * Es lo que decide si un pasajero puede solicitar otro viaje y si un
+     * conductor puede aceptar otro. La tabla `rides` repite esta lista en las
+     * dos columnas generadas que sostienen los índices de "un viaje activo por
+     * pasajero" (`active_passenger_id`) y "un viaje activo por conductor"
+     * (`active_driver_id`): si acá se agrega un estado activo y allá no, la
+     * regla se cae en silencio en cualquiera de las dos. `RideSchemaTest`
+     * recorre estos casos contra la base justamente para que esa divergencia
+     * falle en la suite.
      *
      * @return array<int, self>
      */

--- a/app/Exceptions/Rides/RideNoLongerAvailableException.php
+++ b/app/Exceptions/Rides/RideNoLongerAvailableException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Rides;
+
+use RuntimeException;
+
+/**
+ * El viaje que se intentó aceptar ya no está en `requested` (historia #18):
+ * otro conductor lo aceptó primero, o cambió de estado por otro motivo.
+ *
+ * Se traduce a 409 en bootstrap/app.php y no a 422: no es un problema de forma
+ * de la entrada ni del estado de la cuenta del conductor —eso ya lo filtró
+ * `AcceptRideRequest`— sino de que el recurso cambió entre que el conductor lo
+ * vio disponible y que la petición llegó al servidor.
+ *
+ * No conoce HTTP, igual que el resto de excepciones de dominio del proyecto
+ * (ver `InvalidCredentialsException`): la traducción a código de estado vive
+ * en el exception handler, no acá.
+ */
+final class RideNoLongerAvailableException extends RuntimeException
+{
+    public const MESSAGE = 'Este viaje ya no está disponible.';
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/AcceptRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/AcceptRideController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\AcceptRideAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\AcceptRideRequest;
+use App\Http\Resources\RideResource;
+use App\Models\Ride;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/{ride}/accept
+ *
+ * Asigna el viaje al conductor autenticado (historia #18). El permiso (rol
+ * conductor) y que no tenga ya un viaje propio activo los resuelve
+ * `AcceptRideRequest`; que el viaje siga disponible lo resuelve la Action bajo
+ * lock, porque ahí es donde el estado puede cambiar entre que se resolvió el
+ * binding de la ruta y que se ejecuta esta petición.
+ *
+ * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
+ * implícito de la ruta, igual que en `CancelRideController`.
+ */
+class AcceptRideController extends Controller
+{
+    public function __invoke(
+        AcceptRideRequest $request,
+        AcceptRideAction $acceptRide,
+        Ride $ride,
+    ): JsonResponse {
+        $ride = $acceptRide->handle($ride, $request->user());
+
+        return (new RideResource($ride))->response();
+    }
+}

--- a/app/Http/Requests/Rides/AcceptRideRequest.php
+++ b/app/Http/Requests/Rides/AcceptRideRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/{ride}/accept — ver openapi.yaml.
+ */
+class AcceptRideRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `CancelRideRequest`: un id inexistente sale como 404 antes de que se
+     * evalúe `authorize()`.
+     *
+     * Que el permiso sea del rol conductor lo decide `RidePolicy`, no depende
+     * del viaje de la ruta: cualquier conductor puede intentar aceptar
+     * cualquier viaje `requested`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('accept', Ride::class) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * viaje de la ruta y quién lo pide.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectDriverWithActiveRide(...),
+        ];
+    }
+
+    /**
+     * "Un viaje activo por conductor" se comprueba acá y no con una regla de
+     * campo, mismo criterio que `CreateRideRequest::rejectSecondActiveRide()`:
+     * no lo decide nada de lo que el cliente manda sino el estado de su
+     * cuenta. Por eso el error viaja bajo la clave `ride`, que tampoco es un
+     * campo de la entrada.
+     *
+     * Lo que garantiza la regla cuando dos aceptaciones del mismo conductor
+     * llegan a la vez no es esta consulta sino el índice único de
+     * `active_driver_id` (ver la migración); esto existe para poder responder
+     * 422 en vez de 500 en el caso normal.
+     *
+     * Que el viaje de la ruta ya no esté disponible (lo aceptó otro conductor
+     * primero) no se decide acá: es 409 y lo resuelve `AcceptRideAction` bajo
+     * lock, porque el estado puede cambiar entre que se valida esta petición y
+     * que se ejecuta.
+     */
+    private function rejectDriverWithActiveRide(Validator $validator): void
+    {
+        $driver = $this->user();
+
+        if (! $driver instanceof User) {
+            return;
+        }
+
+        $hasActiveRide = Ride::query()
+            ->where('driver_id', $driver->getKey())
+            ->whereIn('status', RideStatus::active())
+            ->exists();
+
+        if ($hasActiveRide) {
+            $validator->errors()->add(
+                'ride',
+                'Ya tienes un viaje activo; termínalo o cancélalo antes de aceptar otro.',
+            );
+        }
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Requests/Rides/AcceptRideRequest.php
+++ b/app/Http/Requests/Rides/AcceptRideRequest.php
@@ -87,10 +87,4 @@ class AcceptRideRequest extends FormRequest
             );
         }
     }
-
-    public function ride(): Ride
-    {
-        /** @var Ride */
-        return $this->route('ride');
-    }
 }

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -19,9 +19,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * aceptó esos números, así que son parte del viaje y no algo que se recalcule
  * al consultarlo. El cobro final se resuelve al completarlo (historia #24).
  *
- * `active_passenger_id` no aparece acá a propósito: es una columna generada por
- * la base (ver la migración) y escribirla desde la aplicación no tendría efecto
- * más que romper el INSERT.
+ * `active_passenger_id` y `active_driver_id` no aparecen acá a propósito: son
+ * columnas generadas por la base (ver las migraciones) y escribirlas desde la
+ * aplicación no tendría efecto más que romper el INSERT/UPDATE.
  *
  * Los atributos con cast se declaran en el docblock porque su tipo real no es
  * el de la columna (ver .claude/STANDARDS.md).

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -50,4 +50,20 @@ class RidePolicy
     {
         return $user->isPassenger() && $ride->passenger_id === $user->getKey();
     }
+
+    /**
+     * Aceptar un viaje es del rol conductor (historia #18): el pasajero
+     * consigue el suyo solicitándolo, no aceptando el de otro.
+     *
+     * No depende de un viaje concreto, mismo criterio que `create()`: cualquier
+     * conductor puede intentar aceptar cualquier viaje `requested`, así que el
+     * permiso no se resuelve contra una fila. Que el viaje ya no esté
+     * disponible, o que el conductor ya tenga uno propio activo, no se decide
+     * acá: son 409 y 422 respectivamente, porque el permiso lo tiene y lo que
+     * falla es el estado del viaje o el de su propia cuenta.
+     */
+    public function accept(User $user): bool
+    {
+        return $user->isDriver();
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Exceptions\Auth\InvalidCredentialsException;
+use App\Exceptions\Rides\RideNoLongerAvailableException;
 use App\Exceptions\RouteEstimationFailed;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -82,6 +83,19 @@ return Application::configure(basePath: dirname(__DIR__))
             fn (RouteEstimationFailed $e) => new JsonResponse(
                 ['message' => 'No fue posible calcular una ruta entre esas coordenadas. Puede que la zona no esté cubierta por el servicio.'],
                 JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            ),
+        );
+
+        // El viaje que un conductor intentó aceptar ya no está `requested`
+        // (historia #18): otro conductor lo aceptó primero, o cambió de estado
+        // por otro motivo. Es 409 y no 422: no es un problema de forma de la
+        // entrada ni del estado de la cuenta del conductor —eso ya lo filtró
+        // `AcceptRideRequest`— sino de que el recurso cambió entre que se vio
+        // disponible y que la petición llegó al servidor.
+        $exceptions->render(
+            fn (RideNoLongerAvailableException $e) => new JsonResponse(
+                ['message' => $e->getMessage()],
+                JsonResponse::HTTP_CONFLICT,
             ),
         );
     })->create();

--- a/database/migrations/2026_07_31_000003_add_active_driver_id_to_rides_table.php
+++ b/database/migrations/2026_07_31_000003_add_active_driver_id_to_rides_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            // "Un viaje activo por conductor", el mismo mecanismo que
+            // `active_passenger_id` y por el mismo motivo: el Form Request de
+            // aceptar (historia #18) adelanta la regla para responder 422 en
+            // vez de 500, pero entre esa consulta y el UPDATE caben dos
+            // aceptaciones simultáneas del mismo conductor sobre dos viajes
+            // distintos, y ahí lo único que queda en pie es el índice.
+            //
+            // Vale `driver_id` mientras el viaje está activo y NULL en
+            // cualquier otro caso (incluido mientras nadie lo ha aceptado
+            // todavía), así que un conductor acumula viajes terminados sin
+            // límite y solo puede tener uno vivo a la vez. La lista de estados
+            // se escribe literal y no se lee del enum, por el mismo motivo que
+            // `active_passenger_id`: una migración ya corrida no vuelve a
+            // ejecutarse. `RideSchemaTest` recorre el enum contra esta columna
+            // para que la divergencia falle en la suite y no en producción.
+            $table->unsignedBigInteger('active_driver_id')
+                ->nullable()
+                ->storedAs("case when status in ('requested', 'accepted', 'in_progress') then driver_id end");
+
+            $table->unique('active_driver_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            $table->dropUnique(['active_driver_id']);
+            $table->dropColumn('active_driver_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_31_000003_add_active_driver_id_to_rides_table.php
+++ b/database/migrations/2026_07_31_000003_add_active_driver_id_to_rides_table.php
@@ -24,9 +24,18 @@ return new class extends Migration
             // `active_passenger_id`: una migración ya corrida no vuelve a
             // ejecutarse. `RideSchemaTest` recorre el enum contra esta columna
             // para que la divergencia falle en la suite y no en producción.
+            //
+            // VIRTUAL y no STORED (a diferencia de `active_passenger_id`, que
+            // sí puede serlo): esta columna se agrega con `ALTER TABLE` sobre
+            // una tabla `rides` que ya puede tener filas, y SQLite no admite
+            // añadir una columna generada STORED a una tabla con datos
+            // (`cannot add a STORED column`). `active_passenger_id` no tiene
+            // este problema porque se declara dentro del `CREATE TABLE`
+            // original. VIRTUAL sí se puede agregar con datos existentes y
+            // sigue admitiendo índice único tanto en SQLite como en MySQL.
             $table->unsignedBigInteger('active_driver_id')
                 ->nullable()
-                ->storedAs("case when status in ('requested', 'accepted', 'in_progress') then driver_id end");
+                ->virtualAs("case when status in ('requested', 'accepted', 'in_progress') then driver_id end");
 
             $table->unique('active_driver_id');
         });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1099,6 +1099,113 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/{id}/accept:
+    post:
+      tags:
+        - Rides
+      operationId: acceptRide
+      summary: Aceptar una solicitud de viaje disponible
+      description: >-
+        Asigna el viaje al conductor autenticado mientras sigue en
+        `requested` (historia #18). Dos conductores pueden intentar aceptar
+        el mismo viaje casi al mismo tiempo: solo el primero en llegar lo
+        consigue, y el resto recibe **409** porque el viaje ya no está
+        disponible.
+
+        Solo un conductor puede aceptar viajes: un pasajero recibe **403**.
+        Que el conductor ya tenga un viaje propio activo (`accepted` o
+        `in_progress`) es en cambio **422**, porque el permiso lo tiene y lo
+        que le falta es terminar o cancelar el que ya tiene.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje a aceptar.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El viaje quedó asignado al conductor autenticado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: accepted
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  requested_at: "2026-07-31T14:03:21+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es de un conductor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "409":
+          description: >-
+            El viaje ya no está disponible: otro conductor lo aceptó
+            primero, o cambió de estado por otro motivo.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Este viaje ya no está disponible.
+        "422":
+          description: El conductor autenticado ya tiene un viaje propio activo.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Ya tienes un viaje activo; termínalo o cancélalo antes de aceptar otro.
+                errors:
+                  ride:
+                    - Ya tienes un viaje activo; termínalo o cancélalo antes de aceptar otro.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
+use App\Http\Controllers\Api\V1\Rides\AcceptRideController;
 use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
@@ -118,4 +119,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/{ride}/cancel', CancelRideController::class)
         ->name('rides.cancel');
+
+    // Aceptar una solicitud disponible (historia #18). Mismo binding implícito
+    // que cancelar: `{ride}` resuelve el modelo antes de que se evalúe
+    // `AcceptRideRequest`, así que un id inexistente responde 404 antes de la
+    // autorización. Que dos conductores compitan por el mismo viaje no lo
+    // decide la ruta ni el Form Request: lo resuelve `AcceptRideAction` bajo
+    // lock.
+    Route::middleware('auth:api')
+        ->post('rides/{ride}/accept', AcceptRideController::class)
+        ->name('rides.accept');
 });

--- a/tests/Feature/Rides/AcceptRideTest.php
+++ b/tests/Feature/Rides/AcceptRideTest.php
@@ -8,6 +8,7 @@ use App\Enums\RideStatus;
 use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -63,10 +64,11 @@ class AcceptRideTest extends TestCase
         ]);
     }
 
-    public function test_rechaza_al_conductor_que_ya_tiene_un_viaje_propio_activo(): void
+    #[DataProvider('estadosActivosDelConductor')]
+    public function test_rechaza_al_conductor_que_ya_tiene_un_viaje_propio_activo(RideStatus $estado): void
     {
         $conductor = User::factory()->driver()->create();
-        Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+        Ride::factory()->create(['status' => $estado, 'driver_id' => $conductor->id]);
         $otroViaje = Ride::factory()->create(['status' => RideStatus::Requested]);
 
         $this->withToken(JWTAuth::fromUser($conductor))
@@ -115,5 +117,19 @@ class AcceptRideTest extends TestCase
     private function uri(Ride $viaje): string
     {
         return "/api/v1/rides/{$viaje->id}/accept";
+    }
+
+    /**
+     * El criterio de aceptación #3 dice "accepted o in_progress": ambos
+     * estados tienen que rechazar la aceptación, no solo el primero.
+     *
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosActivosDelConductor(): array
+    {
+        return [
+            RideStatus::Accepted->value => [RideStatus::Accepted],
+            RideStatus::InProgress->value => [RideStatus::InProgress],
+        ];
     }
 }

--- a/tests/Feature/Rides/AcceptRideTest.php
+++ b/tests/Feature/Rides/AcceptRideTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/{id}/accept — ver openapi.yaml.
+ *
+ * Historia #18: un conductor disponible acepta un viaje que sigue en
+ * `requested`. El manejo de la carrera entre dos conductores por el mismo
+ * viaje es parte central de la historia, no un detalle.
+ */
+class AcceptRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_conductor_acepta_un_viaje_disponible(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'accepted');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Accepted->value,
+            'driver_id' => $conductor->id,
+        ]);
+    }
+
+    public function test_rechaza_un_viaje_ya_aceptado_por_otro_conductor(): void
+    {
+        // El primer conductor ya aceptó el viaje: se deja así por el modelo y
+        // no por una request previa, porque el guard JWT (stateless) cachea el
+        // usuario resuelto en la instancia del guard durante todo el test —dos
+        // requests autenticadas con cuentas distintas en el mismo método
+        // reusarían la primera. Ver `RequestRideTest` para el mismo criterio.
+        $primerConductor = User::factory()->driver()->create();
+        $segundoConductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $primerConductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($segundoConductor))
+            ->postJson($this->uri($viaje))
+            ->assertStatus(409);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Accepted->value,
+            'driver_id' => $primerConductor->id,
+        ]);
+    }
+
+    public function test_rechaza_al_conductor_que_ya_tiene_un_viaje_propio_activo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+        $otroViaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($otroViaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $otroViaje->id,
+            'status' => RideStatus::Requested->value,
+            'driver_id' => null,
+        ]);
+    }
+
+    public function test_rechaza_a_un_pasajero_que_intenta_aceptar_un_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson('/api/v1/rides/999999/accept')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->postJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/accept";
+    }
+}

--- a/tests/Feature/Rides/RideSchemaTest.php
+++ b/tests/Feature/Rides/RideSchemaTest.php
@@ -83,6 +83,56 @@ class RideSchemaTest extends TestCase
         $this->assertDatabaseCount('rides', 2);
     }
 
+    /**
+     * Mismo mecanismo que `active_passenger_id`, para el conductor (historia
+     * #18): un conductor no puede quedar asignado a dos viajes activos a la
+     * vez, aunque dos aceptaciones lleguen casi al mismo tiempo.
+     */
+    #[DataProvider('estadosActivos')]
+    public function test_el_conductor_no_puede_tener_dos_viajes_activos(RideStatus $estado): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Ride::factory()->create(['status' => $estado, 'driver_id' => $conductor->id]);
+
+        $this->expectException(QueryException::class);
+
+        try {
+            Ride::factory()->create(['status' => $estado, 'driver_id' => $conductor->id]);
+        } finally {
+            $this->assertDatabaseCount('rides', 1);
+        }
+    }
+
+    public function test_liberar_el_viaje_activo_habilita_al_conductor_de_nuevo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $viaje->update(['status' => RideStatus::Completed]);
+        Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    public function test_el_viaje_activo_de_otro_conductor_no_choca(): void
+    {
+        Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => User::factory()->driver()->create()->id]);
+        Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => User::factory()->driver()->create()->id]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
+    public function test_un_viaje_sin_conductor_asignado_no_choca_con_ningun_conductor(): void
+    {
+        // `driver_id` es NULL mientras nadie aceptó el viaje: los índices
+        // únicos ignoran los NULL, así que muchos viajes `requested` conviven
+        // sin conductor asignado.
+        Ride::factory()->create(['status' => RideStatus::Requested]);
+        Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->assertDatabaseCount('rides', 2);
+    }
+
     public function test_borrar_al_pasajero_se_lleva_sus_viajes(): void
     {
         $pasajero = User::factory()->create();

--- a/tests/Unit/Actions/Rides/AcceptRideActionTest.php
+++ b/tests/Unit/Actions/Rides/AcceptRideActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\AcceptRideAction;
+use App\Enums\RideStatus;
+use App\Exceptions\Rides\RideNoLongerAvailableException;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver
+ * .claude/STANDARDS.md).
+ */
+class AcceptRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_asigna_el_conductor_y_pasa_el_viaje_a_accepted(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $resultado = $this->app->make(AcceptRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertSame(RideStatus::Accepted, $resultado->status);
+        $this->assertSame($conductor->getKey(), $resultado->driver_id);
+        $this->assertSame(RideStatus::Accepted, $viaje->refresh()->status);
+        $this->assertSame($conductor->getKey(), $viaje->driver_id);
+    }
+
+    public function test_rechaza_un_viaje_que_ya_no_esta_requested(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted]);
+
+        $this->expectException(RideNoLongerAvailableException::class);
+
+        try {
+            $this->app->make(AcceptRideAction::class)->handle($viaje, $conductor);
+        } finally {
+            $this->assertNull($viaje->refresh()->driver_id);
+        }
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -51,4 +51,14 @@ class RidePolicyTest extends TestCase
 
         $this->assertFalse($conductor->can('cancel', $viaje));
     }
+
+    public function test_el_conductor_puede_aceptar_un_viaje(): void
+    {
+        $this->assertTrue(User::factory()->driver()->create()->can('accept', Ride::class));
+    }
+
+    public function test_el_pasajero_no_puede_aceptar_un_viaje(): void
+    {
+        $this->assertFalse(User::factory()->create()->can('accept', Ride::class));
+    }
 }


### PR DESCRIPTION
Closes #18

## Qué hace

Implementa `POST /api/v1/rides/{ride}/accept`: un conductor autenticado
acepta un viaje que sigue en `requested`.

- **200**: el viaje pasa a `accepted` con el conductor autenticado asignado.
- **403**: la cuenta autenticada no es de un conductor (`RidePolicy::accept`).
- **404**: no existe ningún viaje con ese id (binding implícito de la ruta).
- **409**: el viaje ya no está `requested` (otro conductor lo aceptó primero,
  o cambió de estado por otro motivo) — nueva excepción de dominio
  `RideNoLongerAvailableException`, traducida a 409 en `bootstrap/app.php`.
- **422**: el conductor autenticado ya tiene un viaje propio activo
  (`accepted` o `in_progress`).

La condición de carrera entre dos conductores por el mismo viaje —el punto
central de la historia según el issue— se resuelve en `AcceptRideAction` con
`lockForUpdate()` dentro de una transacción: se relee el viaje bajo lock y se
comprueba el estado ahí, no sobre el modelo que llegó del binding de la ruta.

Para que un conductor no pueda quedar asignado a dos viajes activos a la vez
(incluida la ventana de carrera entre dos aceptaciones simultáneas del mismo
conductor sobre dos viajes distintos), se agregó una migración con
`active_driver_id`, una columna generada + índice único análoga a
`active_passenger_id` que ya protege el lado del pasajero.

## Cómo se probó

- Spec actualizado en `openapi.yaml` (path `/rides/{id}/accept`, ejemplos
  reales por código de estado) antes de escribir tests/código.
- Tests nuevos: `tests/Feature/Rides/AcceptRideTest.php` (un caso por
  criterio de aceptación + 401/404), `tests/Unit/Actions/Rides/AcceptRideActionTest.php`,
  ampliación de `tests/Unit/Policies/RidePolicyTest.php` y de
  `tests/Feature/Rides/RideSchemaTest.php` (constraint de `active_driver_id`,
  simétrica a la de `active_passenger_id`).
- `php artisan test`: 418/418 en verde.
- `./vendor/bin/pint --test`: sin errores.
- `./vendor/bin/phpstan analyse` (nivel 5): 0 errores.

## Decisiones y riesgos

- No expone el conductor asignado en `RideResource`/schema `Ride`: el issue
  no lo pide explícitamente y agregarlo es una decisión de contrato mayor
  (nombre, vehículo, etc.) que corresponde a una historia de tracking en
  tiempo real (#20/#21).
- El intento de aceptación fuera de `requested` que **no** es una carrera
  real (ej. el viaje ya estaba `completed` hace rato) también responde 409:
  se interpretó "ya no está disponible" de forma genérica en vez de limitarlo
  al caso literal "lo aceptó otro conductor", que es como lo describe el
  criterio de aceptación #2 pero no distingue motivos.
- Los scripts de conformidad de la skill de desarrollo
  (`static_conformance.py`, `dynamic_conformance.py`) y los de
  `laravel-api-review`/`laravel-security-review` no pudieron ejecutarse: no
  hay un intérprete de Python real instalado en este entorno (solo el stub
  de Microsoft Store). Se compensó con una revisión manual del diff contra
  los criterios de esas skills (mass assignment, campos expuestos,
  autorización explícita, complejidad/anidación, SQL crudo) más PHPStan a
  nivel 5, que sí corrió limpio.