### PR TITLE
feat(#17): recibir solicitudes de viaje cercanas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,11 @@ REVERB_SCHEME=http
 REVERB_SERVER_HOST=0.0.0.0
 REVERB_SERVER_PORT=8080
 
+# Aviso a conductores cercanos (historia #17): radio en metros alrededor del
+# origen de un viaje nuevo dentro del cual un conductor disponible recibe el
+# aviso por el canal driver.{id}.
+RIDES_NEARBY_RADIUS_METERS=3000
+
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 

--- a/app/Actions/Drivers/UpdateDriverAvailabilityAction.php
+++ b/app/Actions/Drivers/UpdateDriverAvailabilityAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Drivers;
+
+use App\DTOs\DriverAvailabilityUpdate;
+use App\Models\DriverProfile;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * Marca a un conductor disponible o no disponible, y opcionalmente
+ * actualiza su última posición conocida (historia #17).
+ *
+ * Es lo que decide si un conductor entra en la búsqueda de
+ * `NearbyDriverFinder` cuando se crea un viaje nuevo: sin esto, `driver.{id}`
+ * seguiría siendo un canal autorizado que nunca recibe nada.
+ */
+final readonly class UpdateDriverAvailabilityAction
+{
+    public function handle(DriverProfile $profile, DriverAvailabilityUpdate $update): DriverProfile
+    {
+        $datos = ['is_available' => $update->isAvailable];
+
+        if ($update->location !== null) {
+            $datos['latitude'] = $update->location->latitude;
+            $datos['longitude'] = $update->location->longitude;
+            $datos['location_updated_at'] = Date::now();
+        }
+
+        $profile->update($datos);
+
+        return $profile;
+    }
+}

--- a/app/Actions/Rides/AcceptRideAction.php
+++ b/app/Actions/Rides/AcceptRideAction.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Actions\Rides;
 
+use App\DTOs\Coordinates;
 use App\Enums\RideStatus;
+use App\Events\Realtime\RideNoLongerAvailable;
 use App\Exceptions\Rides\RideNoLongerAvailableException;
 use App\Models\Ride;
 use App\Models\User;
+use App\Services\Realtime\NearbyDriverFinder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -24,9 +27,15 @@ use Illuminate\Support\Facades\DB;
  * Que el conductor ya tenga un viaje propio activo lo adelanta
  * `AcceptRideRequest` (422); acá ya no queda esa decisión, solo el cambio de
  * estado.
+ *
+ * Después de confirmar el cambio, avisa a los demás conductores cercanos
+ * (historia #17) que la solicitud ya no está disponible; ver
+ * `notifyOtherDrivers()`.
  */
 final readonly class AcceptRideAction
 {
+    public function __construct(private NearbyDriverFinder $nearbyDrivers) {}
+
     /**
      * @throws RideNoLongerAvailableException si el viaje ya no está en
      *                                        `requested` cuando se resuelve
@@ -34,7 +43,7 @@ final readonly class AcceptRideAction
      */
     public function handle(Ride $ride, User $driver): Ride
     {
-        return DB::transaction(function () use ($ride, $driver): Ride {
+        $accepted = DB::transaction(function () use ($ride, $driver): Ride {
             /** @var Ride $locked */
             $locked = Ride::query()->whereKey($ride->getKey())->lockForUpdate()->firstOrFail();
 
@@ -49,5 +58,32 @@ final readonly class AcceptRideAction
 
             return $locked;
         });
+
+        $this->notifyOtherDrivers($accepted, $driver);
+
+        return $accepted;
+    }
+
+    /**
+     * A quién avisar se recalcula en este momento y no se reutiliza la lista
+     * de `RideRequested`, que no queda persistida en ningún lado (ver
+     * `App\Events\Realtime\RideNoLongerAvailable`). Se dispara después de que
+     * la transacción de arriba ya confirmó el cambio, no dentro de ella: un
+     * evento en cola no tiene por qué esperar a un lock que ya se liberó.
+     */
+    private function notifyOtherDrivers(Ride $ride, User $acceptedBy): void
+    {
+        $origin = new Coordinates((float) $ride->origin_latitude, (float) $ride->origin_longitude);
+
+        $driverIds = array_values(array_diff(
+            $this->nearbyDrivers->near($origin),
+            [$acceptedBy->getKey()],
+        ));
+
+        if ($driverIds === []) {
+            return;
+        }
+
+        RideNoLongerAvailable::dispatch($ride->id, $driverIds);
     }
 }

--- a/app/Actions/Rides/CreateRideAction.php
+++ b/app/Actions/Rides/CreateRideAction.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Actions\Rides;
 
 use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\Coordinates;
 use App\DTOs\RideRequest;
 use App\Enums\RideStatus;
+use App\Events\Realtime\RideRequested;
 use App\Exceptions\RouteEstimationFailed;
 use App\Models\Ride;
 use App\Models\User;
 use App\Services\Maps\RouteEstimator;
+use App\Services\Realtime\NearbyDriverFinder;
 
 /**
  * Crea la solicitud de viaje de un pasajero.
@@ -30,14 +33,17 @@ use App\Services\Maps\RouteEstimator;
  * ruta, la excepción sale antes del INSERT, así que tampoco queda un viaje sin
  * tarifa —que además dejaría al pasajero con un activo que no llegó a pedir.
  *
- * El aviso a los conductores cercanos es de la historia #17; acá el viaje solo
- * queda disponible.
+ * Al final avisa a los conductores cercanos disponibles (historia #17): quién
+ * es "cercano" lo resuelve `NearbyDriverFinder`, y si no hay ninguno no se
+ * dispara ningún evento —un `RideRequested` sin conductores a quién llegarle
+ * no le sirve a nadie.
  */
 final readonly class CreateRideAction
 {
     public function __construct(
         private RouteEstimator $routeEstimator,
         private CalculateFareAction $calculateFare,
+        private NearbyDriverFinder $nearbyDrivers,
     ) {}
 
     /**
@@ -49,7 +55,7 @@ final readonly class CreateRideAction
         $route = $this->routeEstimator->estimate($request->origin, $request->destination);
         $fare = $this->calculateFare->handle($route);
 
-        return Ride::create([
+        $ride = Ride::create([
             'passenger_id' => $passenger->getKey(),
             'status' => RideStatus::Requested,
             'origin_latitude' => $request->origin->latitude,
@@ -61,5 +67,29 @@ final readonly class CreateRideAction
             'currency' => $fare->currency,
             'estimated_fare' => $fare->total,
         ]);
+
+        $this->notifyNearbyDrivers($ride, $request->origin);
+
+        return $ride;
+    }
+
+    private function notifyNearbyDrivers(Ride $ride, Coordinates $origin): void
+    {
+        $driverIds = $this->nearbyDrivers->near($origin);
+
+        if ($driverIds === []) {
+            return;
+        }
+
+        RideRequested::dispatch(
+            rideId: $ride->id,
+            originLatitude: $ride->origin_latitude,
+            originLongitude: $ride->origin_longitude,
+            destinationLatitude: $ride->destination_latitude,
+            destinationLongitude: $ride->destination_longitude,
+            currency: $ride->currency,
+            estimatedFare: $ride->estimated_fare,
+            nearbyDriverIds: $driverIds,
+        );
     }
 }

--- a/app/DTOs/DriverAvailabilityUpdate.php
+++ b/app/DTOs/DriverAvailabilityUpdate.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * Entrada de `UpdateDriverAvailabilityAction` (historia #17).
+ *
+ * `location` es opcional y no un `Coordinates` a secas: marcarse no
+ * disponible no necesita traer una posición, y forzarla obligaría al
+ * cliente a inventar una.
+ */
+final readonly class DriverAvailabilityUpdate
+{
+    public function __construct(
+        public bool $isAvailable,
+        public ?Coordinates $location,
+    ) {}
+}

--- a/app/Events/Realtime/RideNoLongerAvailable.php
+++ b/app/Events/Realtime/RideNoLongerAvailable.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Realtime;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Un viaje que ya se aceptó deja de estar disponible para los demás
+ * conductores que lo habían recibido por `RideRequested` (historia #17).
+ *
+ * A quién avisar se resuelve igual que en `RideRequested` —conductor
+ * disponible dentro del radio configurado alrededor del origen— pero
+ * calculado de nuevo en el momento de aceptar, y no reutilizando la lista
+ * original: no queda persistida en ningún lado (ver `AcceptRideAction`). Un
+ * conductor que se desconectó mientras tanto no necesita el aviso, y uno que
+ * se conectó después nunca vio la solicitud, así que recibir este evento
+ * sobre un viaje que no conoce no tiene efecto en el cliente.
+ */
+final class RideNoLongerAvailable implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets;
+
+    /**
+     * @param  list<int>  $driverIds
+     */
+    public function __construct(
+        public readonly int $rideId,
+        public readonly array $driverIds,
+    ) {}
+
+    /**
+     * @return list<PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return array_map(
+            static fn (int $driverId): PrivateChannel => new PrivateChannel("driver.{$driverId}"),
+            $this->driverIds,
+        );
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'ride.unavailable';
+    }
+
+    /**
+     * @return array{ride_id: int}
+     */
+    public function broadcastWith(): array
+    {
+        return ['ride_id' => $this->rideId];
+    }
+}

--- a/app/Events/Realtime/RideRequested.php
+++ b/app/Events/Realtime/RideRequested.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Realtime;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Un viaje nuevo, disponible para los conductores disponibles cerca del
+ * origen (historia #17).
+ *
+ * A diferencia de `DriverLocationUpdated`, que va a un solo canal (el del
+ * viaje), este evento va a un canal `driver.{id}` por cada conductor
+ * cercano: quién es "cercano" ya lo resolvió `NearbyDriverFinder` antes de
+ * construir el evento, así que acá no queda ninguna consulta pendiente —
+ * mismo criterio que el resto de los eventos de negocio (ver
+ * .claude/STANDARDS.md).
+ *
+ * No lleva ningún dato del pasajero: un conductor decide si acepta por el
+ * trayecto y la tarifa, no por quién lo pide.
+ */
+final class RideRequested implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets;
+
+    /**
+     * @param  list<int>  $nearbyDriverIds
+     */
+    public function __construct(
+        public readonly int $rideId,
+        public readonly float $originLatitude,
+        public readonly float $originLongitude,
+        public readonly float $destinationLatitude,
+        public readonly float $destinationLongitude,
+        public readonly string $currency,
+        public readonly int $estimatedFare,
+        public readonly array $nearbyDriverIds,
+    ) {}
+
+    /**
+     * @return list<PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return array_map(
+            static fn (int $driverId): PrivateChannel => new PrivateChannel("driver.{$driverId}"),
+            $this->nearbyDriverIds,
+        );
+    }
+
+    /**
+     * Nombre con el que el cliente escucha el evento. Explícito para no atar
+     * la app móvil al FQCN de una clase de PHP (mismo criterio que
+     * `DriverLocationUpdated`).
+     */
+    public function broadcastAs(): string
+    {
+        return 'ride.requested';
+    }
+
+    /**
+     * @return array{
+     *     ride_id: int,
+     *     origin: array{latitude: float, longitude: float},
+     *     destination: array{latitude: float, longitude: float},
+     *     currency: string,
+     *     estimated_fare: int,
+     * }
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'ride_id' => $this->rideId,
+            'origin' => [
+                'latitude' => $this->originLatitude,
+                'longitude' => $this->originLongitude,
+            ],
+            'destination' => [
+                'latitude' => $this->destinationLatitude,
+                'longitude' => $this->destinationLongitude,
+            ],
+            'currency' => $this->currency,
+            'estimated_fare' => $this->estimatedFare,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/Drivers/UpdateDriverAvailabilityController.php
+++ b/app/Http/Controllers/Api/V1/Drivers/UpdateDriverAvailabilityController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Drivers;
+
+use App\Actions\Drivers\UpdateDriverAvailabilityAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Drivers\UpdateDriverAvailabilityRequest;
+use App\Http\Resources\DriverProfileResource;
+
+/**
+ * PATCH /api/v1/me/availability
+ *
+ * Marca al conductor autenticado disponible o no disponible para recibir
+ * solicitudes de viaje cercanas, y opcionalmente actualiza su ubicación
+ * (historia #17). Qué perfil se toca y si la cuenta puede operarlo ya lo
+ * resolvió `UpdateDriverAvailabilityRequest`.
+ */
+class UpdateDriverAvailabilityController extends Controller
+{
+    public function __invoke(
+        UpdateDriverAvailabilityRequest $request,
+        UpdateDriverAvailabilityAction $updateAvailability,
+    ): DriverProfileResource {
+        $perfil = $updateAvailability->handle($request->driverProfile(), $request->toUpdate());
+
+        return new DriverProfileResource($perfil);
+    }
+}

--- a/app/Http/Requests/Drivers/UpdateDriverAvailabilityRequest.php
+++ b/app/Http/Requests/Drivers/UpdateDriverAvailabilityRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Drivers;
+
+use App\DTOs\Coordinates;
+use App\DTOs\DriverAvailabilityUpdate;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Entrada de PATCH /api/v1/me/availability — ver openapi.yaml.
+ */
+class UpdateDriverAvailabilityRequest extends FormRequest
+{
+    private ?DriverProfile $driverProfile = null;
+
+    /**
+     * El rol se comprueba primero y sin tocar el perfil, mismo criterio que
+     * `UpdateVehicleRequest::authorize()`: a un pasajero le corresponde 403 y
+     * no 404, porque operar disponibilidad de conductor no es algo de su rol
+     * y un 404 le sugeriría que registrando un perfil podría seguir.
+     *
+     * Un conductor sin perfil creado sí llega a `driverProfile()`, que
+     * responde 404: el recurso no existe, y eso pesa más que la forma del
+     * body.
+     */
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if (! $user instanceof User || ! $user->isDriver()) {
+            return false;
+        }
+
+        return $user->can('updateAvailability', $this->driverProfile());
+    }
+
+    /**
+     * El perfil de la cuenta autenticada, o 404 si todavía no existe.
+     *
+     * Se resuelve por la relación y nunca por un id de la entrada, mismo
+     * criterio que `UpdateVehicleRequest::vehicle()`: es lo que hace
+     * estructuralmente imposible apuntar este endpoint al perfil de otro
+     * conductor.
+     */
+    public function driverProfile(): DriverProfile
+    {
+        if ($this->driverProfile instanceof DriverProfile) {
+            return $this->driverProfile;
+        }
+
+        $user = $this->user();
+        $profile = $user instanceof User ? $user->driverProfile : null;
+
+        if (! $profile instanceof DriverProfile) {
+            throw new NotFoundHttpException(
+                'No tienes un perfil de conductor; regístrate como conductor antes de marcarte disponible.',
+            );
+        }
+
+        return $this->driverProfile = $profile;
+    }
+
+    /**
+     * Normaliza `is_available` a un booleano real ANTES de `required_if` en
+     * `rules()`. Laravel solo compara `required_if:campo,true|false` sin
+     * ambigüedad cuando el valor del otro campo ya es un booleano de PHP
+     * (`parseDependentRuleParameters()` recién ahí convierte los parámetros
+     * `'true'`/`'false'` de la regla); con `1`/`"1"` la comparación es
+     * estricta y nunca calza. Se deja intacto si no vino: `required` en
+     * `rules()` es quien tiene que rechazarlo, no este hook.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('is_available')) {
+            $this->merge(['is_available' => $this->boolean('is_available')]);
+        }
+    }
+
+    /**
+     * `latitude`/`longitude` son obligatorias al marcarse disponible: sin
+     * ubicación conocida, el conductor no entraría en ninguna búsqueda por
+     * radio (ver `EloquentNearbyDriverFinder`) y la disponibilidad no
+     * serviría de nada. Al marcarse no disponible son opcionales: apagar el
+     * servicio no debería exigir mandar una posición.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'is_available' => ['required', 'boolean'],
+            'latitude' => ['required_if:is_available,true', 'numeric', 'between:-90,90'],
+            'longitude' => ['required_if:is_available,true', 'numeric', 'between:-180,180'],
+        ];
+    }
+
+    public function toUpdate(): DriverAvailabilityUpdate
+    {
+        $tieneUbicacion = $this->has('latitude') && $this->has('longitude');
+
+        return new DriverAvailabilityUpdate(
+            isAvailable: $this->boolean('is_available'),
+            location: $tieneUbicacion
+                ? new Coordinates($this->float('latitude'), $this->float('longitude'))
+                : null,
+        );
+    }
+}

--- a/app/Http/Resources/DriverProfileResource.php
+++ b/app/Http/Resources/DriverProfileResource.php
@@ -28,6 +28,17 @@ class DriverProfileResource extends JsonResource
     {
         return [
             'license_number' => $this->resource->license_number,
+            // Historia #17: si el conductor puede recibir solicitudes de
+            // viaje cercanas, y su última posición conocida. `latitude`,
+            // `longitude` y `location_updated_at` viajan siempre presentes,
+            // aunque valgan `null` — mismo criterio que `started_at` en
+            // `RideResource`: el contrato los declara nullable justamente
+            // para que el cliente no tenga que distinguir "sin ubicación
+            // todavía" de "esta respuesta no trae el campo".
+            'is_available' => $this->resource->is_available,
+            'latitude' => $this->resource->latitude,
+            'longitude' => $this->resource->longitude,
+            'location_updated_at' => $this->resource->location_updated_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Models/DriverProfile.php
+++ b/app/Models/DriverProfile.php
@@ -4,15 +4,35 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Policies\DriverProfilePolicy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
-#[Fillable(['user_id', 'license_number'])]
+/**
+ * @property bool $is_available
+ * @property float|null $latitude
+ * @property float|null $longitude
+ * @property Carbon|null $location_updated_at
+ */
+#[Fillable(['user_id', 'license_number', 'is_available', 'latitude', 'longitude', 'location_updated_at'])]
+#[UsePolicy(DriverProfilePolicy::class)]
 class DriverProfile extends Model
 {
     use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'is_available' => 'boolean',
+            'latitude' => 'float',
+            'longitude' => 'float',
+            'location_updated_at' => 'datetime',
+        ];
+    }
 
     public function user(): BelongsTo
     {

--- a/app/Policies/DriverProfilePolicy.php
+++ b/app/Policies/DriverProfilePolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+
+/**
+ * Quién puede operar sobre el perfil de conductor.
+ *
+ * Mismo criterio que `VehiclePolicy` y `RidePolicy`: la autorización de
+ * negocio vive acá y no en los claims del token (ver .claude/STANDARDS.md).
+ */
+class DriverProfilePolicy
+{
+    /**
+     * Marcar disponibilidad y publicar ubicación es del conductor **dueño**
+     * de ese perfil (historia #17).
+     *
+     * `PATCH /me/availability` no lleva id en la ruta —se llega al perfil por
+     * la cuenta que manda el token—, así que hoy no existe una request capaz
+     * de traer acá el perfil de otro conductor. La comprobación de propiedad
+     * se escribe igual, mismo criterio que `VehiclePolicy::update()`: la
+     * garantía tiene que vivir en la regla y no en la forma de la ruta de
+     * hoy.
+     *
+     * El rol se comprueba además de la propiedad: nada impide que una fila
+     * apunte a una cuenta que dejó de ser conductor.
+     */
+    public function updateAvailability(User $user, DriverProfile $profile): bool
+    {
+        return $user->isDriver() && $profile->user_id === $user->getKey();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,9 @@ namespace App\Providers;
 use App\DTOs\FareSchedule;
 use App\Services\Maps\GoogleRoutesEstimator;
 use App\Services\Maps\RouteEstimator;
+use App\Services\Realtime\EloquentNearbyDriverFinder;
 use App\Services\Realtime\EloquentRideParticipants;
+use App\Services\Realtime\NearbyDriverFinder;
 use App\Services\Realtime\RideParticipants;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -25,6 +27,22 @@ class AppServiceProvider extends ServiceProvider
         $this->registerRouteEstimator();
         $this->registerFareSchedule();
         $this->registerRideParticipants();
+        $this->registerNearbyDriverFinder();
+    }
+
+    /**
+     * Fuente de los conductores disponibles cerca de un punto (historia
+     * #17), que es lo que necesitan `CreateRideAction` y `AcceptRideAction`
+     * para avisar y desavisar a los conductores cercanos.
+     *
+     * El radio vigente sale de `config/rides.php`, mismo criterio diferido
+     * que `FareSchedule`: se lee al resolver la clase, no en cada arranque.
+     */
+    private function registerNearbyDriverFinder(): void
+    {
+        $this->app->singleton(NearbyDriverFinder::class, static fn (): NearbyDriverFinder => new EloquentNearbyDriverFinder(
+            radiusMeters: Config::integer('rides.nearby_radius_meters'),
+        ));
     }
 
     /**

--- a/app/Services/Realtime/EloquentNearbyDriverFinder.php
+++ b/app/Services/Realtime/EloquentNearbyDriverFinder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+use App\DTOs\Coordinates;
+use App\Models\DriverProfile;
+
+/**
+ * Implementación vigente de {@see NearbyDriverFinder} desde la historia #17.
+ *
+ * No hay extensión geoespacial disponible en SQLite (el motor de desarrollo y
+ * de la suite), así que el filtro por radio no se hace en SQL: se traen los
+ * conductores disponibles con ubicación conocida y se descarta cada uno en
+ * PHP con la fórmula de Haversine. El volumen de conductores simultáneamente
+ * disponibles es lo que hace viable esto sin un índice geoespacial; si deja
+ * de serlo, el punto de reemplazo es esta clase, no su interfaz.
+ */
+final readonly class EloquentNearbyDriverFinder implements NearbyDriverFinder
+{
+    /** Radio medio de la Tierra en metros (esfera IUGG). */
+    private const EARTH_RADIUS_METERS = 6_371_000;
+
+    public function __construct(private int $radiusMeters) {}
+
+    /**
+     * @return list<int>
+     */
+    public function near(Coordinates $point): array
+    {
+        return DriverProfile::query()
+            ->where('is_available', true)
+            ->whereNotNull('latitude')
+            ->whereNotNull('longitude')
+            ->get(['user_id', 'latitude', 'longitude'])
+            ->filter(fn (DriverProfile $driver): bool => $this->distanceMeters(
+                $point,
+                new Coordinates((float) $driver->latitude, (float) $driver->longitude),
+            ) <= $this->radiusMeters)
+            ->pluck('user_id')
+            ->values()
+            ->all();
+    }
+
+    private function distanceMeters(Coordinates $a, Coordinates $b): float
+    {
+        $latA = deg2rad($a->latitude);
+        $latB = deg2rad($b->latitude);
+        $deltaLat = deg2rad($b->latitude - $a->latitude);
+        $deltaLng = deg2rad($b->longitude - $a->longitude);
+
+        $haversine = sin($deltaLat / 2) ** 2
+            + cos($latA) * cos($latB) * sin($deltaLng / 2) ** 2;
+
+        return 2 * self::EARTH_RADIUS_METERS * asin(min(1.0, sqrt($haversine)));
+    }
+}

--- a/app/Services/Realtime/NearbyDriverFinder.php
+++ b/app/Services/Realtime/NearbyDriverFinder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+use App\DTOs\Coordinates;
+
+/**
+ * Qué conductores disponibles hay cerca de un punto (historia #17).
+ *
+ * Es lo único que necesitan `CreateRideAction`, para saber a quién avisar de
+ * una solicitud nueva, y `AcceptRideAction`, para saber a quién avisar de que
+ * ya no está disponible: ambas Actions piden lo mismo —conductores
+ * disponibles dentro del radio configurado alrededor de un punto— así que
+ * comparten esta interfaz en vez de repetir la consulta.
+ *
+ * Existe como interfaz por el mismo motivo que `RideParticipants`: para que
+ * quien la consume no dependa de Eloquent directamente (ver
+ * .claude/STANDARDS.md, "Services"). La implementación registrada es
+ * {@see EloquentNearbyDriverFinder}.
+ */
+interface NearbyDriverFinder
+{
+    /**
+     * Ids de los conductores marcados como disponibles, con ubicación
+     * conocida, dentro del radio configurado (`config/rides.php`) alrededor
+     * de `$point`.
+     *
+     * @return list<int>
+     */
+    public function near(Coordinates $point): array;
+}

--- a/config/rides.php
+++ b/config/rides.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Aviso a conductores cercanos
+    |--------------------------------------------------------------------------
+    |
+    | Radio, en metros, dentro del cual un conductor disponible recibe el
+    | aviso de una solicitud de viaje nueva (historia #17). Ver
+    | App\Services\Realtime\EloquentNearbyDriverFinder.
+    |
+    */
+
+    'nearby_radius_meters' => (int) env('RIDES_NEARBY_RADIUS_METERS', 3000),
+
+];

--- a/database/factories/DriverProfileFactory.php
+++ b/database/factories/DriverProfileFactory.php
@@ -23,4 +23,20 @@ class DriverProfileFactory extends Factory
             'license_number' => fake()->unique()->bothify('LIC-######'),
         ];
     }
+
+    /**
+     * Disponible para recibir solicitudes de viaje cercanas (historia #17),
+     * con una ubicación conocida. Sin esto un conductor recién registrado
+     * nunca entra en `NearbyDriverFinder` — mismo criterio del default en la
+     * migración.
+     */
+    public function available(float $latitude = 4.710989, float $longitude = -74.072092): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_available' => true,
+            'latitude' => $latitude,
+            'longitude' => $longitude,
+            'location_updated_at' => now(),
+        ]);
+    }
 }

--- a/database/migrations/2026_07_31_000005_add_availability_to_driver_profiles_table.php
+++ b/database/migrations/2026_07_31_000005_add_availability_to_driver_profiles_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            // Si el conductor puede recibir solicitudes de viaje cercanas
+            // (historia #17). Por defecto no: recién registrado, ningún
+            // conductor está trabajando todavía.
+            $table->boolean('is_available')->default(false)->after('license_number');
+
+            // Última posición conocida mientras está disponible. Nullable: un
+            // conductor puede marcarse disponible sin haber compartido
+            // ubicación todavía, aunque entonces no entra en ninguna búsqueda
+            // por radio (ver EloquentNearbyDriverFinder). Misma precisión que
+            // las coordenadas de `rides` (ver esa migración).
+            $table->decimal('latitude', 9, 7)->nullable()->after('is_available');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude');
+
+            // Cuándo se actualizó la posición por última vez. Separado de
+            // `updated_at`: esa columna también cambia al editar solo
+            // `is_available` o `license_number`, y no serviría para decidir
+            // qué tan fresca es la ubicación.
+            $table->timestamp('location_updated_at')->nullable()->after('longitude');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            $table->dropColumn(['is_available', 'latitude', 'longitude', 'location_updated_at']);
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -803,6 +803,117 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me/availability:
+    patch:
+      tags:
+        - Drivers
+      operationId: updateDriverAvailability
+      summary: Marcar disponibilidad y ubicación del conductor
+      description: >-
+        Marca al conductor autenticado disponible o no disponible para recibir
+        solicitudes de viaje nuevas cerca de su ubicación (historia #17), y
+        opcionalmente actualiza esa ubicación.
+
+        Cuelga de `/me` y no lleva id, igual que `/me/vehicle`: se llega al
+        perfil por el token, nunca por un id propio, así que estructuralmente
+        no existe forma de tocar la disponibilidad de otro conductor.
+
+        `latitude`/`longitude` son obligatorias cuando `is_available` es
+        `true`: sin una ubicación conocida, el conductor no entraría en
+        ninguna búsqueda por radio y marcarse disponible no tendría efecto.
+        Son opcionales al marcarse no disponible.
+
+        Mientras está disponible, un conductor recibe por el canal privado
+        `driver.{id}` un evento `ride.requested` por cada viaje nuevo dentro
+        del radio configurado (`RIDES_NEARBY_RADIUS_METERS`), y un evento
+        `ride.unavailable` cuando alguno de esos viajes lo acepta otro
+        conductor.
+
+        Requiere un token vigente y rol `driver`: una cuenta de pasajero
+        recibe 403. Un conductor que todavía no tiene perfil creado recibe
+        404.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateDriverAvailabilityRequest"
+            example:
+              is_available: true
+              latitude: 4.710989
+              longitude: -74.072092
+      responses:
+        "200":
+          description: Disponibilidad (y ubicación, si vino) actualizadas.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/DriverProfile"
+              example:
+                data:
+                  license_number: LIC-445566
+                  is_available: true
+                  latitude: 4.710989
+                  longitude: -74.072092
+                  location_updated_at: "2026-07-31T10:04:05-05:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no es de conductor. Marcar disponibilidad no
+            es algo que un pasajero pueda hacer con otros datos, así que no es
+            un 422.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: >-
+            La cuenta es de conductor pero todavía no tiene un perfil
+            registrado, así que no hay recurso que actualizar.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No tienes un perfil de conductor; regístrate como conductor antes de marcarte disponible.
+        "422":
+          description: >-
+            La entrada no pasó la validación: falta `is_available`, o falta
+            `latitude`/`longitude` (u otra fuera de rango) al marcarse
+            disponible.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The latitude field is required when is available is true.
+                errors:
+                  latitude:
+                    - The latitude field is required when is available is true.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /rides:
     post:
       tags:
@@ -1492,11 +1603,16 @@ components:
     DriverProfile:
       type: object
       description: >-
-        Datos que solo existen para una cuenta de conductor. Hoy es únicamente
-        la licencia; los documentos del vehículo son otra entidad y se registran
-        aparte (historia #12).
+        Datos que solo existen para una cuenta de conductor: la licencia
+        (historia #12) y la disponibilidad/ubicación para recibir solicitudes
+        de viaje cercanas (historia #17); los documentos del vehículo son otra
+        entidad y se registran aparte.
       required:
         - license_number
+        - is_available
+        - latitude
+        - longitude
+        - location_updated_at
       properties:
         license_number:
           type: string
@@ -1506,6 +1622,66 @@ components:
             verifica contra ninguna entidad externa que exista ni que esté
             vigente: devuelve lo que el conductor declaró.
           example: LIC-445566
+        is_available:
+          type: boolean
+          description: >-
+            Si el conductor está marcado como disponible para recibir
+            solicitudes de viaje cercanas por el canal `driver.{id}` (historia
+            #17). `false` por defecto: recién registrado, ningún conductor
+            está trabajando todavía.
+          example: true
+        latitude:
+          type: number
+          format: double
+          nullable: true
+          minimum: -90
+          maximum: 90
+          description: >-
+            Última posición conocida mientras está disponible. `null` si
+            todavía no la compartió.
+          example: 4.710989
+        longitude:
+          type: number
+          format: double
+          nullable: true
+          minimum: -180
+          maximum: 180
+          example: -74.072092
+        location_updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Cuándo se actualizó la posición por última vez. `null` si nunca se compartió.
+          example: "2026-07-31T10:04:05-05:00"
+    UpdateDriverAvailabilityRequest:
+      type: object
+      description: >-
+        Disponibilidad (y opcionalmente ubicación) que el conductor
+        autenticado publica para recibir solicitudes de viaje cercanas
+        (historia #17).
+      required:
+        - is_available
+      properties:
+        is_available:
+          type: boolean
+          description: Si el conductor puede recibir solicitudes de viaje cercanas en este momento.
+          example: true
+        latitude:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+          description: >-
+            Obligatoria cuando `is_available` es `true`: sin ubicación, el
+            conductor no entraría en ninguna búsqueda por radio. Opcional al
+            marcarse no disponible.
+          example: 4.710989
+        longitude:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+          example: -74.072092
     Profile:
       description: >-
         Cuenta autenticada vista por su dueño. Es el schema `User` más lo que

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Drivers\UpdateDriverAvailabilityController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
 use App\Http\Controllers\Api\V1\Rides\AcceptRideController;
@@ -91,6 +92,16 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me/vehicle', UpdateVehicleController::class)
         ->name('vehicles.update');
+
+    // Disponibilidad y ubicación del conductor mientras no está en un viaje
+    // (historia #17). Cuelga de `me`, mismo criterio que el vehículo: se
+    // llega por el token, nunca por un id propio, así que estructuralmente
+    // no existe forma de tocar la disponibilidad de otro conductor. Que solo
+    // los conductores puedan usarlo no lo decide un middleware de rol acá,
+    // sino `DriverProfilePolicy` desde `UpdateDriverAvailabilityRequest`.
+    Route::middleware('auth:api')
+        ->patch('me/availability', UpdateDriverAvailabilityController::class)
+        ->name('drivers.availability');
 
     // La solicitud de viaje (historia #15). Es un recurso propio y no un
     // sub-recurso de `me`: se direcciona por su id —es el `{rideId}` del canal

--- a/tests/Feature/Drivers/UpdateDriverAvailabilityTest.php
+++ b/tests/Feature/Drivers/UpdateDriverAvailabilityTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Drivers;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de PATCH /api/v1/me/availability — ver openapi.yaml.
+ *
+ * Historia #17: es lo que decide si un conductor entra en la búsqueda de
+ * `NearbyDriverFinder` cuando se crea un viaje nuevo. Lo que fija esta suite
+ * es qué perfil se toca (siempre el de la cuenta del token), que la ubicación
+ * sea obligatoria al marcarse disponible pero no al marcarse no disponible, y
+ * el orden de los rechazos: 403 el rol, 404 el recurso que no existe, 422 la
+ * entrada — mismo criterio que `UpdateVehicleTest`.
+ */
+class UpdateDriverAvailabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/availability';
+
+    public function test_marca_disponible_y_guarda_la_ubicacion(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id, 'license_number' => 'LIC-445566']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, [
+                'is_available' => true,
+                'latitude' => 4.710989,
+                'longitude' => -74.072092,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.license_number', 'LIC-445566')
+            ->assertJsonPath('data.is_available', true)
+            ->assertJsonPath('data.latitude', 4.710989)
+            ->assertJsonPath('data.longitude', -74.072092);
+
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $conductor->id,
+            'is_available' => true,
+            'latitude' => 4.710989,
+            'longitude' => -74.072092,
+        ]);
+    }
+
+    public function test_marca_no_disponible_sin_mandar_ubicacion(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['is_available' => false])
+            ->assertOk()
+            ->assertJsonPath('data.is_available', false);
+
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $conductor->id,
+            'is_available' => false,
+        ]);
+    }
+
+    public function test_exige_ubicacion_al_marcarse_disponible(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['is_available' => true])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['latitude', 'longitude']);
+
+        $this->assertDatabaseHas('driver_profiles', ['user_id' => $conductor->id, 'is_available' => false]);
+    }
+
+    public function test_rechaza_is_available_ausente(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['latitude' => 4.7, 'longitude' => -74.0])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('is_available');
+    }
+
+    public function test_rechaza_coordenadas_fuera_de_rango_al_marcarse_disponible(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['is_available' => true, 'latitude' => 95.0, 'longitude' => -74.0])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('latitude');
+    }
+
+    public function test_no_publica_el_id_de_la_fila_ni_el_dueno(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['is_available' => false])
+            ->assertOk();
+
+        $respuesta->assertJsonMissingPath('data.id');
+        $respuesta->assertJsonMissingPath('data.user_id');
+    }
+
+    public function test_responde_404_si_el_conductor_todavia_no_tiene_perfil(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, ['is_available' => false])
+            ->assertNotFound()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_el_404_pesa_mas_que_la_entrada_invalida(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->patchJson(self::URI, ['is_available' => 'tal-vez'])
+            ->assertNotFound();
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_marcar_disponibilidad(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->patchJson(self::URI, ['is_available' => true, 'latitude' => 4.7, 'longitude' => -74.0])
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_al_pasajero_le_responde_403_aunque_los_datos_sean_invalidos(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->patchJson(self::URI, [])
+            ->assertForbidden();
+    }
+
+    public function test_no_toca_el_perfil_de_otro_conductor_aunque_venga_su_id_en_el_body(): void
+    {
+        $otro = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $otro->id]);
+
+        $conductor = User::factory()->driver()->create();
+        $propio = DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->patchJson(self::URI, [
+                'id' => $propio->id + 1000,
+                'user_id' => $otro->id,
+                'is_available' => true,
+                'latitude' => 4.7,
+                'longitude' => -74.0,
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('driver_profiles', ['user_id' => $conductor->id, 'is_available' => true]);
+        $this->assertDatabaseHas('driver_profiles', ['user_id' => $otro->id, 'is_available' => false]);
+    }
+
+    public function test_rechaza_la_actualizacion_sin_token(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->patchJson(self::URI, ['is_available' => false])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_actualizacion_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->patchJson(self::URI, ['is_available' => false])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+}

--- a/tests/Feature/Profile/ShowProfileTest.php
+++ b/tests/Feature/Profile/ShowProfileTest.php
@@ -92,6 +92,14 @@ class ShowProfileTest extends TestCase
                     'role' => 'driver',
                     'driver_profile' => [
                         'license_number' => 'LIC-445566',
+                        // Historia #17: `false`/`null` por defecto, mismo
+                        // criterio que `started_at` en `RideResource` — el
+                        // campo viaja siempre presente, aunque no aplique
+                        // todavía.
+                        'is_available' => false,
+                        'latitude' => null,
+                        'longitude' => null,
+                        'location_updated_at' => null,
                     ],
                 ],
             ]);

