### PR TITLE
feat(#19): iniciar el viaje aceptado

### DIFF
--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -156,3 +156,29 @@ base de desarrollo dejaría un viaje activo que después bloquea al mismo pasaje
 La corrección de fondo del script sigue siendo la ya anotada (no compartir un token que
 una operación invalida); esta entrada agrega que, además, el reporte debería decir **qué
 código de estado** respondió cada operación.
+
+### 2026-07-31 — Cuarta repetición del token compartido (#19), y por qué el conteo engaña
+
+**Qué pasó:** implementando `POST /rides/{id}/start` (#19), el chequeo dinámico reportó
+`OK: 15 operación(es) probadas contra el spec, 0 omitida(s), sin fallos` con la base
+sembrada a propósito (un viaje `accepted` con id 1 asignado al conductor del token).
+El 200 del endpoint nuevo **no se ejecutó**: al terminar la corrida el viaje seguía en
+`accepted` con `started_at` en NULL. Misma causa de siempre — `POST /auth/logout` va
+antes en el orden del spec y deja el token en la blacklist, así que `/rides/1/start`
+respondió el 401 que el contrato también documenta.
+
+**Por qué pasó:** idéntica a las tres entradas anteriores. Lo que agrega este caso es
+que el **conteo de operaciones tampoco sirve como señal**: entre dos corridas seguidas
+pasó de `14 probadas, 1 omitida` a `15 probadas, 0 omitidas` sin que ninguna hubiera
+ejecutado su camino de éxito. Lo único que delató la omisión fue mirar el estado de la
+fila en la base después de correr el script.
+
+**Cómo evitarlo:** lo ya anotado —validar el camino de éxito aparte— y, como control
+barato para cualquier feature que **escriba** algo, comprobar el estado de la fila
+después de la corrida: si el recurso no cambió, el 200/201 no se ejecutó por más verde
+que diga el resumen. Acá se verificó con `curl` contra un servidor propio y una
+`DB_DATABASE` de scratch: 200 con el cuerpo del schema `Ride` (`status: in_progress`,
+`started_at` poblado) y 422 documentado al repetir la llamada. La corrección de fondo
+del script (dejar `/auth/logout` para el final, o un token por operación) lleva cuatro
+historias pendiente y sigue mereciendo su propio issue en vez de colarse en el PR de
+una feature.

--- a/app/Actions/Rides/StartRideAction.php
+++ b/app/Actions/Rides/StartRideAction.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+
+/**
+ * Marca como iniciado un viaje que el conductor asignado ya había aceptado
+ * (historia #19).
+ *
+ * El viaje llega resuelto y validado: que sea del conductor autenticado lo
+ * garantiza `RidePolicy::start()` y que siga en `accepted` lo garantiza
+ * `StartRideRequest`, así que acá no queda ninguna decisión de negocio, solo
+ * la transición. Mismo reparto que en `CancelRideAction`.
+ *
+ * No relee el viaje bajo lock como hace `AcceptRideAction`, y la diferencia es
+ * de quién compite por la fila: allá son dos conductores distintos por un
+ * viaje libre, y perder la carrera en silencio reasignaría el viaje de otro.
+ * Acá el único que puede llegar a la vez es el mismo conductor tocando el
+ * botón dos veces, y lo peor que produce esa carrera es que `started_at` se
+ * reescriba con una marca de tiempo unos milisegundos posterior; el segundo
+ * toque, una vez confirmada la primera transacción, ya sale como 422.
+ *
+ * `active_driver_id` no se toca: es una columna generada y `in_progress` sigue
+ * siendo un estado activo, así que el viaje continúa ocupando al conductor
+ * (ver la migración de `rides`).
+ */
+final readonly class StartRideAction
+{
+    public function handle(Ride $ride): Ride
+    {
+        $ride->update([
+            'status' => RideStatus::InProgress,
+            'started_at' => now(),
+        ]);
+
+        return $ride;
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/StartRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/StartRideController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\StartRideAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\StartRideRequest;
+use App\Http\Resources\RideResource;
+use App\Models\Ride;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/{ride}/start
+ *
+ * Marca el viaje como iniciado (historia #19). Que el conductor autenticado
+ * sea el asignado lo resuelve `RidePolicy::start()` desde `StartRideRequest`,
+ * y que el viaje siga en `accepted`, el propio Form Request.
+ *
+ * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
+ * implícito de la ruta, igual que en `AcceptRideController`.
+ */
+class StartRideController extends Controller
+{
+    public function __invoke(
+        StartRideRequest $request,
+        StartRideAction $startRide,
+        Ride $ride,
+    ): JsonResponse {
+        $ride = $startRide->handle($ride);
+
+        return (new RideResource($ride))->response();
+    }
+}

--- a/app/Http/Requests/Rides/StartRideRequest.php
+++ b/app/Http/Requests/Rides/StartRideRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/{ride}/start — ver openapi.yaml.
+ */
+class StartRideRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `CancelRideRequest`: un id inexistente sale como 404 antes de que se
+     * evalúe `authorize()`.
+     *
+     * Acá el permiso sí depende del viaje concreto —solo lo inicia el
+     * conductor asignado—, a diferencia de `AcceptRideRequest`, donde
+     * cualquier conductor podía intentarlo.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('start', $this->ride()) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * viaje de la ruta y quién lo pide.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectRideNotAccepted(...),
+        ];
+    }
+
+    /**
+     * Que el viaje no esté en `accepted` no es un problema de permisos —el
+     * conductor sigue siendo el asignado— sino de en qué punto del ciclo de
+     * vida está: por eso es 422 y no 403, y por eso vive acá y no en
+     * `RidePolicy::start()`. Mismo criterio que `rejectAlreadyAccepted()` en
+     * `CancelRideRequest`, con el error bajo la clave `ride`, que tampoco es
+     * un campo de la entrada.
+     *
+     * El mensaje no dice en qué estado está el viaje: quien lo pide es el
+     * conductor asignado, así que no hay filtración posible, pero el estado
+     * concreto es ruido para una app que lo único que puede hacer es refrescar
+     * el viaje y volver a mostrar los botones que correspondan.
+     */
+    private function rejectRideNotAccepted(Validator $validator): void
+    {
+        if ($this->ride()->status !== RideStatus::Accepted) {
+            $validator->errors()->add(
+                'ride',
+                'Solo se puede iniciar un viaje que esté aceptado.',
+            );
+        }
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Resources/RideResource.php
+++ b/app/Http/Resources/RideResource.php
@@ -45,6 +45,11 @@ class RideResource extends JsonResource
             // el contrato publica `format: date-time` y el default trae
             // microsegundos que nadie usa acá.
             'requested_at' => $this->resource->created_at?->toIso8601String(),
+            // Presente siempre, aunque valga `null`: el contrato lo declara
+            // obligatorio y nullable justamente para que el cliente no tenga
+            // que distinguir "el viaje todavía no empezó" de "esta respuesta
+            // no trae el campo" (historia #19).
+            'started_at' => $this->resource->started_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * Un viaje solicitado por un pasajero.
@@ -36,11 +37,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $estimated_distance_meters
  * @property int $estimated_duration_seconds
  * @property int $estimated_fare
+ * @property Carbon|null $started_at
  */
 #[Fillable([
     'passenger_id',
     'driver_id',
     'status',
+    'started_at',
     'origin_latitude',
     'origin_longitude',
     'destination_latitude',
@@ -66,6 +69,7 @@ class Ride extends Model
             'estimated_distance_meters' => 'integer',
             'estimated_duration_seconds' => 'integer',
             'estimated_fare' => 'integer',
+            'started_at' => 'datetime',
         ];
     }
 

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -66,4 +66,27 @@ class RidePolicy
     {
         return $user->isDriver();
     }
+
+    /**
+     * Iniciar un viaje es del conductor **asignado a ese viaje** (historia
+     * #19), y por eso sí depende de la fila, al revés que `accept()`: acá el
+     * viaje ya tiene dueño del lado del conductor, y que otro cualquiera
+     * pudiera marcarlo en curso sería marcar el viaje de otra persona.
+     *
+     * Es la contraparte de `cancel()` en el lado del conductor: mismo criterio
+     * de comprobar además el rol, porque nada impide que una fila apunte a una
+     * cuenta que dejó de ser conductor.
+     *
+     * Un viaje sin conductor asignado (`requested`) no lo puede iniciar nadie,
+     * y sale de acá como 403: no es que falte un paso del ciclo de vida que el
+     * conductor pueda dar, es que ese viaje no es suyo. Que el viaje sí sea
+     * suyo pero esté en otro estado (`in_progress`, `completed`, `cancelled`)
+     * es en cambio 422, y lo decide `StartRideRequest`.
+     */
+    public function start(User $user, Ride $ride): bool
+    {
+        return $user->isDriver()
+            && $ride->driver_id !== null
+            && $ride->driver_id === $user->getKey();
+    }
 }

--- a/database/migrations/2026_07_31_000004_add_started_at_to_rides_table.php
+++ b/database/migrations/2026_07_31_000004_add_started_at_to_rides_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            // Cuándo el conductor recogió al pasajero (historia #19). Es un
+            // dato propio del viaje y no algo que se pueda deducir de
+            // `updated_at`: esa columna se mueve con cualquier escritura
+            // posterior —completar el viaje, cancelarlo— y para el pasajero,
+            // para el recibo (#26) y para la tarifa final (#24) la hora de
+            // inicio tiene que quedar fija.
+            //
+            // Nullable porque el viaje existe mucho antes de empezar: nace
+            // `requested` y puede terminar cancelado sin haber arrancado
+            // nunca. NULL significa exactamente eso, "todavía no empezó", y no
+            // hay valor por defecto que pueda representarlo sin mentir.
+            //
+            // No lleva `after()`: SQLite (desarrollo y tests) no reordena
+            // columnas, así que la posición física dependería del motor.
+            $table->timestamp('started_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            $table->dropColumn('started_at');
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -869,6 +869,7 @@ paths:
                   currency: COP
                   estimated_fare: 8850
                   requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1054,6 +1055,7 @@ paths:
                   currency: COP
                   estimated_fare: 8850
                   requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1153,6 +1155,7 @@ paths:
                   currency: COP
                   estimated_fare: 8850
                   requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1198,6 +1201,113 @@ paths:
                 errors:
                   ride:
                     - Ya tienes un viaje activo; termínalo o cancélalo antes de aceptar otro.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /rides/{id}/start:
+    post:
+      tags:
+        - Rides
+      operationId: startRide
+      summary: Iniciar un viaje aceptado
+      description: >-
+        Marca como iniciado el viaje que el conductor autenticado ya había
+        aceptado (historia #19): el viaje pasa de `accepted` a `in_progress` y
+        queda registrada la hora de inicio en `started_at`. Es la transición
+        entre "el conductor va en camino" y "el viaje está en curso", y es lo
+        que habilita el seguimiento de la ubicación para el pasajero.
+
+        Solo el conductor **asignado a ese viaje** puede iniciarlo: cualquier
+        otra cuenta —otro conductor, o el pasajero— recibe **403**. Que el
+        viaje no esté en `accepted` (ya está en curso, se completó o se
+        canceló) es en cambio **422**, porque el permiso lo tiene y lo que no
+        corresponde es la transición.
+
+        La API **no verifica por geolocalización** que el conductor esté
+        realmente en el punto de recogida; queda explícitamente fuera de esta
+        historia.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje a iniciar.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El viaje quedó en curso.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: in_progress
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: "2026-07-31T14:09:05+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El viaje no está asignado a la cuenta autenticada (o la cuenta no
+            es de un conductor).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "422":
+          description: >-
+            El viaje no está en `accepted`: ya está en curso, se completó o se
+            canceló.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Solo se puede iniciar un viaje que esté aceptado.
+                errors:
+                  ride:
+                    - Solo se puede iniciar un viaje que esté aceptado.
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:
@@ -1731,6 +1841,7 @@ components:
         - currency
         - estimated_fare
         - requested_at
+        - started_at
       properties:
         id:
           type: integer
@@ -1780,6 +1891,16 @@ components:
           format: date-time
           description: Momento en que se creó la solicitud.
           example: "2026-07-31T14:03:21+00:00"
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Momento en que el conductor marcó el viaje como iniciado
+            (historia #19). Es `null` mientras el viaje no haya empezado, y
+            el campo está siempre presente para que el cliente no tenga que
+            distinguir "todavía no empezó" de "esta respuesta no lo trae".
+          example: null
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\Rides\AcceptRideController;
 use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
+use App\Http\Controllers\Api\V1\Rides\StartRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
@@ -129,4 +130,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/{ride}/accept', AcceptRideController::class)
         ->name('rides.accept');
+
+    // Iniciar el viaje ya aceptado (historia #19). A diferencia de aceptar,
+    // acá el permiso depende del viaje concreto y no solo del rol: lo inicia
+    // el conductor asignado a *ese* viaje, y eso lo decide `RidePolicy`. Que
+    // el viaje no esté en `accepted` es 422 y lo resuelve `StartRideRequest`;
+    // no hace falta lock porque el único que puede competir por esta fila es
+    // el mismo conductor (ver `StartRideAction`).
+    Route::middleware('auth:api')
+        ->post('rides/{ride}/start', StartRideController::class)
+        ->name('rides.start');
 });

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -66,6 +66,10 @@ class RequestRideTest extends TestCase
                 'currency' => 'COP',
                 'estimated_fare' => 8850,
                 'requested_at' => $viaje->created_at?->toIso8601String(),
+                // El viaje nace sin empezar, pero el campo viaja igual: el
+                // schema `Ride` lo declara obligatorio y nullable (historia
+                // #19), así que el cliente lo encuentra siempre.
+                'started_at' => null,
             ],
         ]);
 

