### PR TITLE
feat(#21): ver estado y ubicación del viaje en tiempo real

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -399,6 +399,29 @@ personas concretas.
   fallar cerrado mientras el binding solo tenía sentido con la tabla `rides` ya creada
   (#15) pero sin ninguna historia que emitiera nada por el canal todavía.
 
+### Qué sale hoy por `ride.{id}` (decidido en #20 y #21)
+
+| Evento | `broadcastAs()` | Payload | Lo dispara |
+|---|---|---|---|
+| `DriverLocationUpdated` | `location.updated` | `driver_id`, `latitude`, `longitude` | `ShareDriverLocationAction` (#20) |
+| `RideStatusChanged` | `status.changed` | `status`, `driver_id` (nullable) | `AcceptRideAction`, `StartRideAction` (#21) |
+
+- El nombre del evento es siempre **explícito** con `broadcastAs()`: la app móvil
+  escucha `status.changed`, no el FQCN de una clase de PHP, que es un detalle interno
+  que se puede renombrar.
+- El evento de estado lleva el estado **nuevo**, no el anterior: el cliente ya sabe en
+  cuál estaba, y lo que necesita para repintar es a dónde pasó.
+- Se dispara solo cuando el estado **efectivamente cambió**. El conductor que pierde la
+  carrera por un viaje ya aceptado sale por la excepción sin publicar nada, así que el
+  pasajero recibe un único "te aceptaron" por el único conductor que quedó asignado.
+- `GET /api/v1/rides/{id}` es el **fallback no realtime** del canal (#21) y lo autoriza
+  la misma regla —`RidePolicy::view()` admite a los mismos dos que entran al canal—.
+  Un desacuerdo entre ambas sería un agujero: lo que no se puede leer por HTTP tampoco
+  debería llegar por el socket, y al revés.
+- La ubicación **no se persiste** ni viaja por HTTP: existe solo mientras el evento pasa
+  por el canal. Que `driver` sea `null` en la respuesta del viaje es lo que le dice al
+  cliente que todavía no hay nadie publicándola.
+
 ### La ruta de autorización es una ruta de la API
 
 `POST /api/v1/broadcasting/auth` (con `auth:api`), declarada en `routes/api.php` y

--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -182,3 +182,27 @@ que diga el resumen. Acá se verificó con `curl` contra un servidor propio y un
 del script (dejar `/auth/logout` para el final, o un token por operación) lleva cuatro
 historias pendiente y sigue mereciendo su propio issue en vez de colarse en el PR de
 una feature.
+
+### 2026-08-01 — `dynamic_conformance.py` daba por incumplido cualquier campo `nullable`
+
+**Qué pasó:** implementando `GET /rides/{id}` (#21), validar a mano el 200 real contra
+el schema `Ride` del spec falló con `None is not of type 'string'` en `started_at`, y
+lo mismo habría pasado con el `driver: null` de un viaje sin aceptar. La respuesta era
+correcta: los dos campos están documentados `nullable: true` a propósito, justamente
+para que el cliente los reciba siempre presentes.
+
+**Por qué pasó:** OpenAPI 3.0 **no es** JSON Schema. Expresa "puede venir en null" con
+su palabra clave propia `nullable: true`, que `jsonschema` no conoce y descarta en
+silencio, quedándose con `type: string` a secas. El script pasaba el schema del spec
+directo a `validate()` sin traducirlo. No se había notado antes porque —por el problema
+del token compartido de las cuatro entradas anteriores— ninguna corrida había llegado
+nunca a validar un cuerpo de éxito con un campo nullable poblado en null.
+
+**Cómo evitarlo:** corregido en el script, que era el arreglo de fondo: `as_json_schema()`
+traduce `nullable: true` a `type: [..., 'null']` (o a un `anyOf` con `{"type": "null"}`
+cuando acompaña a un `allOf`, que es la única forma de anotar un `$ref` en 3.0), se
+aplica al schema de la respuesta y también al spec con el que se construye el
+`RefResolver` —si no, lo que entra por un `$ref` volvería a llegar sin traducir—. Al
+corregirlo se comprobó que el validador sigue detectando incumplimientos reales (un
+`driver` ausente y un `started_at` numérico se reportan igual), que es lo que
+distingue arreglar el validador de apagarlo.

--- a/.claude/skills/laravel-feature-workflow/scripts/dynamic_conformance.py
+++ b/.claude/skills/laravel-feature-workflow/scripts/dynamic_conformance.py
@@ -94,6 +94,47 @@ def response_schema_for(operation: dict[str, Any], status_code: str) -> dict[str
     return content.get("schema")
 
 
+def as_json_schema(node: Any) -> Any:
+    """Traduce `nullable: true` de OpenAPI 3.0 a JSON Schema.
+
+    OpenAPI 3.0 no es JSON Schema: expresa "este campo puede venir en null"
+    con la palabra clave propia `nullable: true`, que `jsonschema` no conoce e
+    ignora — con lo cual un `started_at: null` documentado como nullable
+    fallaba con "None is not of type 'string'". El fallo es del validador, no
+    de la API: sin esta traducción el script reporta como incumplimiento
+    exactamente el patrón que el spec de este proyecto usa a propósito para
+    los campos que el cliente siempre recibe presentes (`started_at`,
+    `driver`).
+
+    Se recorre el nodo entero porque el `nullable` puede estar a cualquier
+    profundidad. Los `$ref` se dejan como están —traducirlos es imposible sin
+    resolverlos—, y por eso el RefResolver se construye sobre el spec ya
+    pasado por esta función: así lo apuntado por un `$ref` también llega
+    traducido al validador.
+    """
+    if isinstance(node, list):
+        return [as_json_schema(item) for item in node]
+
+    if not isinstance(node, dict):
+        return node
+
+    traducido = {clave: as_json_schema(valor) for clave, valor in node.items()}
+
+    if traducido.pop("nullable", False):
+        tipo = traducido.get("type")
+        if isinstance(tipo, str):
+            traducido["type"] = [tipo, "null"]
+        elif isinstance(tipo, list) and "null" not in tipo:
+            traducido["type"] = [*tipo, "null"]
+        elif tipo is None and "allOf" in traducido:
+            # `nullable` junto a un `allOf` (la única forma de anotar un $ref
+            # en 3.0): sin tipo propio que ampliar, se admite el null al lado
+            # de lo que exija el $ref.
+            traducido = {"anyOf": [{"type": "null"}, traducido]}
+
+    return traducido
+
+
 def fill_path(path: str, params: dict[str, Any]) -> str:
     filled = path
     for name, value in params.items():
@@ -134,7 +175,11 @@ def main() -> int:
     tested = 0
     skipped = 0
     failures: list[str] = []
-    resolver = RefResolver.from_schema(spec)
+    # El resolver apunta a una copia ya traducida a JSON Schema, no al spec
+    # crudo: lo que se valida contra un `$ref` sale de acá, así que un
+    # `nullable` dentro de `components.schemas` tiene que estar traducido
+    # antes de que el $ref lo alcance.
+    resolver = RefResolver.from_schema(as_json_schema(spec))
 
     try:
         for path, method, operation in iter_operations(spec):
@@ -176,7 +221,7 @@ def main() -> int:
                 continue
 
             try:
-                validate(instance=body_json, schema=schema, resolver=resolver)
+                validate(instance=body_json, schema=as_json_schema(schema), resolver=resolver)
             except ValidationError as exc:
                 failures.append(
                     f"{method.upper()} {path} ({resp.status_code}): respuesta no cumple el schema — {exc.message}"

--- a/app/Actions/Rides/AcceptRideAction.php
+++ b/app/Actions/Rides/AcceptRideAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Rides;
 use App\DTOs\Coordinates;
 use App\Enums\RideStatus;
 use App\Events\Realtime\RideNoLongerAvailable;
+use App\Events\Realtime\RideStatusChanged;
 use App\Exceptions\Rides\RideNoLongerAvailableException;
 use App\Models\Ride;
 use App\Models\User;
@@ -28,9 +29,11 @@ use Illuminate\Support\Facades\DB;
  * `AcceptRideRequest` (422); acá ya no queda esa decisión, solo el cambio de
  * estado.
  *
- * Después de confirmar el cambio, avisa a los demás conductores cercanos
- * (historia #17) que la solicitud ya no está disponible; ver
- * `notifyOtherDrivers()`.
+ * Después de confirmar el cambio salen dos avisos, los dos fuera de la
+ * transacción: al pasajero por su canal `ride.{id}`, que el viaje pasó a
+ * `accepted` y con qué conductor (historia #21); y a los demás conductores
+ * cercanos, que la solicitud ya no está disponible (historia #17, ver
+ * `notifyOtherDrivers()`).
  */
 final readonly class AcceptRideAction
 {
@@ -58,6 +61,12 @@ final readonly class AcceptRideAction
 
             return $locked;
         });
+
+        // Fuera de la transacción y no adentro: el conductor que llega tarde
+        // sale por la excepción sin pasar por acá, así que el pasajero recibe
+        // un único "te aceptaron" por el único conductor que quedó asignado
+        // (historia #21).
+        RideStatusChanged::dispatch($accepted->id, $accepted->status, $accepted->driver_id);
 
         $this->notifyOtherDrivers($accepted, $driver);
 

--- a/app/Actions/Rides/StartRideAction.php
+++ b/app/Actions/Rides/StartRideAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Rides;
 
 use App\Enums\RideStatus;
+use App\Events\Realtime\RideStatusChanged;
 use App\Models\Ride;
 
 /**
@@ -36,6 +37,12 @@ final readonly class StartRideAction
             'status' => RideStatus::InProgress,
             'started_at' => now(),
         ]);
+
+        // El pasajero está esperando en el canal del viaje desde que lo
+        // aceptaron: que arrancó es justo lo que cambia su pantalla, y desde
+        // acá empieza además a llegarle la ubicación del conductor
+        // (historias #20 y #21).
+        RideStatusChanged::dispatch($ride->id, $ride->status, $ride->driver_id);
 
         return $ride;
     }

--- a/app/Events/Realtime/RideStatusChanged.php
+++ b/app/Events/Realtime/RideStatusChanged.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Realtime;
+
+use App\Enums\RideStatus;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Una transición del ciclo de vida del viaje (historia #21).
+ *
+ * Va al canal del viaje, igual que {@see DriverLocationUpdated}: quien
+ * necesita enterarse es el pasajero que está esperando —y el conductor
+ * asignado, que ya está ahí—, y `RideChannel` resuelve que no entre nadie
+ * más.
+ *
+ * Lleva el estado **nuevo** y el conductor asignado, no el anterior: el
+ * cliente ya sabe en qué estado tenía el viaje, y lo que necesita para
+ * repintar la pantalla es a dónde pasó. Un viaje sin conductor asignado manda
+ * `driver_id: null` en vez de omitir el campo, mismo criterio que el `driver`
+ * de `GET /rides/{id}`.
+ *
+ * Es `ShouldBroadcast` (encolado), como el resto de los eventos de negocio:
+ * la respuesta HTTP de aceptar o iniciar no espera al servidor de Reverb (ver
+ * .claude/STANDARDS.md).
+ */
+final class RideStatusChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets;
+
+    public function __construct(
+        public readonly int $rideId,
+        public readonly RideStatus $status,
+        public readonly ?int $driverId,
+    ) {}
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel("ride.{$this->rideId}");
+    }
+
+    /**
+     * Nombre con el que el cliente escucha el evento. Explícito para no atar
+     * la app móvil al FQCN de una clase de PHP (mismo criterio que
+     * `DriverLocationUpdated`).
+     */
+    public function broadcastAs(): string
+    {
+        return 'status.changed';
+    }
+
+    /**
+     * @return array{status: string, driver_id: int|null}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'driver_id' => $this->driverId,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/ShowRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/ShowRideController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\ShowRideRequest;
+use App\Http\Resources\RideResource;
+use App\Models\Ride;
+
+/**
+ * GET /api/v1/rides/{ride}
+ *
+ * Devuelve el estado actual del viaje y, si ya lo aceptó alguien, quién es el
+ * conductor asignado (historia #21). Es la consulta puntual que acompaña al
+ * canal privado `ride.{id}`: el seguimiento en vivo llega por el canal, y este
+ * endpoint responde "¿en qué punto está mi viaje?" cuando el cliente arranca,
+ * vuelve del segundo plano o perdió la conexión.
+ *
+ * No hay Action detrás, mismo criterio que `ShowProfileController`: leer un
+ * viaje ya resuelto por el binding no decide ni cambia nada, y envolverlo en
+ * una Action sería un pasamanos. Sí hay Policy —a diferencia del perfil—
+ * porque acá el recurso se pide por id y sí existe la pregunta de si es suyo;
+ * la resuelve `RidePolicy::view()` desde `ShowRideRequest`.
+ */
+class ShowRideController extends Controller
+{
+    public function __invoke(ShowRideRequest $request, Ride $ride): RideResource
+    {
+        // La relación se pide explícitamente en vez de dejar que el Resource
+        // la cargue sola al serializar: es la única consulta extra de este
+        // endpoint y así queda a la vista de quien lea el controller.
+        return new RideResource($ride->loadMissing('driver'));
+    }
+}

--- a/app/Http/Requests/Rides/ShowRideRequest.php
+++ b/app/Http/Requests/Rides/ShowRideRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Models\Ride;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de GET /api/v1/rides/{ride} — ver openapi.yaml.
+ */
+class ShowRideRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `StartRideRequest`: un id inexistente sale como 404 antes de que se
+     * evalúe `authorize()`.
+     *
+     * Que un viaje ajeno responda 403 y no 404 es a propósito: los ids son
+     * correlativos, así que el 404 tampoco escondería si el viaje existe —lo
+     * único que agregaría es ambigüedad para el cliente, que no sabría si
+     * reintentar o dejar de pedirlo.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('view', $this->ride()) ?? false;
+    }
+
+    /**
+     * Un GET no trae cuerpo, y el único dato que decide esta operación es el
+     * viaje de la ruta.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Resources/RideDriverResource.php
+++ b/app/Http/Resources/RideDriverResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa al conductor asignado a un viaje según el schema `RideDriver` de
+ * openapi.yaml.
+ *
+ * Es deliberadamente más chico que {@see UserResource}: ahí el que mira es el
+ * dueño de la cuenta, acá es la contraparte del viaje. Va lo mínimo para saber
+ * a quién se está esperando; el `email`, el `phone` y el `role` no tienen nada
+ * que hacer del otro lado, y los datos de la moto (placa, modelo) no entran
+ * todavía porque ninguna historia los pidió.
+ *
+ * Sí publica el `id`, al revés que `DriverProfileResource`: es el id de `User`
+ * con el que el cliente ya nombra a la persona en el canal `driver.{id}`.
+ *
+ * @property-read User $resource
+ */
+class RideDriverResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+        ];
+    }
+}

--- a/app/Http/Resources/RideResource.php
+++ b/app/Http/Resources/RideResource.php
@@ -15,7 +15,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * el viaje sí se direcciona por él: es el `{rideId}` del canal privado
  * `ride.{rideId}` y el que van a llevar los endpoints de aceptar, iniciar y
  * completar. No publica el `passenger_id`: el viaje se solicita siempre desde la
- * cuenta que manda el token.
+ * cuenta que manda el token. Sí publica al conductor asignado, que es la única
+ * de las dos partes que el otro lado no conoce de antemano (historia #21).
  *
  * @property-read Ride $resource
  */
@@ -41,6 +42,18 @@ class RideResource extends JsonResource
             'duration_seconds' => $this->resource->estimated_duration_seconds,
             'currency' => $this->resource->currency,
             'estimated_fare' => $this->resource->estimated_fare,
+            // Presente siempre, aunque valga `null`, por el mismo motivo que
+            // `started_at`: el contrato lo declara obligatorio y nullable para
+            // que el cliente no distinga "todavía no hay conductor" de "esta
+            // respuesta no lo trae" (historia #21).
+            //
+            // La ubicación del conductor no está acá y no es un olvido: no se
+            // persiste, viaja solo por el evento `location.updated` del canal
+            // `ride.{id}` (historia #20). Que `driver` sea `null` es
+            // justamente lo que dice que todavía no hay nadie publicándola.
+            'driver' => $this->resource->driver === null
+                ? null
+                : new RideDriverResource($this->resource->driver),
             // ISO-8601 explícito en vez del formato por defecto de Eloquent:
             // el contrato publica `format: date-time` y el default trae
             // microsegundos que nadie usa acá.

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -35,6 +35,26 @@ class RidePolicy
     }
 
     /**
+     * Ver un viaje es de quienes participan de él: el pasajero que lo pidió y
+     * el conductor asignado (historia #21). Son exactamente los mismos dos que
+     * entran al canal privado `ride.{id}` — el endpoint es la consulta puntual
+     * que acompaña a ese canal, así que un desacuerdo entre ambas reglas sería
+     * un agujero: lo que no se puede leer por HTTP tampoco debería llegar por
+     * el socket, y al revés.
+     *
+     * A diferencia de `cancel()` y `start()`, acá **no** se comprueba además
+     * el rol. Esas deciden si la cuenta puede *operar* el viaje, y una cuenta
+     * que cambió de rol no debería poder; esta solo lee lo que esa misma
+     * persona ya vivió, y quitarle el acceso a su propio viaje porque después
+     * se registró como conductor sería un efecto secundario que nadie pidió.
+     */
+    public function view(User $user, Ride $ride): bool
+    {
+        return $ride->passenger_id === $user->getKey()
+            || ($ride->driver_id !== null && $ride->driver_id === $user->getKey());
+    }
+
+    /**
      * Cancelar un viaje es del pasajero **dueño** de ese viaje (historia #16).
      *
      * Que el viaje ya no esté en `requested` **no** se decide acá: eso

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -979,6 +979,7 @@ paths:
                   duration_seconds: 842
                   currency: COP
                   estimated_fare: 8850
+                  driver: null
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
         "401":
@@ -1111,6 +1112,103 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/{id}:
+    get:
+      tags:
+        - Rides
+      operationId: showRide
+      summary: Ver el estado actual de un viaje
+      description: >-
+        Devuelve el estado del viaje y, si ya lo aceptó alguien, quién es el
+        conductor asignado (historia #21). Es la consulta puntual que
+        acompaña al canal privado `ride.{id}`: el seguimiento en vivo llega
+        por el canal, y este endpoint es el que responde "¿en qué punto está
+        mi viaje?" cuando el cliente arranca, vuelve del segundo plano o
+        perdió la conexión al canal.
+
+        Lo puede consultar el pasajero dueño del viaje y el conductor
+        asignado —los mismos dos que entran al canal—; cualquier otra cuenta
+        recibe **403**.
+
+        Mientras el viaje sigue en `requested` no hay conductor todavía y
+        `driver` vale `null`. Tampoco hay ubicación que mostrar en ese punto,
+        y no porque el campo falte: la posición del conductor no viaja nunca
+        por esta respuesta, solo por el evento `location.updated` del canal,
+        que publica el conductor asignado (historia #20). Sin conductor no hay
+        nadie publicándola.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje a consultar.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El estado actual del viaje.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: requested
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  driver: null
+                  requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: null
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El viaje no es de la cuenta autenticada: ni lo pidió ni está
+            asignada a él como conductor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /rides/{id}/cancel:
     post:
       tags:
@@ -1165,6 +1263,7 @@ paths:
                   duration_seconds: 842
                   currency: COP
                   estimated_fare: 8850
+                  driver: null
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
         "401":
@@ -1265,6 +1364,9 @@ paths:
                   duration_seconds: 842
                   currency: COP
                   estimated_fare: 8850
+                  driver:
+                    id: 42
+                    name: Carlos Pérez
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
         "401":
@@ -1378,6 +1480,9 @@ paths:
                   duration_seconds: 842
                   currency: COP
                   estimated_fare: 8850
+                  driver:
+                    id: 42
+                    name: Carlos Pérez
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: "2026-07-31T14:09:05+00:00"
         "401":
@@ -2096,9 +2201,9 @@ components:
         estimaron al crearlo.
 
         No publica el `passenger_id`: el viaje se solicita siempre desde la
-        cuenta que manda el token, igual que el vehículo del conductor. Tampoco
-        trae al conductor asignado, que todavía no existe cuando el viaje nace
-        (lo asigna la historia #18).
+        cuenta que manda el token, igual que el vehículo del conductor. Sí trae
+        al conductor asignado en `driver`, que vale `null` mientras el viaje
+        sigue en `requested` (lo asigna la historia #18).
       required:
         - id
         - status
@@ -2108,6 +2213,7 @@ components:
         - duration_seconds
         - currency
         - estimated_fare
+        - driver
         - requested_at
         - started_at
       properties:
@@ -2154,6 +2260,21 @@ components:
             un cobro: el monto final se recalcula al completar el viaje con el
             trayecto realmente recorrido.
           example: 8850
+        driver:
+          allOf:
+            - $ref: "#/components/schemas/RideDriver"
+          nullable: true
+          description: >-
+            El conductor asignado al viaje, o `null` mientras nadie lo haya
+            aceptado todavía (historia #21). El campo está siempre presente,
+            igual que `started_at`, para que el cliente no tenga que
+            distinguir "todavía no hay conductor" de "esta respuesta no lo
+            trae".
+
+            Mientras vale `null` tampoco hay ubicación que seguir: la posición
+            del conductor no viaja nunca en esta respuesta, solo por el evento
+            `location.updated` del canal `ride.{id}`, y ese evento lo publica
+            el conductor asignado. Sin conductor no hay nadie publicándolo.
         requested_at:
           type: string
           format: date-time
@@ -2169,6 +2290,31 @@ components:
             el campo está siempre presente para que el cliente no tenga que
             distinguir "todavía no empezó" de "esta respuesta no lo trae".
           example: null
+    RideDriver:
+      type: object
+      description: >-
+        El conductor asignado a un viaje, visto desde el viaje (historia #21).
+
+        Es deliberadamente más chico que `User`: acá el que mira es la
+        contraparte del viaje, no el dueño de la cuenta. Va lo mínimo para
+        saber a quién se está esperando; el teléfono y los datos de la moto
+        (placa, modelo) no entran todavía porque ninguna historia los pidió, y
+        publicar el contacto de una persona a la otra es una decisión de
+        producto, no un detalle de serialización.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          description: >-
+            Id de la cuenta del conductor. Es el mismo id de `User` que usa
+            el canal privado `driver.{driverId}`.
+          example: 42
+        name:
+          type: string
+          description: Nombre con el que el conductor se registró.
+          example: Carlos Pérez
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Rides\ShareRideLocationController;
+use App\Http\Controllers\Api\V1\Rides\ShowRideController;
 use App\Http\Controllers\Api\V1\Rides\StartRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
@@ -121,6 +122,15 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/estimate', EstimateRideController::class)
         ->name('rides.estimate');
+
+    // Consultar el estado del viaje (historia #21). Es el fallback no
+    // realtime del canal privado `ride.{id}`: lo que llega por el socket
+    // mientras la app está viva, este endpoint lo responde cuando arranca o
+    // se reconecta. Por eso lo autoriza la misma regla que el canal —el
+    // pasajero dueño y el conductor asignado—, resuelta en `RidePolicy::view()`.
+    Route::middleware('auth:api')
+        ->get('rides/{ride}', ShowRideController::class)
+        ->name('rides.show');
 
     // Cancelar antes de que un conductor acepte (historia #16). Es el primer
     // endpoint del proyecto que direcciona por id de ruta: `{ride}` se

--- a/tests/Concerns/RecordsBroadcasts.php
+++ b/tests/Concerns/RecordsBroadcasts.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
+ * anota lo que se le pidió publicar.
+ *
+ * Se prefiere sobre `Event::fake()` porque lo que interesa probar no es que la
+ * Action haya despachado una clase, sino lo que efectivamente sale hacia el
+ * cliente: en qué canal, con qué nombre de evento y con qué payload. Con el
+ * evento falseado, `broadcastOn()`/`broadcastAs()`/`broadcastWith()` —que es
+ * justo el contrato que consume la app móvil— nunca llegan a ejecutarse.
+ *
+ * Vive en un trait porque lo comparten los tests de todo lo que hoy viaja por
+ * los canales: el ping de prueba (#5), la solicitud y su retiro hacia los
+ * conductores cercanos (#17), la ubicación del conductor (#20) y los cambios
+ * de estado del viaje (#21).
+ *
+ * La conexión queda registrada al arrancar el test, sin que cada caso tenga
+ * que pedirla: alcanza con que la clase use el trait. Es a propósito —una
+ * request que publique algo sin que el test lo esperara intentaría hablar con
+ * un Reverb real y fallaría por timeout de red, que es un síntoma bastante
+ * malo para diagnosticar. Los casos que además quieran mirar lo publicado
+ * piden el grabador con `grabarBroadcasts()`.
+ */
+trait RecordsBroadcasts
+{
+    private ?object $grabadorDeBroadcasts = null;
+
+    /**
+     * Lo llama Laravel al arrancar cada test, por convención de nombre
+     * (`setUp` + el nombre del trait; ver `TestCase::setUpTraits()`).
+     */
+    protected function setUpRecordsBroadcasts(): void
+    {
+        $this->grabarBroadcasts();
+    }
+
+    /**
+     * Devuelve el grabador registrado como conexión por defecto, el mismo
+     * durante todo el test. Su propiedad pública `$emitidos` acumula un
+     * `[canales, evento, payload]` por publicación, en orden.
+     */
+    protected function grabarBroadcasts(): object
+    {
+        if ($this->grabadorDeBroadcasts !== null) {
+            return $this->grabadorDeBroadcasts;
+        }
+
+        $grabador = new class implements Broadcaster
+        {
+            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
+            public array $emitidos = [];
+
+            public function auth($request) {}
+
+            public function validAuthenticationResponse($request, $result) {}
+
+            public function broadcast(array $channels, $event, array $payload = []): void
+            {
+                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
+            }
+
+            /**
+             * Solo lo publicado bajo un nombre de evento.
+             *
+             * Una misma request puede publicar varias cosas distintas —aceptar
+             * un viaje le avisa al pasajero y además retira la solicitud de los
+             * otros conductores—, así que un test que mira una de ellas filtra
+             * en vez de dar por hecho que es la única.
+             *
+             * @return list<array{0: list<string>, 1: string, 2: array<string, mixed>}>
+             */
+            public function porEvento(string $evento): array
+            {
+                return array_values(array_filter(
+                    $this->emitidos,
+                    fn (array $emitido): bool => $emitido[1] === $evento,
+                ));
+            }
+        };
+
+        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
+        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
+        Config::set('broadcasting.default', 'recording');
+
+        return $this->grabadorDeBroadcasts = $grabador;
+    }
+}

--- a/tests/Feature/Realtime/RealtimePingTest.php
+++ b/tests/Feature/Realtime/RealtimePingTest.php
@@ -7,11 +7,9 @@ namespace Tests\Feature\Realtime;
 use App\Actions\Realtime\SendRealtimePingAction;
 use App\Events\Realtime\RealtimePingSent;
 use App\Models\User;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
+use Tests\Concerns\RecordsBroadcasts;
 use Tests\TestCase;
 
 /**
@@ -26,7 +24,7 @@ use Tests\TestCase;
  */
 class RealtimePingTest extends TestCase
 {
-    use RefreshDatabase;
+    use RecordsBroadcasts, RefreshDatabase;
 
     public function test_el_ping_llega_al_broadcaster_en_el_canal_privado_del_conductor(): void
     {
@@ -85,33 +83,5 @@ class RealtimePingTest extends TestCase
         $pasajero = User::factory()->create();
 
         $this->artisan('realtime:ping', ['driver' => $pasajero->getKey()])->assertFailed();
-    }
-
-    /**
-     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
-     * anota lo que se le pidió publicar.
-     */
-    private function grabarBroadcasts(): object
-    {
-        $grabador = new class implements Broadcaster
-        {
-            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
-            public array $emitidos = [];
-
-            public function auth($request) {}
-
-            public function validAuthenticationResponse($request, $result) {}
-
-            public function broadcast(array $channels, $event, array $payload = []): void
-            {
-                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
-            }
-        };
-
-        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
-        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
-        Config::set('broadcasting.default', 'recording');
-
-        return $grabador;
     }
 }

--- a/tests/Feature/Realtime/RideChannelTest.php
+++ b/tests/Feature/Realtime/RideChannelTest.php
@@ -106,6 +106,25 @@ class RideChannelTest extends TestCase
         $this->assertFalse($channel->join(User::factory()->create(), (string) $viaje->id));
     }
 
+    /**
+     * Criterio de aceptación de la historia #21: un pasajero cualquiera no es
+     * un tercero anónimo —tiene su propio viaje andando— y aun así no escucha
+     * el de otro. El caso importa aparte del tercero sin viajes porque es el
+     * que puede confundirse en el cliente: la app manda el id que tiene a mano
+     * y el canal no debe darle nada si ese id no es el suyo.
+     */
+    public function test_un_pasajero_no_entra_al_canal_de_un_viaje_ajeno(): void
+    {
+        $ajeno = Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => User::factory()->driver()->create()->id,
+        ]);
+        $otroPasajero = User::factory()->create();
+        Ride::factory()->for($otroPasajero, 'passenger')->create();
+
+        $this->assertFalse(app(RideChannel::class)->join($otroPasajero, (string) $ajeno->id));
+    }
+
     public function test_la_implementacion_registrada_deniega_un_viaje_que_no_existe(): void
     {
         $usuario = User::factory()->create();

--- a/tests/Feature/Realtime/RideStatusChangedTest.php
+++ b/tests/Feature/Realtime/RideStatusChangedTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Enums\RideStatus;
+use App\Events\Realtime\RideStatusChanged;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\RecordsBroadcasts;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Los cambios de estado del viaje que salen por el canal privado `ride.{id}`
+ * (historia #21).
+ *
+ * Es la otra mitad de lo que el pasajero escucha mientras sigue su viaje: la
+ * ubicación del conductor la publica la historia #20, y las transiciones del
+ * ciclo de vida —que alguien aceptó, que el viaje arrancó— salen de las
+ * Actions que las producen.
+ *
+ * Se prueba desde el endpoint y no solo desde la Action porque lo que importa
+ * es lo que termina saliendo hacia el cliente (canal, nombre y payload), que
+ * es lo que el evento decide al serializarse.
+ */
+class RideStatusChangedTest extends TestCase
+{
+    use RecordsBroadcasts, RefreshDatabase;
+
+    public function test_aceptar_un_viaje_publica_el_cambio_de_estado_en_el_canal_del_viaje(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson("/api/v1/rides/{$viaje->id}/accept")
+            ->assertOk();
+
+        [$canales, , $payload] = $this->unicoCambioDeEstado($grabador);
+
+        $this->assertSame(["private-ride.{$viaje->id}"], $canales);
+        $this->assertSame(RideStatus::Accepted->value, $payload['status']);
+        $this->assertSame($conductor->id, $payload['driver_id']);
+    }
+
+    public function test_iniciar_un_viaje_publica_el_cambio_de_estado_en_el_canal_del_viaje(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson("/api/v1/rides/{$viaje->id}/start")
+            ->assertOk();
+
+        [$canales, , $payload] = $this->unicoCambioDeEstado($grabador);
+
+        $this->assertSame(["private-ride.{$viaje->id}"], $canales);
+        $this->assertSame(RideStatus::InProgress->value, $payload['status']);
+        $this->assertSame($conductor->id, $payload['driver_id']);
+    }
+
+    /**
+     * Perder la carrera por un viaje ya aceptado no cambia ningún estado, así
+     * que tampoco anuncia uno: el pasajero recibiría dos "te aceptaron" por un
+     * único conductor asignado.
+     */
+    public function test_un_intento_de_aceptar_que_llega_tarde_no_publica_nada(): void
+    {
+        $grabador = $this->grabarBroadcasts();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => User::factory()->driver()->create()->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson("/api/v1/rides/{$viaje->id}/accept")
+            ->assertConflict();
+
+        $this->assertSame([], $grabador->porEvento('status.changed'));
+    }
+
+    public function test_el_evento_declara_el_canal_y_el_nombre_que_escucha_el_cliente(): void
+    {
+        $evento = new RideStatusChanged(rideId: 7, status: RideStatus::InProgress, driverId: 42);
+
+        $this->assertSame('private-ride.7', $evento->broadcastOn()->name);
+        $this->assertSame('status.changed', $evento->broadcastAs());
+        $this->assertSame(
+            ['status' => 'in_progress', 'driver_id' => 42],
+            $evento->broadcastWith(),
+        );
+    }
+
+    /**
+     * El único `status.changed` de la request. Se filtra por evento porque
+     * aceptar puede publicar además el retiro de la solicitud hacia los otros
+     * conductores cercanos (historia #17), que acá no viene al caso; que sea
+     * exactamente uno sí importa, y es lo que se afirma.
+     *
+     * @return array{0: list<string>, 1: string, 2: array<string, mixed>}
+     */
+    private function unicoCambioDeEstado(object $grabador): array
+    {
+        $cambios = $grabador->porEvento('status.changed');
+
+        $this->assertCount(1, $cambios);
+
+        return $cambios[0];
+    }
+}

--- a/tests/Feature/Rides/AcceptRideTest.php
+++ b/tests/Feature/Rides/AcceptRideTest.php
@@ -8,11 +8,9 @@ use App\Enums\RideStatus;
 use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\RecordsBroadcasts;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -25,7 +23,7 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  */
 class AcceptRideTest extends TestCase
 {
-    use RefreshDatabase;
+    use RecordsBroadcasts, RefreshDatabase;
 
     public function test_el_conductor_acepta_un_viaje_disponible(): void
     {
@@ -136,11 +134,15 @@ class AcceptRideTest extends TestCase
             ->postJson($this->uri($viaje))
             ->assertOk();
 
-        $this->assertCount(1, $grabador->emitidos);
-        [$canales, $evento, $payload] = $grabador->emitidos[0];
+        // Se filtra por evento y no se mira `emitidos` entero porque aceptar
+        // publica además el cambio de estado hacia el pasajero (historia #21),
+        // que a este test no le incumbe.
+        $avisos = $grabador->porEvento('ride.unavailable');
+
+        $this->assertCount(1, $avisos);
+        [$canales, , $payload] = $avisos[0];
 
         $this->assertSame(["private-driver.{$otroCercano->id}"], $canales);
-        $this->assertSame('ride.unavailable', $evento);
         $this->assertSame($viaje->id, $payload['ride_id']);
     }
 
@@ -156,7 +158,7 @@ class AcceptRideTest extends TestCase
             ->postJson($this->uri($viaje))
             ->assertOk();
 
-        $this->assertSame([], $grabador->emitidos);
+        $this->assertSame([], $grabador->porEvento('ride.unavailable'));
     }
 
     public function test_no_avisa_a_conductores_disponibles_fuera_del_radio(): void
@@ -173,10 +175,10 @@ class AcceptRideTest extends TestCase
             ->postJson($this->uri($viaje))
             ->assertOk();
 
-        $this->assertSame([], $grabador->emitidos);
+        $this->assertSame([], $grabador->porEvento('ride.unavailable'));
     }
 
-    public function test_no_dispara_ningun_evento_si_no_queda_ningun_otro_conductor_cerca(): void
+    public function test_no_retira_la_solicitud_si_no_queda_ningun_otro_conductor_cerca(): void
     {
         $grabador = $this->grabarBroadcasts();
         $viaje = $this->viajeDisponibleEnElOrigen();
@@ -185,7 +187,7 @@ class AcceptRideTest extends TestCase
             ->postJson($this->uri($viaje))
             ->assertOk();
 
-        $this->assertSame([], $grabador->emitidos);
+        $this->assertSame([], $grabador->porEvento('ride.unavailable'));
     }
 
     /**
@@ -200,35 +202,6 @@ class AcceptRideTest extends TestCase
             'origin_latitude' => 4.710989,
             'origin_longitude' => -74.072092,
         ]);
-    }
-
-    /**
-     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
-     * anota lo que se le pidió publicar (mismo patrón que
-     * ShareRideLocationTest).
-     */
-    private function grabarBroadcasts(): object
-    {
-        $grabador = new class implements Broadcaster
-        {
-            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
-            public array $emitidos = [];
-
-            public function auth($request) {}
-
-            public function validAuthenticationResponse($request, $result) {}
-
-            public function broadcast(array $channels, $event, array $payload = []): void
-            {
-                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
-            }
-        };
-
-        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
-        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
-        Config::set('broadcasting.default', 'recording');
-
-        return $grabador;
     }
 
     private function uri(Ride $viaje): string

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -8,12 +8,11 @@ use App\Enums\RideStatus;
 use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\RecordsBroadcasts;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -27,7 +26,7 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  */
 class RequestRideTest extends TestCase
 {
-    use RefreshDatabase;
+    use RecordsBroadcasts, RefreshDatabase;
 
     private const URI = '/api/v1/rides';
 
@@ -68,6 +67,10 @@ class RequestRideTest extends TestCase
                 'duration_seconds' => 842,
                 'currency' => 'COP',
                 'estimated_fare' => 8850,
+                // Todavía no lo aceptó nadie, y el campo viaja igual por el
+                // mismo motivo que `started_at`: el schema `Ride` lo declara
+                // obligatorio y nullable (historia #21).
+                'driver' => null,
                 'requested_at' => $viaje->created_at?->toIso8601String(),
                 // El viaje nace sin empezar, pero el campo viaja igual: el
                 // schema `Ride` lo declara obligatorio y nullable (historia
@@ -445,35 +448,6 @@ class RequestRideTest extends TestCase
             ->assertCreated();
 
         $this->assertSame([], $grabador->emitidos);
-    }
-
-    /**
-     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
-     * anota lo que se le pidió publicar (mismo patrón que
-     * ShareRideLocationTest).
-     */
-    private function grabarBroadcasts(): object
-    {
-        $grabador = new class implements Broadcaster
-        {
-            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
-            public array $emitidos = [];
-
-            public function auth($request) {}
-
-            public function validAuthenticationResponse($request, $result) {}
-
-            public function broadcast(array $channels, $event, array $payload = []): void
-            {
-                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
-            }
-        };
-
-        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
-        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
-        Config::set('broadcasting.default', 'recording');
-
-        return $grabador;
     }
 
     private function fakeRuta(int $distanciaMetros = 7421, int $duracionSegundos = 842): void

--- a/tests/Feature/Rides/ShareRideLocationTest.php
+++ b/tests/Feature/Rides/ShareRideLocationTest.php
@@ -8,11 +8,9 @@ use App\Enums\RideStatus;
 use App\Events\Realtime\DriverLocationUpdated;
 use App\Models\Ride;
 use App\Models\User;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\RecordsBroadcasts;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -25,7 +23,7 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  */
 class ShareRideLocationTest extends TestCase
 {
-    use RefreshDatabase;
+    use RecordsBroadcasts, RefreshDatabase;
 
     public function test_el_conductor_asignado_comparte_su_ubicacion_en_el_viaje_en_curso(): void
     {
@@ -180,33 +178,5 @@ class ShareRideLocationTest extends TestCase
     private function uri(Ride $viaje): string
     {
         return "/api/v1/rides/{$viaje->id}/location";
-    }
-
-    /**
-     * Registra una conexión de broadcasting que, en vez de hablar con Reverb,
-     * anota lo que se le pidió publicar (mismo patrón que RealtimePingTest).
-     */
-    private function grabarBroadcasts(): object
-    {
-        $grabador = new class implements Broadcaster
-        {
-            /** @var list<array{0: list<string>, 1: string, 2: array<string, mixed>}> */
-            public array $emitidos = [];
-
-            public function auth($request) {}
-
-            public function validAuthenticationResponse($request, $result) {}
-
-            public function broadcast(array $channels, $event, array $payload = []): void
-            {
-                $this->emitidos[] = [array_map(strval(...), $channels), $event, $payload];
-            }
-        };
-
-        Broadcast::extend('recording', fn (): Broadcaster => $grabador);
-        Config::set('broadcasting.connections.recording', ['driver' => 'recording']);
-        Config::set('broadcasting.default', 'recording');
-
-        return $grabador;
     }
 }

--- a/tests/Feature/Rides/ShowRideTest.php
+++ b/tests/Feature/Rides/ShowRideTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/rides/{id} — ver openapi.yaml.
+ *
+ * Historia #21: el pasajero sigue su viaje en vivo por el canal `ride.{id}`,
+ * y este endpoint es la consulta puntual con la que arranca o se recupera si
+ * perdió el canal. Lo consultan los mismos dos que entran al canal: el
+ * pasajero dueño y el conductor asignado.
+ */
+class ShowRideTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_consulta_el_estado_de_su_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', RideStatus::Requested->value);
+        $respuesta->assertJsonPath('data.estimated_fare', $viaje->estimated_fare);
+    }
+
+    /**
+     * El criterio de aceptación de #21 sobre un viaje todavía sin aceptar:
+     * la respuesta tiene que decir que no hay conductor. Y no hay ubicación
+     * que seguir justamente porque no hay conductor — la posición no viaja
+     * nunca por esta respuesta, solo por el evento `location.updated` del
+     * canal, que publica el conductor asignado (#20).
+     */
+    public function test_un_viaje_sin_aceptar_publica_el_conductor_en_nulo(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Requested,
+            'driver_id' => null,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.status', RideStatus::Requested->value);
+        $respuesta->assertJsonPath('data.driver', null);
+
+        // Presente y en `null`, no ausente: el contrato lo declara obligatorio
+        // para que el cliente no distinga "todavía no hay conductor" de "esta
+        // respuesta no lo trae".
+        $this->assertArrayHasKey('driver', $respuesta->json('data'));
+    }
+
+    #[DataProvider('estadosConConductorAsignado')]
+    public function test_un_viaje_con_conductor_publica_quien_es(RideStatus $estado): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create(['name' => 'Carlos Pérez']);
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => $estado,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.status', $estado->value);
+        $respuesta->assertJsonPath('data.driver.id', $conductor->id);
+        $respuesta->assertJsonPath('data.driver.name', 'Carlos Pérez');
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosConConductorAsignado(): array
+    {
+        return [
+            RideStatus::Accepted->value => [RideStatus::Accepted],
+            RideStatus::InProgress->value => [RideStatus::InProgress],
+        ];
+    }
+
+    /**
+     * El conductor asignado ve el viaje por el mismo endpoint: es la otra
+     * mitad del canal `ride.{id}`, no un tercero.
+     */
+    public function test_el_conductor_asignado_tambien_consulta_el_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson($this->uri($viaje))
+            ->assertOk()
+            ->assertJsonPath('data.id', $viaje->id);
+    }
+
+    /**
+     * El conductor asignado no lleva datos de contacto ni de la moto: ninguna
+     * historia los pidió todavía y publicar el teléfono de una persona a la
+     * otra es una decisión de producto, no de serialización.
+     */
+    public function test_el_conductor_publicado_no_lleva_datos_de_contacto(): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $conductorPublicado = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertOk()
+            ->json('data.driver');
+
+        $this->assertSame(['id', 'name'], array_keys($conductorPublicado));
+    }
+
+    public function test_rechaza_a_quien_no_participa_del_viaje(): void
+    {
+        $viaje = Ride::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * Un conductor cualquiera tampoco: aceptar un viaje disponible es otra
+     * operación (#18) y no pasa por acá.
+     */
+    public function test_rechaza_a_un_conductor_que_no_es_el_asignado(): void
+    {
+        $asignado = User::factory()->driver()->create();
+        $otroConductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $asignado->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($otroConductor))
+            ->getJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson('/api/v1/rides/999999')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $viaje = Ride::factory()->create();
+
+        $this->getJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}";
+    }
+}