--- a/tests/Feature/Rides/AcceptRideTest.php
+++ b/tests/Feature/Rides/AcceptRideTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Tests\Feature\Rides;
 
 use App\Enums\RideStatus;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
@@ -112,6 +116,119 @@ class AcceptRideTest extends TestCase
             ->assertJsonStructure(['message']);
 
         $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    /**
+     * Historia #17: al aceptarse, el viaje deja de estar disponible para los
+     * demás conductores cercanos que lo habían recibido.
+     */
+    public function test_avisa_a_los_demas_conductores_cercanos_que_el_viaje_ya_no_esta_disponible(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $viaje = $this->viajeDisponibleEnElOrigen();
+
+        $aceptante = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $aceptante->id]);
+        $otroCercano = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $otroCercano->id]);
+
+        $this->withToken(JWTAuth::fromUser($aceptante))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertCount(1, $grabador->emitidos);
+        [$canales, $evento, $payload] = $grabador->emitidos[0];
+
+        $this->assertSame(["private-driver.{$otroCercano->id}"], $canales);
+        $this->assertSame('ride.unavailable', $evento);
+        $this->assertSame($viaje->id, $payload['ride_id']);
+    }
+
+    public function test_no_avisa_al_conductor_que_acepto_el_viaje(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $viaje = $this->viajeDisponibleEnElOrigen();
+
+        $aceptante = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $aceptante->id]);
+
+        $this->withToken(JWTAuth::fromUser($aceptante))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    public function test_no_avisa_a_conductores_disponibles_fuera_del_radio(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $viaje = $this->viajeDisponibleEnElOrigen();
+
+        $aceptante = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $aceptante->id]);
+        $lejano = User::factory()->driver()->create();
+        DriverProfile::factory()->available(latitude: 4.9, longitude: -74.3)->create(['user_id' => $lejano->id]);
+
+        $this->withToken(JWTAuth::fromUser($aceptante))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    public function test_no_dispara_ningun_evento_si_no_queda_ningun_otro_conductor_cerca(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $viaje = $this->viajeDisponibleEnElOrigen();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    /**
+     * Viaje `requested` con un origen fijo, para poder ubicar conductores
+     * cerca o lejos de forma determinística (`Ride::factory()` por defecto
+     * sortea coordenadas al azar dentro de Bogotá).
+     */
+    private function viajeDisponibleEnElOrigen(): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::Requested,
+            'origin_latitude' => 4.710989,
+            'origin_longitude' => -74.072092,
+        ]);
+    }
+
+    /**
+     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
+     * anota lo que se le pidió publicar (mismo patrón que
+     * ShareRideLocationTest).
+     */
+    private function grabarBroadcasts(): object
+    {
+        $grabador = new class implements Broadcaster
+        {
+            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
+            public array $emitidos = [];
+
+            public function auth($request) {}
+
+            public function validAuthenticationResponse($request, $result) {}
+
+            public function broadcast(array $channels, $event, array $payload = []): void
+            {
+                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
+            }
+        };
+
+        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
+        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
+        Config::set('broadcasting.default', 'recording');
+
+        return $grabador;
     }
 
     private function uri(Ride $viaje): string

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Tests\Feature\Rides;
 
 use App\Enums\RideStatus;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -349,6 +352,128 @@ class RequestRideTest extends TestCase
             ->assertJsonStructure(['message']);
 
         $this->assertDatabaseCount('rides', 0);
