### PR TITLE
feat(#23): cancelar un viaje aceptado (conductor)

### DIFF
--- a/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
+++ b/.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md
@@ -206,3 +206,26 @@ aplica al schema de la respuesta y también al spec con el que se construye el
 corregirlo se comprobó que el validador sigue detectando incumplimientos reales (un
 `driver` ausente y un `started_at` numérico se reportan igual), que es lo que
 distingue arreglar el validador de apagarlo.
+
+### 2026-08-01 — Sin intérprete Python real en el entorno del agente
+
+**Qué pasó:** implementando `POST /rides/{id}/cancel` para el conductor (#23), tanto
+`static_conformance.py` como `dynamic_conformance.py` fallaron antes de correr una
+sola línea: `python`/`python3`/`py` resuelven al stub de Microsoft Store de Windows
+("Python was not found; run without arguments to install from the Microsoft Store"),
+no a un intérprete real. No es un fallo del spec ni del código de la feature.
+
+**Por qué pasó:** el entorno de esa corrida del agente no tenía Python instalado, solo
+el alias de ejecución de Windows que apunta a la Store.
+
+**Cómo evitarlo:** si `python --version` (o `python3`/`py`) no devuelve una versión
+real, no asumir que los scripts corrieron — verificarlo primero. Sin Python, la
+alternativa que se usó acá: revisar el YAML del spec a mano (releerlo completo tras
+editar) y validar la conformidad dinámica manualmente con un servidor real
+(`php artisan serve`) contra una `DB_DATABASE` de scratch, sembrando con `tinker` los
+estados necesarios para cada rama del contrato (pasajero cancela, conductor devuelve
+al pool, 403 de un tercero, 422 de un viaje `in_progress`) y comparando el cuerpo real
+con el schema del spec a ojo. Esto no reemplaza los scripts —no hay contraprueba
+automática de que el schema rechace un cuerpo inválido—, así que en un entorno con
+Python disponible, seguir corriendo `static_conformance.py`/`dynamic_conformance.py`
+como primera opción.

--- a/app/Actions/Rides/CancelRideAction.php
+++ b/app/Actions/Rides/CancelRideAction.php
@@ -7,24 +7,41 @@ namespace App\Actions\Rides;
 use App\DTOs\RideCancellation;
 use App\Enums\RideStatus;
 use App\Models\Ride;
+use App\Models\User;
 
 /**
- * Cancela un viaje del pasajero autenticado, ya sea que todavía no lo haya
- * visto aceptado (historia #16) o que un conductor ya lo haya aceptado
- * (historia #22) — `CancelRideRequest` es quien decide cuáles estados llegan
- * hasta acá, así que esta Action no distingue el caso salvo para calcular si
- * corresponde penalización.
+ * Mismo endpoint, dos operaciones distintas según quién cancela — ver
+ * `RidePolicy::cancel()` y `CancelRideRequest`, que ya resolvieron que
+ * `$actor` es uno de los dos dueños posibles del viaje antes de que esta
+ * Action se ejecute:
  *
- * No hace falta tocar `driver_id`: el conductor asignado queda en la fila
- * como registro histórico de a quién se le canceló, y `active_driver_id` es
- * una columna generada por la base que se recalcula sola al salir de los
- * estados activos, igual que `active_passenger_id` (ver la migración de
- * `rides`), así que el conductor queda libre para aceptar otro viaje sin que
- * esta Action escriba nada más.
+ * - El **pasajero** cancela un viaje que todavía no vio aceptado (historia
+ *   #16) o que un conductor ya aceptó (historia #22): el viaje pasa a
+ *   `cancelled`.
+ * - El **conductor asignado** cancela un viaje `accepted` que todavía no
+ *   inició (historia #23): el viaje no se cancela, vuelve a `requested` sin
+ *   conductor, para que otros conductores puedan aceptarlo.
  */
 final readonly class CancelRideAction
 {
-    public function handle(Ride $ride): RideCancellation
+    public function handle(Ride $ride, User $actor): RideCancellation
+    {
+        if ($ride->driver_id === $actor->getKey()) {
+            return $this->returnToPool($ride, $actor);
+        }
+
+        return $this->cancel($ride);
+    }
+
+    /**
+     * No hace falta tocar `driver_id`: el conductor asignado queda en la fila
+     * como registro histórico de a quién se le canceló, y `active_driver_id`
+     * es una columna generada por la base que se recalcula sola al salir de
+     * los estados activos, igual que `active_passenger_id` (ver la migración
+     * de `rides`), así que el conductor queda libre para aceptar otro viaje
+     * sin que esta Action escriba nada más.
+     */
+    private function cancel(Ride $ride): RideCancellation
     {
         // Solo cancelar un viaje ya `accepted` implica que un conductor se
         // había comprometido y se desplazó hacia el punto de recogida; por
@@ -35,5 +52,28 @@ final readonly class CancelRideAction
         $ride->update(['status' => RideStatus::Cancelled]);
 
         return new RideCancellation($ride, $feeApplies);
+    }
+
+    /**
+     * `driver_id` sí se limpia acá, al revés que en `cancel()`: el viaje
+     * sigue en pie para el pasajero y tiene que volver a aparecer como
+     * disponible para cualquier conductor, no solo para el que se bajó.
+     *
+     * El conteo de cancelaciones queda en el perfil del conductor para uso
+     * futuro en políticas de calidad (historia #23); esta historia solo lo
+     * registra, no bloquea la cancelación actual ni penaliza con ella. Es
+     * `?->` porque el invariante real —todo conductor tiene perfil, ver
+     * `RegisterDriverAction`— no lo garantiza esta Action.
+     */
+    private function returnToPool(Ride $ride, User $driver): RideCancellation
+    {
+        $ride->update([
+            'status' => RideStatus::Requested,
+            'driver_id' => null,
+        ]);
+
+        $driver->driverProfile?->increment('cancellation_count');
+
+        return new RideCancellation($ride, feeApplies: false);
     }
 }

--- a/app/DTOs/RideCancellation.php
+++ b/app/DTOs/RideCancellation.php
@@ -7,9 +7,12 @@ namespace App\DTOs;
 use App\Models\Ride;
 
 /**
- * Resultado de cancelar un viaje: el viaje ya `cancelled` junto con si esta
- * cancelación en particular generó una penalización por cancelación tardía
- * (historia #22).
+ * Resultado de `POST /rides/{id}/cancel`: el viaje ya `cancelled` (si canceló
+ * el pasajero) o de vuelta en `requested` sin conductor (si lo devolvió el
+ * conductor asignado, historia #23), junto con si esta cancelación en
+ * particular generó una penalización por cancelación tardía (historia #22).
+ * `feeApplies` siempre es `false` cuando quien cancela es el conductor: ese
+ * caso no cancela el viaje ni genera cargo.
  *
  * El cálculo y cobro efectivo del cargo, si aplica, quedan fuera de esta
  * historia: acá solo se determina si corresponde, igual que `RideEstimate`

--- a/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/CancelRideController.php
@@ -14,10 +14,12 @@ use Illuminate\Http\JsonResponse;
 /**
  * POST /api/v1/rides/{ride}/cancel
  *
- * Cancela el viaje del pasajero autenticado, ya sea que siga en `requested`
- * (historia #16) o que un conductor ya lo haya aceptado (historia #22). El
- * viaje ya llega validado desde `CancelRideRequest`, así que acá no queda
- * ninguna decisión.
+ * Cancela el viaje, ya sea a pedido del pasajero dueño —siga en `requested`
+ * (historia #16) o ya lo haya aceptado un conductor (historia #22)— o del
+ * conductor asignado, que en cambio lo devuelve al pool (historia #23). Cuál
+ * de los dos es y si corresponde ya lo resolvió `CancelRideRequest`; acá no
+ * queda ninguna decisión, solo pasarle el actor a la Action para que elija la
+ * rama.
  *
  * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
  * implícito de la ruta (`{ride}`): la reflexión de esta firma es lo que usa
@@ -32,7 +34,7 @@ class CancelRideController extends Controller
         CancelRideAction $cancelRide,
         Ride $ride,
     ): JsonResponse {
-        $cancellation = $cancelRide->handle($ride);
+        $cancellation = $cancelRide->handle($ride, $request->user());
 
         return (new RideCancellationResource($cancellation))->response();
     }

--- a/app/Http/Requests/Rides/CancelRideRequest.php
+++ b/app/Http/Requests/Rides/CancelRideRequest.php
@@ -11,6 +11,11 @@ use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Entrada de POST /api/v1/rides/{ride}/cancel — ver openapi.yaml.
+ *
+ * Mismo endpoint para el pasajero dueño (historias #16/#22) y para el
+ * conductor asignado (historia #23); cuál de los dos puede cancelar y qué
+ * hace cada uno lo decide `RidePolicy::cancel()` y `CancelRideAction`, no
+ * este Form Request.
  */
 class CancelRideRequest extends FormRequest
 {
@@ -20,9 +25,9 @@ class CancelRideRequest extends FormRequest
      * resuelva este Form Request—, así que un id inexistente nunca llega
      * hasta acá: sale como 404 antes de que se evalúe `authorize()`.
      *
-     * Que el viaje sea del pasajero autenticado se resuelve acá y no en el
-     * controller, igual que en `CreateRideRequest`, para que el 403 se
-     * resuelva antes que la validación de estado.
+     * Que el viaje sea del pasajero dueño o del conductor asignado se
+     * resuelve acá y no en el controller, igual que en `CreateRideRequest`,
+     * para que el 403 se resuelva antes que la validación de estado.
      */
     public function authorize(): bool
     {
@@ -51,15 +56,15 @@ class CancelRideRequest extends FormRequest
     }
 
     /**
-     * Este endpoint cubre dos ventanas del ciclo de vida del viaje: antes de
-     * que un conductor lo acepte (`requested`, historia #16) y después de que
-     * lo acepta pero todavía no lo inicia (`accepted`, historia #22) — en
-     * ambos casos el pasajero sigue siendo dueño del viaje, así que a partir
-     * de acá no es un problema de permisos sino de en qué punto del ciclo de
-     * vida está, por eso es 422 y no 403, y por eso vive acá y no en
-     * `RidePolicy::cancel()`. Mismo criterio que "ya tiene un viaje activo"
-     * en `CreateRideRequest`, con el error bajo la clave `ride`, que tampoco
-     * es un campo de la entrada.
+     * `requested` y `accepted` son cancelables por quien ya tiene permiso
+     * según `RidePolicy::cancel()` — el pasajero en cualquiera de los dos
+     * (historias #16/#22), el conductor asignado solo en `accepted`, porque
+     * sin conductor asignado nunca llega hasta acá autorizado (historia
+     * #23). A partir de ahí no es un problema de permisos sino de en qué
+     * punto del ciclo de vida está el viaje, por eso es 422 y no 403, y por
+     * eso vive acá y no en `RidePolicy::cancel()`. Mismo criterio que "ya
+     * tiene un viaje activo" en `CreateRideRequest`, con el error bajo la
+     * clave `ride`, que tampoco es un campo de la entrada.
      *
      * El `match` cubre los cinco casos de `RideStatus` en vez de aislar los
      * dos cancelables con un `if` antes: así queda un único punto exhaustivo

--- a/app/Http/Resources/RideCancellationResource.php
+++ b/app/Http/Resources/RideCancellationResource.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\DTOs\RideCancellation;
+use App\Enums\RideStatus;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * Serializa el resultado de cancelar un viaje según el schema de la
- * respuesta 200 de `POST /rides/{id}/cancel` en openapi.yaml: los mismos
- * campos que `RideResource` más `cancellation_fee_applies`.
+ * Serializa el resultado de `POST /rides/{id}/cancel` según el schema de su
+ * respuesta 200 en openapi.yaml: los mismos campos que `RideResource` más
+ * `cancellation_fee_applies` — pero solo cuando el viaje quedó `cancelled`.
+ * Si en cambio volvió a `requested` (el conductor asignado lo devolvió al
+ * pool, historia #23), ese campo no aplica y se omite.
  *
  * Reutiliza `RideResource` para el viaje en vez de repetir el mapeo de
  * campos: esta clase solo agrega el campo que `RideResource` no conoce.
@@ -27,7 +30,10 @@ class RideCancellationResource extends JsonResource
     {
         return [
             ...(new RideResource($this->resource->ride))->toArray($request),
-            'cancellation_fee_applies' => $this->resource->feeApplies,
+            'cancellation_fee_applies' => $this->when(
+                $this->resource->ride->status === RideStatus::Cancelled,
+                $this->resource->feeApplies,
+            ),
         ];
     }
 }

--- a/app/Models/DriverProfile.php
+++ b/app/Models/DriverProfile.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Carbon;
  * @property float|null $latitude
  * @property float|null $longitude
  * @property Carbon|null $location_updated_at
+ * @property int $cancellation_count
  */
 #[Fillable(['user_id', 'license_number', 'is_available', 'latitude', 'longitude', 'location_updated_at'])]
 #[UsePolicy(DriverProfilePolicy::class)]
@@ -31,6 +32,7 @@ class DriverProfile extends Model
             'latitude' => 'float',
             'longitude' => 'float',
             'location_updated_at' => 'datetime',
+            'cancellation_count' => 'integer',
         ];
     }
 

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -55,20 +55,25 @@ class RidePolicy
     }
 
     /**
-     * Cancelar un viaje es del pasajero **dueño** de ese viaje (historia #16).
+     * Cancelar un viaje es del pasajero **dueño** de ese viaje (historia #16),
+     * o del conductor **asignado** a ese viaje (historia #23) — mismo
+     * endpoint, dos operaciones distintas: `CancelRideAction` decide si
+     * cancela el viaje o lo devuelve al pool según cuál de los dos sea quien
+     * llama.
      *
-     * Que el viaje ya no esté en `requested` **no** se decide acá: eso
-     * responde 422, porque el permiso de cancelar lo tiene y lo que cambia es
-     * el flujo a seguir (ver `CancelRideRequest`). Un 403 le diría que el
-     * permiso le falta, que es otra cosa.
+     * Que el viaje ya no esté en un estado cancelable para ese actor **no**
+     * se decide acá: eso responde 422, porque el permiso de cancelar lo tiene
+     * y lo que cambia es el flujo a seguir (ver `CancelRideRequest`). Un 403
+     * le diría que el permiso le falta, que es otra cosa.
      *
-     * El rol se comprueba además de la propiedad, mismo criterio que
-     * `VehiclePolicy::update()`: nada impide que una fila apunte a una cuenta
-     * que dejó de ser pasajero.
+     * El rol se comprueba además de la propiedad en ambas ramas, mismo
+     * criterio que `VehiclePolicy::update()`: nada impide que una fila apunte
+     * a una cuenta que dejó de tener ese rol.
      */
     public function cancel(User $user, Ride $ride): bool
     {
-        return $user->isPassenger() && $ride->passenger_id === $user->getKey();
+        return ($user->isPassenger() && $ride->passenger_id === $user->getKey())
+            || ($user->isDriver() && $ride->driver_id === $user->getKey());
     }
 
     /**

--- a/database/migrations/2026_08_01_000001_add_cancellation_count_to_driver_profiles_table.php
+++ b/database/migrations/2026_08_01_000001_add_cancellation_count_to_driver_profiles_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            // Cuántas veces el conductor devolvió al pool un viaje que ya
+            // había aceptado (historia #23), sin distinguir el motivo. Es un
+            // conteo acumulado para uso futuro en políticas de calidad — esta
+            // historia solo lo registra, no lo usa para bloquear ni penalizar
+            // todavía.
+            $table->unsignedInteger('cancellation_count')->default(0)->after('license_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            $table->dropColumn('cancellation_count');
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1216,23 +1216,36 @@ paths:
       operationId: cancelRide
       summary: Cancelar un viaje solicitado o ya aceptado
       description: >-
-        Cancela el viaje del pasajero autenticado, ya sea que siga en
+        Mismo endpoint para dos operaciones distintas según quién lo llama:
+
+        **El pasajero dueño del viaje** lo cancela, ya sea que siga en
         `requested` (historia #16) o que un conductor ya lo haya aceptado en
         `accepted` (historia #22). En ambos casos el viaje pasa a
-        `cancelled`; la diferencia es `cancellation_fee_applies` en la
-        respuesta: `false` cuando todavía no había conductor asignado, y
-        `true` cuando ya lo había, porque ese conductor ya se había
-        comprometido y desplazado hacia el punto de recogida. El cálculo y
-        cobro efectivo de esa penalización, si aplica, se procesan en el
-        flujo de pagos — acá solo se indica si corresponde.
+        `cancelled`, y la respuesta incluye `cancellation_fee_applies`:
+        `false` cuando todavía no había conductor asignado, y `true` cuando
+        ya lo había, porque ese conductor ya se había comprometido y
+        desplazado hacia el punto de recogida. El cálculo y cobro efectivo de
+        esa penalización, si aplica, se procesan en el flujo de pagos — acá
+        solo se indica si corresponde.
+
+        **El conductor asignado** cancela un viaje que aceptó pero todavía no
+        inició, es decir en `accepted` (historia #23). El viaje **no** se
+        cancela: vuelve a `requested` sin conductor asignado, para que otros
+        conductores puedan aceptarlo. La respuesta es el viaje ya sin
+        `driver` y sin el campo `cancellation_fee_applies` — no aplica
+        ningún cargo, porque el viaje sigue en pie para el pasajero. El
+        sistema registra internamente el conteo de cancelaciones del
+        conductor para uso futuro en políticas de calidad; no se expone en
+        esta respuesta ni bloquea la operación.
 
         Un viaje `in_progress`, `completed` o ya `cancelled` no se puede
-        cancelar por este endpoint.
+        cancelar por este endpoint, sin importar quién lo pida.
 
-        Solo el pasajero dueño del viaje puede cancelarlo: cualquier otra
-        cuenta recibe **403**. Que el viaje no esté en un estado cancelable
-        es en cambio **422**, porque no es un problema de permisos sino de en
-        qué punto del ciclo de vida está el viaje.
+        Solo el pasajero dueño del viaje o el conductor asignado pueden
+        llamar a este endpoint: cualquier otra cuenta recibe **403**. Que el
+        viaje no esté en un estado cancelable es en cambio **422**, porque no
+        es un problema de permisos sino de en qué punto del ciclo de vida
+        está el viaje.
       security:
         - bearerAuth: []
       parameters:
@@ -1245,7 +1258,10 @@ paths:
           example: 1
       responses:
         "200":
-          description: El viaje quedó cancelado.
+          description: >-
+            El viaje quedó `cancelled` (si cancela el pasajero) o volvió a
+            `requested` sin conductor asignado (si cancela el conductor) —
+            ver la descripción del endpoint.
           content:
             application/json:
               schema:
@@ -1257,8 +1273,6 @@ paths:
                     allOf:
                       - $ref: "#/components/schemas/Ride"
                       - type: object
-                        required:
-                          - cancellation_fee_applies
                         properties:
                           cancellation_fee_applies:
                             type: boolean
@@ -1270,6 +1284,11 @@ paths:
                               `requested`. El cálculo y cobro efectivo del
                               cargo, si aplica, se procesan en el flujo de
                               pagos, fuera de alcance de este endpoint.
+
+                              Ausente cuando quien cancela es el conductor
+                              asignado (historia #23): ese caso no cancela el
+                              viaje ni genera cargo, solo lo devuelve al pool
+                              sin conductor.
                             example: true
               example:
                 data:
@@ -1298,7 +1317,9 @@ paths:
               example:
                 message: Unauthenticated.
         "403":
-          description: El viaje no pertenece al pasajero autenticado.
+          description: >-
+            El viaje no pertenece al pasajero autenticado ni está asignado al
+            conductor autenticado.
           content:
             application/json:
               schema:
@@ -1317,7 +1338,8 @@ paths:
           description: >-
             El viaje no está en un estado cancelable por este endpoint: está
             `in_progress`, ya se `completed`, o ya se había `cancelled`
-            antes.
+            antes. Aplica igual sin importar si quien cancela es el pasajero
+            o el conductor asignado.
           content:
             application/json:
               schema:

--- a/tests/Feature/Rides/CancelRideTest.php
+++ b/tests/Feature/Rides/CancelRideTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Rides;
 
 use App\Enums\RideStatus;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -15,13 +16,14 @@ use Tymon\JWTAuth\Facades\JWTAuth;
 /**
  * Contrato de POST /api/v1/rides/{id}/cancel — ver openapi.yaml.
  *
- * Cubre dos ventanas del ciclo de vida del viaje: antes de que un conductor
- * lo acepte (`requested`, historia #16), donde no genera cargo porque hoy no
- * existe nada que cobrar en ese estado (el motor de tarifa solo entra al
- * completar el viaje, historia #24); y después de que un conductor ya lo
- * aceptó (`accepted`, historia #22), donde sí indica que aplica una
- * penalización por cancelación tardía, aunque el cobro efectivo quede fuera
- * de esta historia.
+ * Cubre dos ventanas del ciclo de vida del viaje del lado del pasajero: antes
+ * de que un conductor lo acepte (`requested`, historia #16), donde no genera
+ * cargo porque hoy no existe nada que cobrar en ese estado (el motor de
+ * tarifa solo entra al completar el viaje, historia #24); y después de que un
+ * conductor ya lo aceptó (`accepted`, historia #22), donde sí indica que
+ * aplica una penalización por cancelación tardía, aunque el cobro efectivo
+ * quede fuera de esta historia. Y del lado del conductor asignado, que
+ * devuelve el viaje al pool en vez de cancelarlo (`accepted`, historia #23).
  */
 class CancelRideTest extends TestCase
 {
@@ -146,6 +148,107 @@ class CancelRideTest extends TestCase
             ->assertJsonStructure(['message']);
 
         $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Requested->value]);