--- a/tests/Feature/Rides/StartRideTest.php
+++ b/tests/Feature/Rides/StartRideTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/{id}/start — ver openapi.yaml.
+ *
+ * Historia #19: el conductor que ya aceptó el viaje marca que recogió al
+ * pasajero. Lo que distingue esta operación de aceptar es de quién es el
+ * permiso: acá no vale cualquier conductor, solo el asignado a ese viaje.
+ */
+class StartRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_conductor_asignado_inicia_su_viaje_aceptado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeAceptadoPor($conductor);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'in_progress');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::InProgress->value,
+            'driver_id' => $conductor->id,
+        ]);
+    }
+
+    public function test_registra_la_hora_de_inicio(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeAceptadoPor($conductor);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        // La hora de inicio es un criterio de aceptación por sí misma, y el
+        // contrato la publica: sin ella el pasajero no puede saber desde
+        // cuándo está en curso el viaje que está viendo.
+        $this->assertNotNull($respuesta->json('data.started_at'));
+        $this->assertNotNull($viaje->refresh()->started_at);
+    }
+
+    public function test_el_viaje_no_iniciado_publica_started_at_nulo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson("/api/v1/rides/{$viaje->id}/accept")
+            ->assertOk();
+
+        // El campo está siempre presente, no solo cuando el viaje ya empezó:
+        // así el cliente no tiene que distinguir "todavía no empezó" de "esta
+        // respuesta no lo trae" (ver el schema `Ride` en openapi.yaml). La
+        // estructura se afirma aparte del valor a propósito: `assertJsonPath`
+        // contra `null` también pasa si la clave no viene, que es justo el
+        // caso que este test existe para descartar.
+        $respuesta->assertJsonStructure(['data' => ['started_at']]);
+        $respuesta->assertJsonPath('data.started_at', null);
+    }
+
+    public function test_rechaza_a_un_conductor_que_no_es_el_asignado(): void
+    {
+        $asignado = User::factory()->driver()->create();
+        $otroConductor = User::factory()->driver()->create();
+        $viaje = $this->viajeAceptadoPor($asignado);
+
+        $this->withToken(JWTAuth::fromUser($otroConductor))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Accepted->value,
+            'started_at' => null,
+        ]);
+    }
+
+    public function test_rechaza_al_pasajero_del_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Accepted->value,
+        ]);
+    }
+
+    #[DataProvider('estadosQueNoSePuedenIniciar')]
+    public function test_rechaza_un_viaje_que_no_esta_aceptado(RideStatus $estado): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => $estado,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => $estado->value,
+        ]);
+    }
+
+    public function test_rechaza_un_viaje_requested_sin_conductor_asignado(): void
+    {
+        // Sin conductor asignado no hay a quién dejarlo iniciar, así que la
+        // Policy corta antes que la validación de estado: es 403 y no 422.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Requested->value,
+        ]);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson('/api/v1/rides/999999/start')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $viaje = $this->viajeAceptadoPor(User::factory()->driver()->create());
+
+        $this->postJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Accepted->value,
+            'started_at' => null,
+        ]);
+    }
+
+    private function viajeAceptadoPor(User $conductor): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/start";
+    }
+
+    /**
+     * El criterio de aceptación #3 nombra `in_progress` y el viaje cancelado;
+     * `completed` va por el mismo camino y se cubre por completitud del ciclo
+     * de vida. `requested` queda fuera de este conjunto a propósito: ahí no
+     * hay conductor asignado y la respuesta correcta es 403, con su propio
+     * test.
+     *
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosQueNoSePuedenIniciar(): array
+    {
+        return [
+            RideStatus::InProgress->value => [RideStatus::InProgress],
+            RideStatus::Completed->value => [RideStatus::Completed],
+            RideStatus::Cancelled->value => [RideStatus::Cancelled],
+        ];
+    }
+}

--- a/tests/Unit/Actions/Rides/StartRideActionTest.php
+++ b/tests/Unit/Actions/Rides/StartRideActionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\StartRideAction;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class StartRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pasa_el_viaje_a_in_progress(): void
+    {
+        $viaje = $this->viajeAceptado();
+
+        $resultado = $this->app->make(StartRideAction::class)->handle($viaje);
+
+        $this->assertSame(RideStatus::InProgress, $resultado->status);
+        $this->assertSame(RideStatus::InProgress, $viaje->refresh()->status);
+    }
+
+    public function test_registra_la_hora_de_inicio(): void
+    {
+        Carbon::setTestNow('2026-07-31 14:09:05');
+        $viaje = $this->viajeAceptado();
+
+        $this->app->make(StartRideAction::class)->handle($viaje);
+
+        $this->assertNotNull($viaje->refresh()->started_at);
+        $this->assertTrue(Carbon::now()->equalTo($viaje->started_at));
+    }
+
+    public function test_no_toca_al_conductor_asignado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->app->make(StartRideAction::class)->handle($viaje);
+
+        $this->assertSame($conductor->getKey(), $viaje->refresh()->driver_id);
+    }
+
+    private function viajeAceptado(): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => User::factory()->driver(),
+        ]);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -61,4 +61,34 @@ class RidePolicyTest extends TestCase
     {
         $this->assertFalse(User::factory()->create()->can('accept', Ride::class));
     }
+
+    public function test_el_conductor_asignado_puede_iniciar_su_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('start', $viaje));
+    }
+
+    public function test_otro_conductor_no_puede_iniciar_un_viaje_ajeno(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse(User::factory()->driver()->create()->can('start', $viaje));
+    }
+
+    public function test_nadie_puede_iniciar_un_viaje_sin_conductor_asignado(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => null]);
+
+        $this->assertFalse(User::factory()->driver()->create()->can('start', $viaje));
+    }
+
+    public function test_el_pasajero_no_puede_iniciar_su_propio_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse($pasajero->can('start', $viaje));
+    }
 }


### PR DESCRIPTION
Closes #19

## Qué hace

`POST /api/v1/rides/{ride}/start` marca como iniciado el viaje que el conductor
autenticado ya había aceptado: pasa de `accepted` a `in_progress` y registra la
hora de inicio.

Los tres criterios de aceptación, uno por uno:

- **200 + `in_progress` + hora de inicio** — nueva columna `rides.started_at`
  (nullable: el viaje existe mucho antes de empezar y puede cancelarse sin
  arrancar nunca). Es una columna propia y no `updated_at`, que se mueve con
  cualquier escritura posterior; para el recibo (#26) y la tarifa final (#24)
  la hora de inicio tiene que quedar fija.
- **403 si el viaje no es del conductor** — `RidePolicy::start()`. Es la primera
  regla del lado conductor que depende de la fila y no solo del rol, al revés que
  `accept()`: acá el viaje ya tiene conductor asignado, y dejar que otro lo marque
  en curso sería marcar el viaje de otra persona. Un viaje `requested` (sin
  conductor) también sale 403: no es un paso del ciclo de vida que le falte al
  conductor, es que ese viaje no es suyo.
- **422 si el viaje no está en `accepted`** — `StartRideRequest`, con el error bajo
  la clave `ride` (que no es un campo de la entrada), mismo criterio que
  `CancelRideRequest`.

El contrato se actualizó primero (SDD): `openapi.yaml` gana el path `/rides/{id}/start`
y `started_at` en el schema `Ride`, obligatorio y nullable. Que sea obligatorio es la
decisión que se lleva la única incompatibilidad del PR: **todas** las respuestas que ya
publicaban un viaje (`POST /rides`, `/cancel`, `/accept`) traen el campo desde ahora,
valiendo `null` mientras el viaje no haya empezado. Es aditivo para cualquier cliente
que ignore campos desconocidos, y evita que el cliente tenga que distinguir "todavía no
empezó" de "esta respuesta no lo trae".

## Cómo se probó

Tests primero, confirmados en rojo antes de implementar (ruta y Action inexistentes,
Policy denegando).

- `tests/Feature/Rides/StartRideTest.php` — un test por criterio de aceptación, más
  403 del pasajero del viaje, 403 del viaje sin conductor, 404, 401 sin token, y
  `started_at: null` presente en un viaje que no empezó. Los estados que no se pueden
  iniciar van por data provider (`in_progress`, `completed`, `cancelled`).
- `tests/Unit/Actions/Rides/StartRideActionTest.php` y casos nuevos en
  `RidePolicyTest`.
- Suite completa: **437 tests, 437 pasando**. `./vendor/bin/pint --test` limpio,
  `phpstan` 0 errores, chequeos de complejidad/arquitectura/seguridad de las skills
  sin hallazgos.
- Conformidad estática: `15 rutas, 0 avisos`.
- Conformidad dinámica: el script dio verde **sin haber ejecutado el 200** (ver abajo),
  así que el camino de éxito se verificó aparte contra un servidor real y una
  `DB_DATABASE` de scratch — 200 con el cuerpo del schema `Ride` (`status: in_progress`,
  `started_at` poblado) y 422 documentado al repetir la llamada.
- La migración se corrió también sobre una base con datos ya existentes, que es donde
  SQLite es quisquilloso con las columnas generadas de `rides`.

## Decisiones y riesgos

- **`StartRideAction` no relee bajo lock**, a diferencia de `AcceptRideAction`, y es
  deliberado: allá compiten dos conductores distintos por un viaje libre y perder la
  carrera en silencio reasignaría el viaje de otro. Acá el único que puede llegar a la
  vez es el mismo conductor tocando el botón dos veces, y lo peor que produce esa
  carrera es un `started_at` reescrito unos milisegundos después; el segundo toque, ya
  confirmada la primera transacción, sale 422.
- **No se dispara ningún evento de broadcasting**, aunque las notas técnicas del issue
  lo mencionen. Es el mismo criterio que siguió #18 al aceptar: el canal `ride.{id}`
  hoy deniega todas las suscripciones (`PendingRideParticipants`) y quién escucha qué
  cambio de estado tiene su propio criterio de aceptación en #21. Emitirlo acá sería
  adelantar el diseño de esa historia sin sus reglas.
- **Sin validación por geolocalización** de que el conductor esté en el punto de
  recogida: explícitamente fuera de alcance en el issue.
- **No se agregó sección a `STANDARDS.md`**, siguiendo lo que hicieron #16 y #18: las
  decisiones de estas historias viven en los comentarios del código y en `openapi.yaml`.
- Se registró en `KNOWN_ERRORS.md` del skill (paso 7 del flujo) la **cuarta repetición**
  del "verde por omisión" de `dynamic_conformance.py`: `POST /auth/logout` va antes en
  el orden del spec, invalida el token compartido y deja que el resto de operaciones
  respondan un 401 que el contrato también documenta. Lo nuevo de este caso es que el
  conteo de operaciones tampoco sirve de señal (pasó de 14 a 15 "probadas" sin ejecutar
  ningún camino de éxito); lo único que lo delató fue mirar la fila en la base. La
  corrección de fondo del script sigue mereciendo su propio issue en vez de colarse en
  el PR de una feature.