+    }
+
+    /**
+     * Historia #17: el viaje nuevo avisa a los conductores disponibles
+     * dentro del radio configurado por el canal `driver.{id}`.
+     */
+    public function test_avisa_por_el_canal_del_conductor_disponible_dentro_del_radio(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $this->fakeRuta(distanciaMetros: 7421, duracionSegundos: 842);
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $viaje = Ride::sole();
+
+        $this->assertCount(1, $grabador->emitidos);
+        [$canales, $evento, $payload] = $grabador->emitidos[0];
+
+        $this->assertSame(["private-driver.{$conductor->id}"], $canales);
+        $this->assertSame('ride.requested', $evento);
+        $this->assertSame($viaje->id, $payload['ride_id']);
+        $this->assertSame(4.710989, $payload['origin']['latitude']);
+        $this->assertSame(-74.061, $payload['destination']['longitude']);
+        $this->assertSame('COP', $payload['currency']);
+        $this->assertSame(8850, $payload['estimated_fare']);
+    }
+
+    public function test_avisa_a_varios_conductores_disponibles_cercanos_a_la_vez(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $this->fakeRuta();
+        $primero = User::factory()->driver()->create();
+        $segundo = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $primero->id]);
+        DriverProfile::factory()->available(latitude: 4.711, longitude: -74.0715)->create(['user_id' => $segundo->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertCount(1, $grabador->emitidos);
+        [$canales] = $grabador->emitidos[0];
+        $this->assertEqualsCanonicalizing(
+            ["private-driver.{$primero->id}", "private-driver.{$segundo->id}"],
+            $canales,
+        );
+    }
+
+    public function test_no_avisa_a_un_conductor_marcado_no_disponible(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $this->fakeRuta();
+        $conductor = User::factory()->driver()->create();
+        // `is_available` en falso por defecto (ver la migración).
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    public function test_no_avisa_a_un_conductor_disponible_fuera_del_radio_configurado(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $this->fakeRuta();
+        $conductor = User::factory()->driver()->create();
+        // A varios kilómetros del origen de `datosValidos()` (4.710989,
+        // -74.072092): muy lejos del radio por defecto (3000 m).
+        DriverProfile::factory()->available(latitude: 4.9, longitude: -74.3)->create(['user_id' => $conductor->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    public function test_no_dispara_ningun_evento_si_no_hay_conductores_disponibles_cerca(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $this->fakeRuta();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, $this->datosValidos())
+            ->assertCreated();
+
+        $this->assertSame([], $grabador->emitidos);
+    }
+
+    /**
+     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
+     * anota lo que se le pidió publicar (mismo patrón que
+     * ShareRideLocationTest).
+     */
+    private function grabarBroadcasts(): object
+    {
+        $grabador = new class implements Broadcaster
+        {
+            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
+            public array $emitidos = [];
+
+            public function auth($request) {}
+
+            public function validAuthenticationResponse($request, $result) {}
+
+            public function broadcast(array $channels, $event, array $payload = []): void
+            {
+                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
+            }
+        };
+
+        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
+        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
+        Config::set('broadcasting.default', 'recording');
+
+        return $grabador;
     }
 
     private function fakeRuta(int $distanciaMetros = 7421, int $duracionSegundos = 842): void

--- a/tests/Unit/Actions/Drivers/UpdateDriverAvailabilityActionTest.php
+++ b/tests/Unit/Actions/Drivers/UpdateDriverAvailabilityActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Drivers;
+
+use App\Actions\Drivers\UpdateDriverAvailabilityAction;
+use App\DTOs\Coordinates;
+use App\DTOs\DriverAvailabilityUpdate;
+use App\Models\DriverProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class UpdateDriverAvailabilityActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_marca_disponible_y_guarda_la_ubicacion(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+
+        $actualizado = $this->action()->handle($perfil, new DriverAvailabilityUpdate(
+            isAvailable: true,
+            location: new Coordinates(4.710989, -74.072092),
+        ));
+
+        $this->assertTrue($actualizado->is_available);
+        $this->assertSame(4.710989, $actualizado->latitude);
+        $this->assertSame(-74.072092, $actualizado->longitude);
+        $this->assertNotNull($actualizado->location_updated_at);
+    }
+
+    public function test_marca_no_disponible_sin_tocar_la_ubicacion_si_no_llega_ninguna(): void
+    {
+        $perfil = DriverProfile::factory()->available()->create();
+        $ubicacionPrevia = $perfil->location_updated_at;
+
+        $actualizado = $this->action()->handle($perfil, new DriverAvailabilityUpdate(
+            isAvailable: false,
+            location: null,
+        ));
+
+        $this->assertFalse($actualizado->is_available);
+        $this->assertSame(4.710989, $actualizado->latitude);
+        $this->assertSame(-74.072092, $actualizado->longitude);
+        $this->assertNotNull($ubicacionPrevia);
+        $this->assertTrue($ubicacionPrevia->equalTo($actualizado->location_updated_at));
+    }
+
+    public function test_actualiza_la_ubicacion_de_un_conductor_ya_disponible(): void
+    {
+        $perfil = DriverProfile::factory()->available(latitude: 4.6, longitude: -74.1)->create();
+
+        $actualizado = $this->action()->handle($perfil, new DriverAvailabilityUpdate(
+            isAvailable: true,
+            location: new Coordinates(4.71, -74.07),
+        ));
+
+        $this->assertSame(4.71, $actualizado->latitude);
+        $this->assertSame(-74.07, $actualizado->longitude);
+    }
+
+    private function action(): UpdateDriverAvailabilityAction
+    {
+        return $this->app->make(UpdateDriverAvailabilityAction::class);
+    }
+}

--- a/tests/Unit/Actions/Rides/AcceptRideActionTest.php
+++ b/tests/Unit/Actions/Rides/AcceptRideActionTest.php
@@ -6,10 +6,13 @@ namespace Tests\Unit\Actions\Rides;
 
 use App\Actions\Rides\AcceptRideAction;
 use App\Enums\RideStatus;
+use App\Events\Realtime\RideNoLongerAvailable;
 use App\Exceptions\Rides\RideNoLongerAvailableException;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 /**
@@ -45,5 +48,47 @@ class AcceptRideActionTest extends TestCase
         } finally {
             $this->assertNull($viaje->refresh()->driver_id);
         }
+    }
+
+    /**
+     * Historia #17: avisa a los demás conductores cercanos que el viaje ya
+     * no está disponible.
+     */
+    public function test_dispara_ride_no_longer_available_para_los_demas_conductores_cercanos(): void
+    {
+        Event::fake([RideNoLongerAvailable::class]);
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Requested,
+            'origin_latitude' => 4.710989,
+            'origin_longitude' => -74.072092,
+        ]);
+        $aceptante = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $aceptante->id]);
+        $otroCercano = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $otroCercano->id]);
+
+        $this->app->make(AcceptRideAction::class)->handle($viaje, $aceptante);
+
+        Event::assertDispatched(
+            RideNoLongerAvailable::class,
+            fn (RideNoLongerAvailable $evento): bool => $evento->rideId === $viaje->id
+                && $evento->driverIds === [$otroCercano->id],
+        );
+    }
+
+    public function test_no_dispara_ride_no_longer_available_para_el_conductor_que_acepto(): void
+    {
+        Event::fake([RideNoLongerAvailable::class]);
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Requested,
+            'origin_latitude' => 4.710989,
+            'origin_longitude' => -74.072092,
+        ]);
+        $aceptante = User::factory()->driver()->create();
+        DriverProfile::factory()->available()->create(['user_id' => $aceptante->id]);
+
+        $this->app->make(AcceptRideAction::class)->handle($viaje, $aceptante);
+
+        Event::assertNotDispatched(RideNoLongerAvailable::class);
     }
 }