+    }
+
+    public function test_el_conductor_asignado_cancela_su_viaje_aceptado_y_vuelve_al_pool(): void
+    {
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'requested');
+        $respuesta->assertJsonMissingPath('data.cancellation_fee_applies');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Requested->value,
+            'driver_id' => null,
+        ]);
+    }
+
+    public function test_cancelar_como_conductor_libera_al_conductor_para_aceptar_otro_viaje(): void
+    {
+        // `active_driver_id` es una columna generada por la base (ver la
+        // migración de `rides`): confirmar que se libera es lo que garantiza
+        // que el conductor pueda aceptar otro viaje después.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_driver_id' => null,
+        ]);
+    }
+
+    public function test_el_conductor_asignado_no_puede_cancelar_un_viaje_en_curso_con_este_endpoint(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::InProgress->value]);
+    }
+
+    public function test_rechaza_cancelar_como_un_conductor_que_no_es_el_asignado(): void
+    {
+        $asignado = User::factory()->driver()->create();
+        $otro = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $asignado->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($otro))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', ['id' => $viaje->id, 'status' => RideStatus::Accepted->value, 'driver_id' => $asignado->id]);
+    }
+
+    public function test_cancelar_repetidamente_como_conductor_incrementa_su_conteo_sin_bloquear(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id, 'cancellation_count' => 0]);
+
+        $primerViaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($primerViaje))
+            ->assertOk();
+
+        // El conductor queda libre (el primer viaje volvió al pool), así que
+        // puede aceptar y cancelar un segundo viaje sin que nada lo bloquee.
+        $segundoViaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($segundoViaje))
+            ->assertOk();
+
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $conductor->id,
+            'cancellation_count' => 2,
+        ]);
     }
 
     public function test_responde_404_cuando_el_viaje_no_existe(): void