--- a/tests/Feature/Rides/StartRideTest.php
+++ b/tests/Feature/Rides/StartRideTest.php
@@ -9,6 +9,7 @@ use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\RecordsBroadcasts;
 use Tests\TestCase;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -18,10 +19,15 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  * Historia #19: el conductor que ya aceptó el viaje marca que recogió al
  * pasajero. Lo que distingue esta operación de aceptar es de quién es el
  * permiso: acá no vale cualquier conductor, solo el asignado a ese viaje.
+ *
+ * Iniciar publica el cambio de estado hacia el pasajero (historia #21); lo que
+ * sale por el canal se prueba en `RideStatusChangedTest`. Acá el trait está
+ * solo para que las requests que lo disparan no terminen buscando un Reverb
+ * real.
  */
 class StartRideTest extends TestCase
 {
-    use RefreshDatabase;
+    use RecordsBroadcasts, RefreshDatabase;
 
     public function test_el_conductor_asignado_inicia_su_viaje_aceptado(): void
     {

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Policies;
 
+use App\Enums\UserRole;
 use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -90,5 +91,47 @@ class RidePolicyTest extends TestCase
         $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['driver_id' => User::factory()->driver()]);
 
         $this->assertFalse($pasajero->can('start', $viaje));
+    }
+
+    public function test_el_pasajero_dueno_puede_ver_su_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $this->assertTrue($pasajero->can('view', $viaje));
+    }
+
+    public function test_el_conductor_asignado_puede_ver_el_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('view', $viaje));
+    }
+
+    public function test_un_tercero_no_puede_ver_el_viaje(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse(User::factory()->create()->can('view', $viaje));
+        $this->assertFalse(User::factory()->driver()->create()->can('view', $viaje));
+    }
+
+    /**
+     * Ver el viaje **no** comprueba el rol además de la propiedad, al revés
+     * que cancelar o iniciar. Es a propósito: allá se decide si esa cuenta
+     * puede *operar* el viaje, y una cuenta que cambió de rol no debería poder
+     * hacerlo; acá solo se lee lo que esa misma persona ya vivió, y quitarle
+     * el acceso a su propio historial por un cambio de rol sería un efecto
+     * secundario, no una regla que alguien haya pedido.
+     */
+    public function test_quien_participo_del_viaje_lo_sigue_viendo_aunque_cambie_de_rol(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $pasajero->update(['role' => UserRole::Driver]);
+
+        $this->assertTrue($pasajero->fresh()->can('view', $viaje));
     }
 }