--- a/tests/Unit/Actions/Rides/CreateRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CreateRideActionTest.php
@@ -9,13 +9,16 @@ use App\DTOs\Coordinates;
 use App\DTOs\RideRequest;
 use App\DTOs\RouteEstimate;
 use App\Enums\RideStatus;
+use App\Events\Realtime\RideRequested;
 use App\Exceptions\RouteEstimationFailed;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
 use App\Services\Maps\RouteEstimator;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 /**
@@ -136,6 +139,46 @@ class CreateRideActionTest extends TestCase
         } finally {
             $this->assertDatabaseCount('rides', 1);
         }
+    }
+
+    /**
+     * Historia #17: avisa a los conductores disponibles cercanos al origen.
+     */
+    public function test_dispara_ride_requested_con_los_conductores_disponibles_cercanos(): void
+    {
+        Event::fake([RideRequested::class]);
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->available(latitude: 4.710989, longitude: -74.072092)
+            ->create(['user_id' => $conductor->id]);
+
+        $viaje = $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        Event::assertDispatched(
+            RideRequested::class,
+            fn (RideRequested $evento): bool => $evento->rideId === $viaje->id
+                && $evento->nearbyDriverIds === [$conductor->id],
+        );
+    }
+
+    public function test_no_dispara_ride_requested_si_no_hay_conductores_disponibles_cerca(): void
+    {
+        Event::fake([RideRequested::class]);
+
+        $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        Event::assertNotDispatched(RideRequested::class);
+    }
+
+    public function test_no_dispara_ride_requested_para_un_conductor_no_disponible(): void
+    {
+        Event::fake([RideRequested::class]);
+        $conductor = User::factory()->driver()->create();
+        // No disponible: la fábrica lo deja así por defecto.
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        Event::assertNotDispatched(RideRequested::class);
     }
 
     private function action(?RouteEstimate $trayecto = null): CreateRideAction