--- a/tests/Unit/Actions/Rides/CancelRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CancelRideActionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions\Rides;
 
 use App\Actions\Rides\CancelRideAction;
 use App\Enums\RideStatus;
+use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -23,7 +24,7 @@ class CancelRideActionTest extends TestCase
     {
         $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
 
-        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertSame(RideStatus::Cancelled, $resultado->ride->status);
         $this->assertSame(RideStatus::Cancelled, $viaje->refresh()->status);
@@ -36,7 +37,7 @@ class CancelRideActionTest extends TestCase
         // que el pasajero pueda volver a solicitar un viaje después.
         $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
 
-        $this->app->make(CancelRideAction::class)->handle($viaje);
+        $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertDatabaseHas('rides', [
             'id' => $viaje->id,
@@ -48,7 +49,7 @@ class CancelRideActionTest extends TestCase
     {
         $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
 
-        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertFalse($resultado->feeApplies);
     }
@@ -58,7 +59,7 @@ class CancelRideActionTest extends TestCase
         $conductor = User::factory()->create();
         $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
 
-        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje);
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertTrue($resultado->feeApplies);
     }
@@ -71,7 +72,7 @@ class CancelRideActionTest extends TestCase
         $conductor = User::factory()->create();
         $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
 
-        $this->app->make(CancelRideAction::class)->handle($viaje);
+        $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertDatabaseHas('rides', [
             'id' => $viaje->id,
@@ -84,11 +85,101 @@ class CancelRideActionTest extends TestCase
         $conductor = User::factory()->create();
         $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
 
-        $this->app->make(CancelRideAction::class)->handle($viaje);
+        $this->app->make(CancelRideAction::class)->handle($viaje, $viaje->passenger);
 
         $this->assertDatabaseHas('rides', [
             'id' => $viaje->id,
             'driver_id' => $conductor->id,
         ]);
+    }
+
+    /**
+     * Cuando quien cancela es el conductor asignado (historia #23), la
+     * Action toma la otra rama: el viaje no se cancela, vuelve al pool.
+     */
+    public function test_el_conductor_asignado_devuelve_el_viaje_al_pool_en_vez_de_cancelarlo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertSame(RideStatus::Requested, $resultado->ride->status);
+        $this->assertSame(RideStatus::Requested, $viaje->refresh()->status);
+    }
+
+    public function test_devolver_al_pool_deja_el_viaje_sin_conductor_asignado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertNull($viaje->refresh()->driver_id);
+    }
+
+    public function test_devolver_al_pool_no_aplica_penalizacion(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertFalse($resultado->feeApplies);
+    }
+
+    public function test_devolver_al_pool_libera_el_slot_de_viaje_activo_del_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_driver_id' => null,
+        ]);
+    }
+
+    public function test_devolver_al_pool_mantiene_al_pasajero_con_su_viaje_activo(): void
+    {
+        // El viaje sigue en pie para el pasajero: vuelve a `requested`, que
+        // sigue siendo un estado activo, así que su slot no se libera.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'active_passenger_id' => $viaje->passenger_id,
+        ]);
+    }
+
+    public function test_devolver_al_pool_incrementa_el_conteo_de_cancelaciones_del_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id, 'cancellation_count' => 2]);
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertDatabaseHas('driver_profiles', [
+            'user_id' => $conductor->id,
+            'cancellation_count' => 3,
+        ]);
+    }
+
+    public function test_devolver_al_pool_no_falla_si_el_conductor_no_tiene_perfil(): void
+    {
+        // En producción todo conductor tiene perfil (se crea junto con la
+        // cuenta, ver `RegisterDriverAction`); esto solo cubre que la Action
+        // no explote si ese invariante no se cumpliera.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Accepted, 'driver_id' => $conductor->id]);
+
+        $resultado = $this->app->make(CancelRideAction::class)->handle($viaje, $conductor);
+
+        $this->assertSame(RideStatus::Requested, $resultado->ride->status);
     }
 }

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -53,6 +53,33 @@ class RidePolicyTest extends TestCase
         $this->assertFalse($conductor->can('cancel', $viaje));
     }
 
