### PR TITLE
feat(#22): cancelar un viaje aceptado (pasajero)

### DIFF
--- a/app/Actions/Rides/CancelRideAction.php
+++ b/app/Actions/Rides/CancelRideAction.php
@@ -4,27 +4,36 @@ declare(strict_types=1);
 
 namespace App\Actions\Rides;
 
+use App\DTOs\RideCancellation;
 use App\Enums\RideStatus;
 use App\Models\Ride;
 
 /**
- * Cancela un viaje que un pasajero todavía no ha visto aceptado (historia #16).
+ * Cancela un viaje del pasajero autenticado, ya sea que todavía no lo haya
+ * visto aceptado (historia #16) o que un conductor ya lo haya aceptado
+ * (historia #22) — `CancelRideRequest` es quien decide cuáles estados llegan
+ * hasta acá, así que esta Action no distingue el caso salvo para calcular si
+ * corresponde penalización.
  *
- * El viaje llega ya resuelto y ya validado: que siga en `requested` lo
- * garantiza `CancelRideRequest` antes de invocar esta Action, así que acá no
- * queda ninguna decisión de negocio, solo el cambio de estado.
- *
- * No hace falta tocar `driver_id` ni `active_passenger_id`: el viaje nunca
- * tuvo conductor asignado en este estado, y `active_passenger_id` es una
- * columna generada por la base que se recalcula sola al salir de los estados
- * activos (ver la migración de `rides`).
+ * No hace falta tocar `driver_id`: el conductor asignado queda en la fila
+ * como registro histórico de a quién se le canceló, y `active_driver_id` es
+ * una columna generada por la base que se recalcula sola al salir de los
+ * estados activos, igual que `active_passenger_id` (ver la migración de
+ * `rides`), así que el conductor queda libre para aceptar otro viaje sin que
+ * esta Action escriba nada más.
  */
 final readonly class CancelRideAction
 {
-    public function handle(Ride $ride): Ride
+    public function handle(Ride $ride): RideCancellation
     {
+        // Solo cancelar un viaje ya `accepted` implica que un conductor se
+        // había comprometido y se desplazó hacia el punto de recogida; por
+        // eso la penalización depende del estado *antes* de cancelar, y no
+        // de si el viaje terminó con conductor asignado.
+        $feeApplies = $ride->status === RideStatus::Accepted;
+
         $ride->update(['status' => RideStatus::Cancelled]);
 
-        return $ride;
+        return new RideCancellation($ride, $feeApplies);
     }
 }

--- a/app/DTOs/RideCancellation.php
+++ b/app/DTOs/RideCancellation.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Models\Ride;
+
+/**
+ * Resultado de cancelar un viaje: el viaje ya `cancelled` junto con si esta
+ * cancelación en particular generó una penalización por cancelación tardía
+ * (historia #22).
+ *
+ * El cálculo y cobro efectivo del cargo, si aplica, quedan fuera de esta
+ * historia: acá solo se determina si corresponde, igual que `RideEstimate`
+ * solo estima sin cobrar.
+ */
+final readonly class RideCancellation
+{
+    public function __construct(
+        public Ride $ride,
+        public bool $feeApplies,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
@@ -7,16 +7,17 @@ namespace App\Http\Controllers\Api\V1\Rides;
 use App\Actions\Rides\CancelRideAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Rides\CancelRideRequest;
-use App\Http\Resources\RideResource;
+use App\Http\Resources\RideCancellationResource;
 use App\Models\Ride;
 use Illuminate\Http\JsonResponse;
 
 /**
  * POST /api/v1/rides/{ride}/cancel
  *
- * Cancela la solicitud de viaje del pasajero autenticado mientras sigue en
- * `requested`, sin generar ningún cargo (historia #16). El viaje ya llega
- * validado desde `CancelRideRequest`, así que acá no queda ninguna decisión.
+ * Cancela el viaje del pasajero autenticado, ya sea que siga en `requested`
+ * (historia #16) o que un conductor ya lo haya aceptado (historia #22). El
+ * viaje ya llega validado desde `CancelRideRequest`, así que acá no queda
+ * ninguna decisión.
  *
  * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
  * implícito de la ruta (`{ride}`): la reflexión de esta firma es lo que usa
@@ -31,8 +32,8 @@ class CancelRideController extends Controller
         CancelRideAction $cancelRide,
         Ride $ride,
     ): JsonResponse {
-        $ride = $cancelRide->handle($ride);
+        $cancellation = $cancelRide->handle($ride);
 
-        return (new RideResource($ride))->response();
+        return (new RideCancellationResource($cancellation))->response();
     }
 }

--- a/app/Http/Requests/Rides/CancelRideRequest.php
+++ b/app/Http/Requests/Rides/CancelRideRequest.php
@@ -46,25 +46,37 @@ class CancelRideRequest extends FormRequest
     public function after(): array
     {
         return [
-            $this->rejectAlreadyAccepted(...),
+            $this->rejectNotCancellable(...),
         ];
     }
 
     /**
-     * Que el viaje ya no esté en `requested` no es un problema de permisos
-     * —el pasajero sigue siendo dueño del viaje— sino de en qué punto del
-     * ciclo de vida está: por eso es 422 y no 403, y por eso vive acá y no en
+     * Este endpoint cubre dos ventanas del ciclo de vida del viaje: antes de
+     * que un conductor lo acepte (`requested`, historia #16) y después de que
+     * lo acepta pero todavía no lo inicia (`accepted`, historia #22) — en
+     * ambos casos el pasajero sigue siendo dueño del viaje, así que a partir
+     * de acá no es un problema de permisos sino de en qué punto del ciclo de
+     * vida está, por eso es 422 y no 403, y por eso vive acá y no en
      * `RidePolicy::cancel()`. Mismo criterio que "ya tiene un viaje activo"
      * en `CreateRideRequest`, con el error bajo la clave `ride`, que tampoco
      * es un campo de la entrada.
+     *
+     * El `match` cubre los cinco casos de `RideStatus` en vez de aislar los
+     * dos cancelables con un `if` antes: así queda un único punto exhaustivo
+     * — si `RideStatus` gana un caso nuevo, esto deja de compilar en vez de
+     * fallar en silencio con un mensaje genérico.
      */
-    private function rejectAlreadyAccepted(Validator $validator): void
+    private function rejectNotCancellable(Validator $validator): void
     {
-        if ($this->ride()->status !== RideStatus::Requested) {
-            $validator->errors()->add(
-                'ride',
-                'El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.',
-            );
+        $message = match ($this->ride()->status) {
+            RideStatus::Requested, RideStatus::Accepted => null,
+            RideStatus::InProgress => 'El viaje está en curso; no se puede cancelar de esta forma.',
+            RideStatus::Completed => 'El viaje ya se completó; no se puede cancelar.',
+            RideStatus::Cancelled => 'El viaje ya estaba cancelado.',
+        };
+
+        if ($message !== null) {
+            $validator->errors()->add('ride', $message);
         }
     }
 

--- a/app/Http/Resources/RideCancellationResource.php
+++ b/app/Http/Resources/RideCancellationResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\DTOs\RideCancellation;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el resultado de cancelar un viaje según el schema de la
+ * respuesta 200 de `POST /rides/{id}/cancel` en openapi.yaml: los mismos
+ * campos que `RideResource` más `cancellation_fee_applies`.
+ *
+ * Reutiliza `RideResource` para el viaje en vez de repetir el mapeo de
+ * campos: esta clase solo agrega el campo que `RideResource` no conoce.
+ *
+ * @property-read RideCancellation $resource
+ */
+class RideCancellationResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            ...(new RideResource($this->resource->ride))->toArray($request),
+            'cancellation_fee_applies' => $this->resource->feeApplies,
+        ];
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1116,19 +1116,25 @@ paths:
       tags:
         - Rides
       operationId: cancelRide
-      summary: Cancelar una solicitud de viaje antes de que un conductor la acepte
+      summary: Cancelar un viaje solicitado o ya aceptado
       description: >-
-        Cancela el viaje del pasajero autenticado mientras sigue en
-        `requested`, sin que se genere ningún cargo (historia #16). Es la
-        ventana entre pedir el viaje y que algún conductor lo acepte; una vez
-        que el viaje pasa a `accepted` o más adelante, este endpoint ya no
-        aplica — esa cancelación tiene sus propias reglas (penalización,
-        liberar al conductor) y es una historia aparte (#22, #23).
+        Cancela el viaje del pasajero autenticado, ya sea que siga en
+        `requested` (historia #16) o que un conductor ya lo haya aceptado en
+        `accepted` (historia #22). En ambos casos el viaje pasa a
+        `cancelled`; la diferencia es `cancellation_fee_applies` en la
+        respuesta: `false` cuando todavía no había conductor asignado, y
+        `true` cuando ya lo había, porque ese conductor ya se había
+        comprometido y desplazado hacia el punto de recogida. El cálculo y
+        cobro efectivo de esa penalización, si aplica, se procesan en el
+        flujo de pagos — acá solo se indica si corresponde.
+
+        Un viaje `in_progress`, `completed` o ya `cancelled` no se puede
+        cancelar por este endpoint.
 
         Solo el pasajero dueño del viaje puede cancelarlo: cualquier otra
-        cuenta recibe **403**. Que el viaje ya no esté en `requested` es en
-        cambio **422**, porque no es un problema de permisos sino de en qué
-        punto del ciclo de vida está el viaje.
+        cuenta recibe **403**. Que el viaje no esté en un estado cancelable
+        es en cambio **422**, porque no es un problema de permisos sino de en
+        qué punto del ciclo de vida está el viaje.
       security:
         - bearerAuth: []
       parameters:
@@ -1150,7 +1156,23 @@ paths:
                   - data
                 properties:
                   data:
-                    $ref: "#/components/schemas/Ride"
+                    allOf:
+                      - $ref: "#/components/schemas/Ride"
+                      - type: object
+                        required:
+                          - cancellation_fee_applies
+                        properties:
+                          cancellation_fee_applies:
+                            type: boolean
+                            description: >-
+                              Si esta cancelación generó una penalización por
+                              cancelación tardía (historia #22): `true` cuando
+                              el viaje ya tenía conductor asignado
+                              (`accepted`), `false` cuando todavía estaba
+                              `requested`. El cálculo y cobro efectivo del
+                              cargo, si aplica, se procesan en el flujo de
+                              pagos, fuera de alcance de este endpoint.
+                            example: true
               example:
                 data:
                   id: 1
@@ -1167,6 +1189,7 @@ paths:
                   estimated_fare: 8850
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
+                  cancellation_fee_applies: true
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1193,17 +1216,18 @@ paths:
                 message: "No query results for model [App\\Models\\Ride] 1."
         "422":
           description: >-
-            El viaje ya no está en `requested` (fue aceptado, está en curso,
-            ya se completó o ya se había cancelado antes).
+            El viaje no está en un estado cancelable por este endpoint: está
+            `in_progress`, ya se `completed`, o ya se había `cancelled`
+            antes.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
               example:
-                message: El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.
+                message: El viaje está en curso; no se puede cancelar de esta forma.
                 errors:
                   ride:
-                    - El viaje ya fue aceptado; usa el flujo de cancelación de viaje aceptado.
+                    - El viaje está en curso; no se puede cancelar de esta forma.
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:

--- a/tests/Feature/Rides/CancelRideTest.php
+++ b/tests/Feature/Rides/CancelRideTest.php
@@ -15,11 +15,13 @@ use Tymon\JWTAuth\Facades\JWTAuth;
 /**
  * Contrato de POST /api/v1/rides/{id}/cancel — ver openapi.yaml.
  *
- * Cubre la ventana entre pedir el viaje y que algún conductor lo acepte
- * (historia #16): no genera cargo porque hoy no existe nada que cobrar en
- * `requested` (el motor de tarifa solo entra al completar el viaje, historia
- * #24), así que basta con que el viaje quede `cancelled` sin dejar rastro
- * adicional.
+ * Cubre dos ventanas del ciclo de vida del viaje: antes de que un conductor
+ * lo acepte (`requested`, historia #16), donde no genera cargo porque hoy no
+ * existe nada que cobrar en ese estado (el motor de tarifa solo entra al
+ * completar el viaje, historia #24); y después de que un conductor ya lo
+ * aceptó (`accepted`, historia #22), donde sí indica que aplica una
+ * penalización por cancelación tardía, aunque el cobro efectivo quede fuera
+ * de esta historia.
  */
 class CancelRideTest extends TestCase
 {
@@ -36,6 +38,7 @@ class CancelRideTest extends TestCase
 
         $respuesta->assertJsonPath('data.id', $viaje->id);
         $respuesta->assertJsonPath('data.status', 'cancelled');
+        $respuesta->assertJsonPath('data.cancellation_fee_applies', false);
 
         $this->assertDatabaseHas('rides', [
             'id' => $viaje->id,
@@ -55,12 +58,57 @@ class CancelRideTest extends TestCase
         $this->assertDatabaseCount('rides', 1);
     }
 
-    #[DataProvider('estadosYaNoRequested')]
-    public function test_rechaza_cancelar_un_viaje_que_ya_no_esta_requested(RideStatus $estado): void
+    public function test_el_pasajero_cancela_su_viaje_ya_aceptado(): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'cancelled');
+        $respuesta->assertJsonPath('data.cancellation_fee_applies', true);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Cancelled->value,
+        ]);
+    }
+
+    public function test_cancelar_un_viaje_aceptado_libera_al_conductor(): void
+    {
+        // `active_driver_id` es una columna generada por la base (ver la
+        // migración de `rides`): confirmar que se libera es lo que garantiza
+        // que el conductor pueda aceptar otro viaje después.
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_driver_id' => null,
+        ]);
+    }
+
+    #[DataProvider('estadosNoCancelables')]
+    public function test_rechaza_cancelar_un_viaje_que_no_esta_requested_ni_accepted(RideStatus $estado): void
     {
         // Es 422 y no 403: el pasajero sigue siendo dueño del viaje, lo que
-        // cambia es el flujo a seguir (historia #22/#23 para viajes
-        // aceptados en adelante).
+        // cambia es que ya no hay ningún flujo de cancelación que aplique
+        // para ese punto del ciclo de vida.
         $pasajero = User::factory()->create();
         $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['status' => $estado]);
 
@@ -75,10 +123,12 @@ class CancelRideTest extends TestCase
     /**
      * @return array<string, array{RideStatus}>
      */
-    public static function estadosYaNoRequested(): array
+    public static function estadosNoCancelables(): array
     {
+        $noCancelables = [RideStatus::InProgress, RideStatus::Completed, RideStatus::Cancelled];
+
         return array_reduce(
-            array_filter(RideStatus::cases(), static fn (RideStatus $estado): bool => $estado !== RideStatus::Requested),
+            $noCancelables,
             static fn (array $casos, RideStatus $estado): array => [...$casos, $estado->value => [$estado]],
             [],
         );

--- a/tests/Unit/Actions/Rides/CancelRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CancelRideActionTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Actions\Rides;
 use App\Actions\Rides\CancelRideAction;
 use App\Enums\RideStatus;
 use App\Models\Ride;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -24,7 +25,7 @@ class CancelRideActionTest extends TestCase
 
         $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
 
-        $this->assertSame(RideStatus::Cancelled, $resultado->status);
+        $this->assertSame(RideStatus::Cancelled, $resultado->ride->status);
         $this->assertSame(RideStatus::Cancelled, $viaje->refresh()->status);
     }
 
@@ -40,6 +41,54 @@ class CancelRideActionTest extends TestCase
         $this->assertDatabaseHas('rides', [
             'id' => $viaje->id,
             'active_passenger_id' => null,
+        ]);
+    }
+
+    public function test_cancelar_desde_requested_no_aplica_penalizacion(): void
+    {
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertFalse($resultado->feeApplies);
+    }
+
+    public function test_cancelar_desde_accepted_aplica_penalizacion(): void
+    {
+        $conductor = User::factory()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertTrue($resultado->feeApplies);
+    }
+
+    public function test_cancelar_desde_accepted_libera_el_slot_de_viaje_activo_del_conductor(): void
+    {
+        // `active_driver_id` es una columna generada por la base (ver la
+        // migración de `rides`): confirmar que se libera es lo que garantiza
+        // que el conductor pueda aceptar otro viaje después.
+        $conductor = User::factory()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_driver_id' => null,
+        ]);
+    }
+
+    public function test_cancelar_desde_accepted_conserva_el_conductor_como_registro_historico(): void
+    {
+        $conductor = User::factory()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'driver_id' => $conductor->id,
         ]);
     }
 }