--- a/tests/Unit/Policies/DriverProfilePolicyTest.php
+++ b/tests/Unit/Policies/DriverProfilePolicyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Policies;
+
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Policy invocada directo, sin pasar por HTTP.
+ *
+ * `PATCH /me/availability` no lleva id en la ruta, así que hoy no existe una
+ * request que le pase a la Policy el perfil de otra persona. Mismo criterio
+ * que `VehiclePolicyTest`: el caso "conductor que intenta operar el perfil
+ * ajeno" es inalcanzable por HTTP y solo verificable acá.
+ */
+class DriverProfilePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_conductor_puede_actualizar_su_propia_disponibilidad(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $perfil = DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('updateAvailability', $perfil));
+    }
+
+    public function test_el_conductor_no_puede_actualizar_la_disponibilidad_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $ajeno = DriverProfile::factory()->create(['user_id' => User::factory()->driver()]);
+
+        $this->assertFalse($conductor->can('updateAvailability', $ajeno));
+    }
+
+    public function test_el_pasajero_no_puede_actualizar_disponibilidad_aunque_figure_como_dueno(): void
+    {
+        // La base no impide que una fila apunte a una cuenta de pasajero (un
+        // rol degradado a mano, por ejemplo). Operar disponibilidad sigue
+        // siendo del rol conductor, así que la propiedad sola no alcanza.
+        $pasajero = User::factory()->create();
+        $perfil = DriverProfile::factory()->create(['user_id' => $pasajero->id]);
+
+        $this->assertFalse($pasajero->can('updateAvailability', $perfil));
+    }
+}