### PR DESCRIPTION
Closes #21

## Qué hace

Cierra la mitad del pasajero del seguimiento en vivo: hasta ahora el conductor
publicaba su ubicación (#20) pero por el canal `ride.{id}` no viajaba ningún cambio
de estado, y no había forma de consultar el viaje por HTTP.

- **`GET /api/v1/rides/{id}`** — consulta puntual del viaje. Es el fallback no
  realtime del canal: responde "¿en qué punto está mi viaje?" cuando el cliente
  arranca, vuelve del segundo plano o perdió la conexión.
- **Evento `RideStatusChanged`** (`status.changed`, `ShouldBroadcast`) al canal
  `ride.{id}`, disparado desde `AcceptRideAction` y `StartRideAction` con el estado
  nuevo y el conductor asignado.
- **`RidePolicy::view()`** — autoriza al pasajero dueño y al conductor asignado, los
  mismos dos que entran al canal.
- **Schema `Ride` + `RideResource`**: nuevo campo `driver` (`RideDriver`: `id`,
  `name`), presente siempre y `null` mientras nadie haya aceptado.

Criterios de aceptación:

| AC | Dónde queda cubierto |
|---|---|
| Suscrito a `ride.{id}` recibe ubicación **y** cambios de estado | `RideStatusChangedTest` (el de ubicación ya venía de #20) |
| Suscribirse a un viaje ajeno se rechaza | `RideChannelTest::test_un_pasajero_no_entra_al_canal_de_un_viaje_ajeno` |
| Un viaje `requested` indica que no hay conductor ni ubicación | `ShowRideTest::test_un_viaje_sin_aceptar_publica_el_conductor_en_nulo` |

## Cómo se probó

Flujo Issue → SDD → TDD → implementación → conformidad. Los tests se escribieron
contra el spec y fallaron primero (14 fallos + 1 error antes de implementar).

- `php artisan test`: **474 pasando**, 1402 assertions.
- `./vendor/bin/pint --test`, `composer stan` (0 errores), `composer audit`,
  `complexity_check.py`, `architecture_check.py`, `security_check.py` — todo en verde.
- Conformidad estática: `17 rutas, 0 avisos`.
- Conformidad dinámica: `17 operaciones, sin fallos`. Como el `OK` del script no
  prueba que el 200 autenticado se haya ejecutado (ver `KNOWN_ERRORS.md`), el camino
  de éxito se verificó aparte contra un servidor real y se validó el cuerpo contra el
  schema del spec, en los dos estados: `driver: null` (viaje `requested`) y
  `driver: {id, name}` (viaje `accepted`).

## Decisiones y riesgos

- **`driver` es un campo del schema `Ride` compartido**, así que también aparece en
  las respuestas de solicitar/cancelar/aceptar/iniciar. Es aditivo y nullable, pero
  toca el contrato de esos cuatro endpoints: sus ejemplos en `openapi.yaml` y la
  aserción exacta de `RequestRideTest` se actualizaron en consecuencia.
- **`RideDriver` lleva solo `id` y `name`.** El teléfono del conductor y los datos de
  la moto (placa, modelo) serían útiles para el pasajero, pero ninguna historia los
  pidió y publicar el contacto de una persona a la otra es una decisión de producto.
  Queda como candidato a historia aparte.
- **`view()` no comprueba el rol**, al revés que `cancel()`/`start()`. Esas deciden si
  la cuenta puede *operar* el viaje; esta solo lee lo que esa misma persona ya vivió, y
  quitarle el acceso a su propio viaje por un cambio de rol sería un efecto secundario
  que nadie pidió. Hay un test que fija ese comportamiento.
- **Viaje ajeno responde 403 y no 404.** Los ids son correlativos, así que el 404
  tampoco escondería si el viaje existe; lo único que agregaría es ambigüedad.
- **`CancelRideAction` no dispara el evento.** La cancelación de #16 solo aplica a un
  viaje `requested`, donde no hay conductor escuchando y el único suscrito es quien la
  pidió. Las cancelaciones con conductor asignado son #22/#23 y ahí sí corresponde.

### Fuera del alcance estricto del issue (señalado a propósito)

- **`dynamic_conformance.py` no traducía `nullable` de OpenAPI 3.0 a JSON Schema**, así
  que daba por incumplido cualquier campo nullable — `started_at` (#19) y el `driver`
  nuevo. No se había notado porque ninguna corrida había llegado a validar un cuerpo de
  éxito. Sin arreglarlo, el paso de conformidad de esta feature no probaba nada, así
  que se corrigió en el script (`as_json_schema()`) y se registró en `KNOWN_ERRORS.md`.
  Se verificó que el validador **sigue detectando incumplimientos reales**.
- **El grabador de broadcasts estaba duplicado** en `RealtimePingTest` y
  `ShareRideLocationTest`; este PR necesitaba un tercer uso. Se extrajo a
  `tests/Concerns/RecordsBroadcasts` sin cambiar su comportamiento.
- `STANDARDS.md` documenta qué eventos salen hoy por `ride.{id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)