### PR DESCRIPTION
Closes #22

## Qué hace

Extiende `POST /api/v1/rides/{id}/cancel` (endpoint existente de la historia #16)
para cubrir también la ventana en la que el viaje ya está `accepted`:

- Un viaje `requested` o `accepted` del pasajero autenticado se cancela y pasa a
  `cancelled`.
- La respuesta agrega `cancellation_fee_applies`: `false` cuando se cancela desde
  `requested` (sin conductor asignado todavía), `true` cuando se cancela desde
  `accepted` (el conductor ya se había comprometido y desplazado). El cálculo y
  cobro efectivo de esa penalización quedan fuera de alcance de esta historia,
  como indica el issue.
- El conductor asignado queda libre para aceptar otro viaje: `active_driver_id`
  es una columna generada que se recalcula sola al salir de los estados activos
  (mismo mecanismo que ya usaba `active_passenger_id`), así que no hace falta
  tocar `driver_id` — que además queda como registro histórico de a quién se le
  canceló.
- Un viaje `in_progress`, `completed` o `cancelled` sigue respondiendo 422, con
  un mensaje específico por estado.

## Cómo se probó

- `php artisan test` — 499 tests, todos en verde (incluye 16 en
  `CancelRideActionTest`/`CancelRideTest`, con casos nuevos para el estado
  `accepted`: penalización, liberación del conductor, y que el conductor
  asignado se conserva).
- `./vendor/bin/pint --test` — sin errores.
- `./vendor/bin/phpstan analyse --no-progress` (`composer stan`) — sin errores.
- `openapi.yaml` actualizado (descripción, ejemplo 200 con
  `cancellation_fee_applies`, mensaje 422) y revisado manualmente por
  estructura/indentación.

## Decisiones y riesgos

- Se reutiliza el mismo endpoint `POST /rides/{id}/cancel` en vez de crear uno
  nuevo, siguiendo literalmente el criterio de aceptación del issue #22 y las
  notas técnicas del issue, que apuntan a extender `CancelRideAction`. La
  documentación previa en `openapi.yaml` sugería un endpoint aparte para #22/#23;
  se actualizó esa descripción para reflejar el diseño real.
- La penalización se representa como un booleano nuevo
  (`cancellation_fee_applies`) en la respuesta del propio endpoint, no como un
  campo del schema `Ride` compartido con el resto de endpoints (create/accept/
  start/etc.), para no ensanchar ese contrato a endpoints donde no aplica. Se
  implementó con un DTO (`RideCancellation`) y un resource propio
  (`RideCancellationResource`) que reutiliza `RideResource` para no duplicar el
  mapeo de campos.
- El issue #23 (cancelación por el conductor de un viaje `accepted`) queda fuera
  de esta historia; el "conteo de cancelaciones" que menciona ese issue tampoco
  se toca acá.
- No se pudieron correr los scripts de conformidad estática/dinámica de la skill
  `laravel-feature-workflow` ni los de `laravel-api-review`/
  `laravel-security-review` (requieren Python, no disponible en este entorno de
  ejecución). Se compensó con una revisión manual del diff (complejidad,
  autorización, mass assignment, campos expuestos) y con la suite completa de
  PHPUnit + Pint + PHPStan en verde.

🤖 Generado con el agente desarrollador autónomo.