--- a/tests/Unit/Services/Realtime/EloquentNearbyDriverFinderTest.php
+++ b/tests/Unit/Services/Realtime/EloquentNearbyDriverFinderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Realtime;
+
+use App\DTOs\Coordinates;
+use App\Models\DriverProfile;
+use App\Services\Realtime\EloquentNearbyDriverFinder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EloquentNearbyDriverFinderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ORIGEN = [4.710989, -74.072092];
+
+    public function test_encuentra_un_conductor_disponible_dentro_del_radio(): void
+    {
+        $conductor = DriverProfile::factory()->available()->create();
+
+        $ids = $this->finder(3000)->near(new Coordinates(...self::ORIGEN));
+
+        $this->assertSame([$conductor->user_id], $ids);
+    }
+
+    public function test_ignora_un_conductor_no_disponible(): void
+    {
+        DriverProfile::factory()->create([
+            'latitude' => self::ORIGEN[0],
+            'longitude' => self::ORIGEN[1],
+            'is_available' => false,
+        ]);
+
+        $this->assertSame([], $this->finder(3000)->near(new Coordinates(...self::ORIGEN)));
+    }
+
+    public function test_ignora_un_conductor_sin_ubicacion_conocida(): void
+    {
+        DriverProfile::factory()->create(['is_available' => true]);
+
+        $this->assertSame([], $this->finder(3000)->near(new Coordinates(...self::ORIGEN)));
+    }
+
+    public function test_ignora_un_conductor_disponible_fuera_del_radio(): void
+    {
+        DriverProfile::factory()->available(latitude: 4.9, longitude: -74.3)->create();
+
+        $this->assertSame([], $this->finder(3000)->near(new Coordinates(...self::ORIGEN)));
+    }
+
+    public function test_respeta_el_radio_configurado(): void
+    {
+        // ~1.1 km al norte del origen.
+        $conductor = DriverProfile::factory()->available(latitude: 4.721, longitude: -74.072092)->create();
+
+        $this->assertSame([], $this->finder(500)->near(new Coordinates(...self::ORIGEN)));
+        $this->assertSame([$conductor->user_id], $this->finder(2000)->near(new Coordinates(...self::ORIGEN)));
+    }
+
+    public function test_devuelve_varios_conductores_cercanos(): void
+    {
+        $primero = DriverProfile::factory()->available()->create();
+        $segundo = DriverProfile::factory()->available(latitude: 4.711, longitude: -74.0715)->create();
+
+        $ids = $this->finder(3000)->near(new Coordinates(...self::ORIGEN));
+
+        $this->assertEqualsCanonicalizing([$primero->user_id, $segundo->user_id], $ids);
+    }
+
+    private function finder(int $radiusMeters): EloquentNearbyDriverFinder
+    {
+        return new EloquentNearbyDriverFinder($radiusMeters);
+    }
+}