+    public function test_el_conductor_asignado_puede_cancelar_el_viaje_que_acepto(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('cancel', $viaje));
+    }
+
+    public function test_otro_conductor_no_puede_cancelar_un_viaje_que_no_acepto(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse(User::factory()->driver()->create()->can('cancel', $viaje));
+    }
+
+    public function test_un_pasajero_no_puede_cancelar_por_este_metodo_un_viaje_sin_conductor_asignado_aunque_la_fila_apunte_a_su_cuenta(): void
+    {
+        // Contraparte de `test_un_conductor_no_puede_cancelar_...`: un
+        // pasajero cuya cuenta quedó como `driver_id` de un viaje ajeno (algo
+        // que el dominio no produce hoy) tampoco debería poder cancelar por
+        // la vía del conductor, porque su rol no es conductor.
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $pasajero->id]);
+
+        $this->assertFalse($pasajero->can('cancel', $viaje));
+    }
+
     public function test_el_conductor_puede_aceptar_un_viaje(): void
     {
         $this->assertTrue(User::factory()->driver()->create()->can('accept', Ride::class));


### PR DESCRIPTION
Closes #23

## Qué hace

`POST /rides/{id}/cancel` ya existía solo para el pasajero (#16/#22). Esta
historia lo extiende para el **conductor asignado**: mismo endpoint, pero en
vez de cancelar el viaje lo devuelve al pool.

- **`RidePolicy::cancel()`** ahora autoriza también al conductor asignado
  (`ride.driver_id === user.id`), además del pasajero dueño.
- **`CancelRideAction`** se bifurca según el actor: si es el conductor
  asignado, el viaje vuelve a `requested` con `driver_id = null` (en vez de
  `cancelled`) y se incrementa `driver_profiles.cancellation_count`; en
  cualquier otro caso sigue el flujo existente de cancelación del pasajero.
- **`driver_profiles.cancellation_count`** — nueva columna (migración),
  `unsignedInteger` con default `0`. Deliberadamente fuera del `#[Fillable]`
  del modelo: solo se escribe internamente vía `increment()`, nunca por mass
  assignment desde un Form Request.
- **`RideCancellationResource`** omite `cancellation_fee_applies` cuando el
  viaje terminó `requested` (conductor) en vez de `cancelled` (pasajero): ese
  campo deja de tener sentido en ese caso.
- `CancelRideRequest`/`CancelRideController` no cambian de lógica, solo pasan
  el actor autenticado a la Action y actualizan sus comentarios para reflejar
  que el endpoint ahora cubre dos operaciones.

Criterios de aceptación de #23:

| AC | Dónde queda cubierto |
|---|---|
| Conductor cancela un `accepted` propio → vuelve a `requested` sin conductor | `CancelRideTest::test_el_conductor_asignado_cancela_su_viaje_aceptado_y_vuelve_al_pool`, `CancelRideActionTest::test_el_conductor_asignado_devuelve_el_viaje_al_pool_en_vez_de_cancelarlo` |
| `in_progress` no se cancela por este endpoint (conductor) | `CancelRideTest::test_el_conductor_asignado_no_puede_cancelar_un_viaje_en_curso_con_este_endpoint` — reutiliza el mismo 422 que ya existía para el pasajero |
| Cancelaciones repetidas incrementan el conteo sin bloquear | `CancelRideTest::test_cancelar_repetidamente_como_conductor_incrementa_su_conteo_sin_bloquear`, `CancelRideActionTest::test_devolver_al_pool_incrementa_el_conteo_de_cancelaciones_del_conductor` |

## Cómo se probó

Flujo Issue → SDD → TDD → implementación → conformidad:

- `openapi.yaml` actualizado primero: `/rides/{id}/cancel` documenta las dos
  ramas (pasajero/conductor), `cancellation_fee_applies` pasó a no-requerido
  con la aclaración de cuándo se omite, y el 403 menciona al conductor
  asignado.
- Tests escritos contra el spec y confirmados en rojo antes de implementar
  (9 fallos + 2 errores de columna faltante).
- `php artisan test`: **514 pasando**, 1479 assertions.
- `./vendor/bin/pint --test`, `php vendor/bin/phpstan analyse` (nivel 5, 0
  errores).
- Revisión de arquitectura/complejidad y de seguridad (skills
  `laravel-api-review`/`laravel-security-review`) hechas **a mano**: el
  entorno de esta corrida no tiene un intérprete Python real (`python`/`py`
  resuelven al stub de Microsoft Store), así que `complexity_check.py`,
  `architecture_check.py` y `security_check.py` no pudieron correr. Sin
  hallazgos: Action/Controller/Request/Resource siguen exactamente el mismo
  patrón que `AcceptRideAction`/`AcceptRideController`; sin SQL crudo, sin
  campos sensibles expuestos, `cancellation_count` fuera de `Fillable`,
  autorización resuelta por Policy antes de la Action.
- Conformidad estática y dinámica: por el mismo motivo (sin Python),
  `static_conformance.py`/`dynamic_conformance.py` tampoco pudieron correr.
  Se validó a mano contra un servidor real (`php artisan serve`) con una
  `DB_DATABASE` de scratch aparte (no se tocó la base de desarrollo),
  sembrada con `tinker`: 200 del conductor (`status: requested`, sin
  `cancellation_fee_applies`), 200 del pasajero (`status: cancelled`, con
  `cancellation_fee_applies: true`), 403 de un conductor no asignado, 422 de
  un viaje `in_progress`, y `cancellation_count` incrementado en la base
  después de la corrida. Quedó registrado en `KNOWN_ERRORS.md` de
  `laravel-feature-workflow` para que la próxima corrida sepa verificar
  Python antes de asumir que los scripts corrieron.

## Decisiones y riesgos

- **Mismo endpoint para dos operaciones** en vez de una ruta nueva
  (`/rides/{id}/return-to-pool` o similar): el propio issue #23 referencia
  `CancelRideAction`/`RidePolicy` como los puntos de extensión, y
  semánticamente ambas acciones son "quien tiene un compromiso con este
  viaje se baja de él" — el pasajero lo cancela porque es suyo, el conductor
  lo suelta porque no es su viaje, solo su compromiso de llevarlo.
- **`cancellation_count` no se usa todavía para nada** (bloquear, penalizar):
  el issue lo deja explícito ("para uso futuro en políticas de calidad"), así
  que no se implementó ninguna lógica de umbral o sanción — sería alcance no
  pedido.
- **`?->` al incrementar el conteo** (`$driver->driverProfile?->increment(...)`):
  en producción todo conductor tiene perfil (se crea junto con la cuenta, ver
  `RegisterDriverAction`), pero la Action no fuerza ese invariante — se cubrió
  con un test explícito de que no explota si faltara.
- **No se actualizó `RideResource` con un campo `driver`**: ese campo lo
  agrega el PR #51 (#21), que todavía no está mergeado a `main` al momento de
  abrir este PR — nada de esta historia depende de él.

🤖 Generated with [Claude Code](https://claude.com/claude-code)