### PR DESCRIPTION
Closes #17

## Qué hace

Un conductor disponible recibe, por el canal privado `driver.{id}` que ya
existía (creado en #5, con su docblock apuntando explícitamente a esta
historia), un evento `ride.requested` por cada viaje nuevo dentro de un
radio configurable alrededor de su ubicación, y un evento `ride.unavailable`
cuando otro conductor acepta ese viaje primero.

- `App\Events\Realtime\RideRequested` / `RideNoLongerAvailable`
  (`ShouldBroadcast`), disparados desde `CreateRideAction` y
  `AcceptRideAction` respectivamente — nunca desde el controller.
- `App\Services\Realtime\NearbyDriverFinder` (interfaz) +
  `EloquentNearbyDriverFinder`: conductores disponibles con ubicación
  conocida dentro del radio (`config/rides.php`,
  `RIDES_NEARBY_RADIUS_METERS`, default 3000 m), filtrados en PHP con
  Haversine — SQLite no tiene extensión geoespacial.
- `PATCH /me/availability` (pieza de soporte, ver "Decisiones y riesgos"):
  marca al conductor disponible/no disponible y opcionalmente actualiza su
  última ubicación conocida. Sigue el mismo patrón que `PATCH /me/vehicle`
  (Action, Form Request, Policy, Resource, sub-recurso de `me` sin id en la
  ruta).
- Migración: `driver_profiles.is_available/latitude/longitude/location_updated_at`.
- `openapi.yaml`: nuevo path `/me/availability` y schema `DriverProfile`
  ampliado. Los eventos de WebSocket no se documentan ahí, mismo criterio
  que `DriverLocationUpdated` (#20): quedan en los docblocks de las clases.

## Cómo se probó

- `php vendor/bin/phpunit`: 494 tests, todos en verde (incluye ~20 tests
  nuevos: Feature de `PATCH /me/availability`, broadcasting desde
  `POST /rides` y `POST /rides/{id}/accept`, Unit de la Action, la Policy y
  `EloquentNearbyDriverFinder`).
- `php vendor/bin/pint --test`: sin errores.
- `php vendor/bin/phpstan analyse` (nivel del proyecto): sin errores.
- Revisé a mano `app/` con el checklist de `laravel-api-review` y
  `laravel-security-review` (complejidad, Controllers finos, Actions sin
  HTTP, mass assignment, autorización visible, exposición de datos,
  consistencia `.env.example`/`config`): sin hallazgos. **No pude correr
  los scripts automatizados de esas dos skills ni `static_conformance.py`/
  `dynamic_conformance.py`**: este entorno no tiene un intérprete de Python
  instalado (solo el stub de Microsoft Store). Vale la pena que alguien con
  Python disponible los corra sobre esta rama antes de mergear.

## Decisiones y riesgos

- **No existía ningún concepto de "conductor disponible" ni de ubicación
  persistida fuera de un viaje en curso.** `ShareDriverLocationAction`
  (#20) transmite la ubicación pero explícitamente no la guarda, y
  `DriverProfile` solo tenía `license_number`. El propio issue #17 asume
  que ese concepto existe ("conductor autenticado marcado como
  disponible... dentro de un radio... de su ubicación") pero no lo
  especifica, y ninguna otra historia del backlog lo cubre. Diseñé
  `PATCH /me/availability` como la pieza que falta, en vez de pedir
  aclaración, porque es una decisión de implementación (qué forma tiene el
  endpoint) y no una decisión de negocio ambigua — `STANDARDS.md` no tiene
  nada pendiente al respecto y el patrón a seguir (`/me/vehicle`) ya estaba
  establecido en el repo.
- **A quién avisar que un viaje ya no está disponible (`RideNoLongerAvailable`)
  se recalcula en el momento de aceptar**, con el mismo `NearbyDriverFinder`,
  en vez de persistir la lista original de conductores notificados. Es
  una aproximación razonable: un conductor que se desconectó mientras tanto
  no necesita el aviso, y uno que se conectó después nunca vio la
  solicitud, así que recibir el evento sobre un viaje que no conoce no
  tiene efecto en el cliente. Evita una columna nueva (`notified_driver_ids`
  o similar) para un caso donde la precisión exacta no aporta.
- **El filtro por radio se hace en PHP (Haversine), no en SQL**: SQLite (el
  motor de desarrollo y de tests) no tiene extensión geoespacial. Es viable
  mientras el volumen de conductores simultáneamente disponibles sea
  manejable; si deja de serlo, el punto de reemplazo es
  `EloquentNearbyDriverFinder`, no su interfaz.
- **`latitude`/`longitude` son obligatorias en `PATCH /me/availability`
  solo cuando `is_available` es `true`.** Marcarse no disponible no debería
  exigir mandar una posición. Nota técnica: Laravel compara
  `required_if:campo,true|false` de forma confiable solo cuando el otro
  campo ya es un booleano real de PHP, así que `prepareForValidation()`
  normaliza `is_available` con `$this->boolean()` antes de que corran las
  reglas — con `required_if:is_available,1` la comparación es estricta y
  nunca calza contra un JSON boolean real. Quedó cubierto por
  `test_exige_ubicacion_al_marcarse_disponible`.
- `DriverProfileResource` ahora expone `is_available`/`latitude`/`longitude`/
  `location_updated_at`; es un cambio aditivo pero toca la forma de
  `GET /me` para cuentas de conductor (actualicé el `assertExactJson` de
  `ShowProfileTest`).