### PR TITLE
feat(#24): completar el viaje

### DIFF
--- a/app/Actions/Rides/CompleteRideAction.php
+++ b/app/Actions/Rides/CompleteRideAction.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Actions\Payments\CalculateFareAction;
+use App\DTOs\RouteEstimate;
+use App\Enums\RideStatus;
+use App\Events\Realtime\RideStatusChanged;
+use App\Models\Ride;
+
+/**
+ * Marca como completado un viaje que el conductor asignado tiene en curso
+ * (historia #24) y recalcula la tarifa final.
+ *
+ * El viaje llega resuelto y validado: que sea del conductor autenticado lo
+ * garantiza `RidePolicy::complete()` y que siga en `in_progress` lo
+ * garantiza `CompleteRideRequest`, mismo reparto que en `StartRideAction`.
+ * Tampoco hace falta lock por el mismo motivo que allá: el único que compite
+ * por esta fila es el mismo conductor tocando el botón dos veces.
+ *
+ * La tarifa final sale de la misma `CalculateFareAction` que la estimada al
+ * crear el viaje (ver .claude/STANDARDS.md, "Cálculo de tarifas"), con un
+ * `RouteEstimate` distinto: no hay tracking de la distancia realmente
+ * recorrida (la ubicación del conductor solo se transmite por broadcast, ver
+ * `Ride`), así que se reusa la distancia cotizada al pedir el viaje y se
+ * reemplaza la duración estimada por el tiempo real transcurrido entre
+ * `started_at` y ahora.
+ */
+final readonly class CompleteRideAction
+{
+    public function __construct(private CalculateFareAction $calculateFare) {}
+
+    public function handle(Ride $ride): Ride
+    {
+        $completedAt = now();
+
+        $fare = $this->calculateFare->handle(new RouteEstimate(
+            distanceMeters: $ride->estimated_distance_meters,
+            durationSeconds: max(0, $completedAt->getTimestamp() - $ride->started_at->getTimestamp()),
+        ));
+
+        $ride->update([
+            'status' => RideStatus::Completed,
+            'completed_at' => $completedAt,
+            'final_fare' => $fare->total,
+        ]);
+
+        // Cierra el ciclo de vida para el pasajero que sigue el viaje por el
+        // canal privado (historia #21); el cobro en sí queda fuera de esta
+        // historia (lo resuelve "Pagar el viaje al finalizar").
+        RideStatusChanged::dispatch($ride->id, $ride->status, $ride->driver_id);
+
+        return $ride;
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/CompleteRideController.php
+++ b/app/Http/Controllers/Api/V1/Rides/CompleteRideController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\CompleteRideAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\CompleteRideRequest;
+use App\Http\Resources\RideResource;
+use App\Models\Ride;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/{ride}/complete
+ *
+ * Marca el viaje como completado (historia #24). Que el conductor autenticado
+ * sea el asignado lo resuelve `RidePolicy::complete()` desde
+ * `CompleteRideRequest`, y que el viaje siga en `in_progress`, el propio Form
+ * Request.
+ *
+ * El parámetro `Ride $ride` es lo que hace que Laravel resuelva el binding
+ * implícito de la ruta, igual que en `StartRideController`.
+ */
+class CompleteRideController extends Controller
+{
+    public function __invoke(
+        CompleteRideRequest $request,
+        CompleteRideAction $completeRide,
+        Ride $ride,
+    ): JsonResponse {
+        $ride = $completeRide->handle($ride);
+
+        return (new RideResource($ride))->response();
+    }
+}

--- a/app/Http/Requests/Rides/CompleteRideRequest.php
+++ b/app/Http/Requests/Rides/CompleteRideRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/{ride}/complete — ver openapi.yaml.
+ */
+class CompleteRideRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `StartRideRequest`: un id inexistente sale como 404 antes de que se
+     * evalúe `authorize()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('complete', $this->ride()) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * viaje de la ruta y quién lo pide.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectRideNotInProgress(...),
+        ];
+    }
+
+    /**
+     * Que el viaje no esté en `in_progress` no es un problema de permisos
+     * —el conductor sigue siendo el asignado— sino de en qué punto del ciclo
+     * de vida está: por eso es 422 y no 403, mismo criterio que
+     * `rejectRideNotAccepted()` en `StartRideRequest`, con el error bajo la
+     * clave `ride`, que tampoco es un campo de la entrada.
+     */
+    private function rejectRideNotInProgress(Validator $validator): void
+    {
+        if ($this->ride()->status !== RideStatus::InProgress) {
+            $validator->errors()->add(
+                'ride',
+                'Solo se puede completar un viaje que esté en curso.',
+            );
+        }
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Resources/RideResource.php
+++ b/app/Http/Resources/RideResource.php
@@ -63,6 +63,14 @@ class RideResource extends JsonResource
             // que distinguir "el viaje todavía no empezó" de "esta respuesta
             // no trae el campo" (historia #19).
             'started_at' => $this->resource->started_at?->toIso8601String(),
+            // Mismo criterio que `started_at`, para "el viaje todavía no
+            // terminó" (historia #24).
+            'completed_at' => $this->resource->completed_at?->toIso8601String(),
+            // El cobro final recalculado al completar el viaje, distinto de
+            // `estimated_fare`. `null` hasta que el viaje se completa; mismo
+            // criterio de siempre presente que el resto de los campos que
+            // nacen a mitad del ciclo de vida.
+            'final_fare' => $this->resource->final_fare,
         ];
     }
 }

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -38,12 +38,16 @@ use Illuminate\Support\Carbon;
  * @property int $estimated_duration_seconds
  * @property int $estimated_fare
  * @property Carbon|null $started_at
+ * @property Carbon|null $completed_at
+ * @property int|null $final_fare
  */
 #[Fillable([
     'passenger_id',
     'driver_id',
     'status',
     'started_at',
+    'completed_at',
+    'final_fare',
     'origin_latitude',
     'origin_longitude',
     'destination_latitude',
@@ -70,6 +74,8 @@ class Ride extends Model
             'estimated_duration_seconds' => 'integer',
             'estimated_fare' => 'integer',
             'started_at' => 'datetime',
+            'completed_at' => 'datetime',
+            'final_fare' => 'integer',
         ];
     }
 

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -116,6 +116,24 @@ class RidePolicy
     }
 
     /**
+     * Completar un viaje es del conductor **asignado a ese viaje** (historia
+     * #24), mismo criterio que `start()`: depende de la fila porque el viaje
+     * ya tiene dueño del lado del conductor.
+     *
+     * Un viaje sin conductor asignado (`requested`) no lo puede completar
+     * nadie, y sale de acá como 403: no es que falte un paso del ciclo de
+     * vida que el conductor pueda dar, es que ese viaje no es suyo. Que el
+     * viaje sí sea suyo pero esté en otro estado (`accepted`, `completed`,
+     * `cancelled`) es en cambio 422, y lo decide `CompleteRideRequest`.
+     */
+    public function complete(User $user, Ride $ride): bool
+    {
+        return $user->isDriver()
+            && $ride->driver_id !== null
+            && $ride->driver_id === $user->getKey();
+    }
+
+    /**
      * Publicar la ubicación es del conductor **asignado a ese viaje**
      * (historia #20), mismo criterio que `start()`: depende de la fila
      * porque el viaje ya tiene dueño del lado del conductor.

--- a/database/migrations/2026_08_01_000002_add_completed_at_and_final_fare_to_rides_table.php
+++ b/database/migrations/2026_08_01_000002_add_completed_at_and_final_fare_to_rides_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            // Cuándo el conductor marcó el viaje como completado (historia
+            // #24). Mismo criterio que `started_at`: es un dato propio del
+            // viaje, no algo deducible de `updated_at`, y nullable porque el
+            // viaje puede terminar cancelado sin haber llegado a completarse.
+            $table->timestamp('completed_at')->nullable();
+
+            // El cobro final, recalculado al completar el viaje con el
+            // trayecto realmente recorrido en vez del estimado al pedirlo
+            // (ver `CalculateFareAction` y .claude/STANDARDS.md, "Cálculo de
+            // tarifas"). Nullable por el mismo motivo que `completed_at`: no
+            // hay tarifa final que registrar hasta que el viaje se completa.
+            // Entero en la unidad mínima de `currency`, igual que
+            // `estimated_fare`.
+            $table->integer('final_fare')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rides', function (Blueprint $table) {
+            $table->dropColumn(['completed_at', 'final_fare']);
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -982,6 +982,8 @@ paths:
                   driver: null
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
+                  completed_at: null
+                  final_fare: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1175,6 +1177,8 @@ paths:
                   driver: null
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
+                  completed_at: null
+                  final_fare: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1307,6 +1311,8 @@ paths:
                   driver: null
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
+                  completed_at: null
+                  final_fare: null
                   cancellation_fee_applies: true
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -1415,6 +1421,8 @@ paths:
                     name: Carlos Pérez
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: null
+                  completed_at: null
+                  final_fare: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1531,6 +1539,8 @@ paths:
                     name: Carlos Pérez
                   requested_at: "2026-07-31T14:03:21+00:00"
                   started_at: "2026-07-31T14:09:05+00:00"
+                  completed_at: null
+                  final_fare: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1570,6 +1580,121 @@ paths:
                 errors:
                   ride:
                     - Solo se puede iniciar un viaje que esté aceptado.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /rides/{id}/complete:
+    post:
+      tags:
+        - Rides
+      operationId: completeRide
+      summary: Completar un viaje en curso
+      description: >-
+        Marca como completado el viaje que el conductor autenticado tiene en
+        curso (historia #24): el viaje pasa de `in_progress` a `completed`,
+        queda registrada la hora de finalización en `completed_at`, y se
+        recalcula la tarifa final en `final_fare` a partir del trayecto
+        realmente recorrido —la distancia cotizada al pedir el viaje y la
+        duración real transcurrida desde `started_at`— usando la misma
+        fórmula que la tarifa estimada (ver "Cálculo de tarifas" en
+        .claude/STANDARDS.md).
+
+        Solo el conductor **asignado a ese viaje** puede completarlo:
+        cualquier otra cuenta —otro conductor, o el pasajero— recibe
+        **403**. Que el viaje no esté en `in_progress` (todavía no arrancó,
+        ya se completó o se canceló) es en cambio **422**, porque el permiso
+        lo tiene y lo que no corresponde es la transición.
+
+        El procesamiento del cobro en sí queda fuera de esta historia: acá
+        solo se calcula y persiste el monto a cobrar (la historia "Pagar el
+        viaje al finalizar" es quien lo procesa).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje a completar.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El viaje quedó completado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Ride"
+              example:
+                data:
+                  id: 1
+                  status: completed
+                  origin:
+                    latitude: 4.710989
+                    longitude: -74.072092
+                  destination:
+                    latitude: 4.698
+                    longitude: -74.061
+                  distance_meters: 7421
+                  duration_seconds: 842
+                  currency: COP
+                  estimated_fare: 8850
+                  driver:
+                    id: 42
+                    name: Carlos Pérez
+                  requested_at: "2026-07-31T14:03:21+00:00"
+                  started_at: "2026-07-31T14:09:05+00:00"
+                  completed_at: "2026-07-31T14:19:05+00:00"
+                  final_fare: 8450
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El viaje no está asignado a la cuenta autenticada (o la cuenta no
+            es de un conductor).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "422":
+          description: >-
+            El viaje no está en `in_progress`: todavía no arrancó, ya se
+            completó o se canceló.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Solo se puede completar un viaje que esté en curso.
+                errors:
+                  ride:
+                    - Solo se puede completar un viaje que esté en curso.
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:
@@ -2262,6 +2387,8 @@ components:
         - driver
         - requested_at
         - started_at
+        - completed_at
+        - final_fare
       properties:
         id:
           type: integer
@@ -2335,6 +2462,28 @@ components:
             (historia #19). Es `null` mientras el viaje no haya empezado, y
             el campo está siempre presente para que el cliente no tenga que
             distinguir "todavía no empezó" de "esta respuesta no lo trae".
+          example: null
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Momento en que el conductor marcó el viaje como completado
+            (historia #24). Es `null` mientras el viaje no haya terminado, y
+            el campo está siempre presente por el mismo motivo que
+            `started_at`.
+          example: null
+        final_fare:
+          type: integer
+          nullable: true
+          description: >-
+            Monto final del viaje, entero en la unidad mínima de `currency`,
+            recalculado al completarlo (historia #24) con el trayecto
+            realmente recorrido en vez del estimado al solicitarlo. Es
+            `null` mientras el viaje no esté `completed`; no es en sí mismo
+            un cobro procesado, solo el monto que corresponde cobrar (eso lo
+            resuelve la historia "Pagar el viaje al finalizar", fuera de
+            alcance de #24).
           example: null
     RideDriver:
       type: object

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
 use App\Http\Controllers\Api\V1\Rides\AcceptRideController;
 use App\Http\Controllers\Api\V1\Rides\CancelRideController;
+use App\Http\Controllers\Api\V1\Rides\CompleteRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Rides\ShareRideLocationController;
@@ -162,6 +163,16 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/{ride}/start', StartRideController::class)
         ->name('rides.start');
+
+    // Completar el viaje ya iniciado (historia #24). Mismo criterio de
+    // autorización que iniciar: `{ride}` resuelve el binding implícito antes
+    // de `CompleteRideRequest`, y quién puede completarlo depende de la fila
+    // (RidePolicy::complete()), no solo del rol. Que el viaje no esté en
+    // `in_progress` es 422 y lo resuelve el propio Form Request; no hace
+    // falta lock por el mismo motivo que iniciar (ver `CompleteRideAction`).
+    Route::middleware('auth:api')
+        ->post('rides/{ride}/complete', CompleteRideController::class)
+        ->name('rides.complete');
 
     // Publicar la ubicación del conductor durante el viaje (historia #20).
     // Mismo criterio de autorización que iniciar: `{ride}` resuelve el

--- a/tests/Feature/Rides/CompleteRideTest.php
+++ b/tests/Feature/Rides/CompleteRideTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\RecordsBroadcasts;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/{id}/complete — ver openapi.yaml.
+ *
+ * Historia #24: el conductor que ya inició el viaje lo marca como
+ * completado al llegar al destino. Cierra el ciclo de vida del viaje y
+ * recalcula la tarifa final con el trayecto realmente recorrido; el cobro en
+ * sí (historia "Pagar el viaje al finalizar") queda fuera de alcance.
+ *
+ * Completar publica el cambio de estado hacia el pasajero (historia #21); lo
+ * que sale por el canal se prueba en `RideStatusChangedTest`. Acá el trait
+ * está solo para que las requests que lo disparan no terminen buscando un
+ * Reverb real.
+ */
+class CompleteRideTest extends TestCase
+{
+    use RecordsBroadcasts, RefreshDatabase;
+
+    public function test_el_conductor_asignado_completa_su_viaje_en_curso(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeEnCursoPor($conductor);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.id', $viaje->id);
+        $respuesta->assertJsonPath('data.status', 'completed');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Completed->value,
+            'driver_id' => $conductor->id,
+        ]);
+    }
+
+    public function test_registra_la_hora_de_finalizacion(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeEnCursoPor($conductor);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        // La hora de finalización es un criterio de aceptación por sí misma,
+        // y el contrato la publica: sin ella no hay forma de saber desde
+        // cuándo terminó el viaje (para el recibo, historia #26).
+        $this->assertNotNull($respuesta->json('data.completed_at'));
+        $this->assertNotNull($viaje->refresh()->completed_at);
+    }
+
+    public function test_recalcula_la_tarifa_final_con_el_trayecto_realmente_recorrido(): void
+    {
+        Carbon::setTestNow('2026-07-31 14:09:05');
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeEnCursoPor($conductor, distanciaMetros: 7421);
+
+        // 600 segundos de viaje real, distintos de los 842 estimados al
+        // pedirlo: lo que se cobra tiene que salir de este número, no de
+        // `estimated_fare`.
+        Carbon::setTestNow('2026-07-31 14:19:05');
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        // base 1500 + distancia round(7421*800/1000)=5937 + tiempo
+        // round(600*100/60)=1000 = 8437, redondeado hacia arriba a 8450.
+        $respuesta->assertJsonPath('data.final_fare', 8450);
+        $this->assertSame(8450, $viaje->refresh()->final_fare);
+    }
+
+    public function test_el_viaje_aun_no_completado_publica_completed_at_y_final_fare_nulos(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::Accepted,
+            'driver_id' => $conductor->id,
+        ]);
+
+        // El campo está siempre presente, no solo cuando el viaje ya
+        // terminó: así el cliente no tiene que distinguir "todavía no
+        // terminó" de "esta respuesta no lo trae" (ver el schema `Ride` en
+        // openapi.yaml). La estructura se afirma aparte del valor a
+        // propósito: `assertJsonPath` contra `null` también pasa si la clave
+        // no viene, que es justo el caso que este test existe para
+        // descartar.
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson("/api/v1/rides/{$viaje->id}/start")
+            ->assertOk();
+
+        $respuesta->assertJsonStructure(['data' => ['completed_at', 'final_fare']]);
+        $respuesta->assertJsonPath('data.completed_at', null);
+        $respuesta->assertJsonPath('data.final_fare', null);
+    }
+
+    public function test_rechaza_a_un_conductor_que_no_es_el_asignado(): void
+    {
+        $asignado = User::factory()->driver()->create();
+        $otroConductor = User::factory()->driver()->create();
+        $viaje = $this->viajeEnCursoPor($asignado);
+
+        $this->withToken(JWTAuth::fromUser($otroConductor))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::InProgress->value,
+            'completed_at' => null,
+        ]);
+    }
+
+    public function test_rechaza_al_pasajero_del_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $conductor->id,
+            'started_at' => now(),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::InProgress->value,
+        ]);
+    }
+
+    #[DataProvider('estadosQueNoSePuedenCompletar')]
+    public function test_rechaza_un_viaje_que_no_esta_en_curso(RideStatus $estado): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => $estado,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => $estado->value,
+        ]);
+    }
+
+    public function test_rechaza_un_viaje_requested_sin_conductor_asignado(): void
+    {
+        // Sin conductor asignado no hay a quién dejarlo completar, así que la
+        // Policy corta antes que la validación de estado: es 403 y no 422.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['status' => RideStatus::Requested]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::Requested->value,
+        ]);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson('/api/v1/rides/999999/complete')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $viaje = $this->viajeEnCursoPor(User::factory()->driver()->create());
+
+        $this->postJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseHas('rides', [
+            'id' => $viaje->id,
+            'status' => RideStatus::InProgress->value,
+            'completed_at' => null,
+        ]);
+    }
+
+    private function viajeEnCursoPor(User $conductor, int $distanciaMetros = 7421): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $conductor->id,
+            'estimated_distance_meters' => $distanciaMetros,
+            'started_at' => now(),
+        ]);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/complete";
+    }
+
+    /**
+     * El criterio de aceptación #3 nombra la transición inválida en general;
+     * `accepted` (todavía no arrancó), `completed` y `cancelled` cubren el
+     * resto del ciclo de vida. `requested` queda fuera de este conjunto a
+     * propósito: ahí no hay conductor asignado y la respuesta correcta es
+     * 403, con su propio test.
+     *
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosQueNoSePuedenCompletar(): array
+    {
+        return [
+            RideStatus::Accepted->value => [RideStatus::Accepted],
+            RideStatus::Completed->value => [RideStatus::Completed],
+            RideStatus::Cancelled->value => [RideStatus::Cancelled],
+        ];
+    }
+}

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -76,6 +76,10 @@ class RequestRideTest extends TestCase
                 // schema `Ride` lo declara obligatorio y nullable (historia
                 // #19), así que el cliente lo encuentra siempre.
                 'started_at' => null,
+                // Mismo criterio para completar el viaje (historia #24): el
+                // viaje recién nace, todavía muy lejos de completarse.
+                'completed_at' => null,
+                'final_fare' => null,
             ],
         ]);
 

--- a/tests/Unit/Actions/Rides/CompleteRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CompleteRideActionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\CompleteRideAction;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class CompleteRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('fares.currency', 'COP');
+        Config::set('fares.base', 1500);
+        Config::set('fares.per_kilometer', 800);
+        Config::set('fares.per_minute', 100);
+        Config::set('fares.per_waiting_minute', 60);
+        Config::set('fares.minimum', 3000);
+        Config::set('fares.rounding_step', 50);
+    }
+
+    public function test_pasa_el_viaje_a_completed(): void
+    {
+        $viaje = $this->viajeEnCurso();
+
+        $resultado = $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        $this->assertSame(RideStatus::Completed, $resultado->status);
+        $this->assertSame(RideStatus::Completed, $viaje->refresh()->status);
+    }
+
+    public function test_registra_la_hora_de_finalizacion(): void
+    {
+        Carbon::setTestNow('2026-07-31 14:09:05');
+        $viaje = $this->viajeEnCurso();
+
+        Carbon::setTestNow('2026-07-31 14:19:05');
+        $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        $this->assertNotNull($viaje->refresh()->completed_at);
+        $this->assertTrue(Carbon::now()->equalTo($viaje->completed_at));
+    }
+
+    public function test_recalcula_la_tarifa_con_la_distancia_estimada_y_la_duracion_real(): void
+    {
+        Carbon::setTestNow('2026-07-31 14:09:05');
+        $viaje = $this->viajeEnCurso(distanciaMetros: 7421);
+
+        // 600 segundos reales, no los 842 estimados al pedir el viaje.
+        Carbon::setTestNow('2026-07-31 14:19:05');
+
+        $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        // base 1500 + distancia round(7421*800/1000)=5937 + tiempo
+        // round(600*100/60)=1000 = 8437, redondeado hacia arriba a 8450.
+        $this->assertSame(8450, $viaje->refresh()->final_fare);
+    }
+
+    public function test_una_distancia_recorrida_distinta_cambia_la_tarifa(): void
+    {
+        Carbon::setTestNow('2026-07-31 14:09:05');
+        $viaje = $this->viajeEnCurso(distanciaMetros: 1000);
+
+        Carbon::setTestNow('2026-07-31 14:11:05'); // 120 segundos despues
+
+        $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        // base 1500 + distancia round(1000*800/1000)=800 + tiempo
+        // round(120*100/60)=200 = 2500, bajo el mínimo (3000): se aplica el
+        // piso y se redondea a 3000.
+        $this->assertSame(3000, $viaje->refresh()->final_fare);
+    }
+
+    public function test_no_toca_al_conductor_asignado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => $conductor->id,
+            'started_at' => now(),
+        ]);
+
+        $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        $this->assertSame($conductor->getKey(), $viaje->refresh()->driver_id);
+    }
+
+    private function viajeEnCurso(int $distanciaMetros = 7421): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::InProgress,
+            'driver_id' => User::factory()->driver(),
+            'estimated_distance_meters' => $distanciaMetros,
+            'started_at' => now(),
+        ]);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -120,6 +120,36 @@ class RidePolicyTest extends TestCase
         $this->assertFalse($pasajero->can('start', $viaje));
     }
 
+    public function test_el_conductor_asignado_puede_completar_su_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('complete', $viaje));
+    }
+
+    public function test_otro_conductor_no_puede_completar_un_viaje_ajeno(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse(User::factory()->driver()->create()->can('complete', $viaje));
+    }
+
+    public function test_nadie_puede_completar_un_viaje_sin_conductor_asignado(): void
+    {
+        $viaje = Ride::factory()->create(['driver_id' => null]);
+
+        $this->assertFalse(User::factory()->driver()->create()->can('complete', $viaje));
+    }
+
+    public function test_el_pasajero_no_puede_completar_su_propio_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create(['driver_id' => User::factory()->driver()]);
+
+        $this->assertFalse($pasajero->can('complete', $viaje));
+    }
+
     public function test_el_pasajero_dueno_puede_ver_su_viaje(): void
     {
         $pasajero = User::factory()->create();


### PR DESCRIPTION
Closes #24

## Qué hace

Implementa `POST /api/v1/rides/{id}/complete` (historia #24): el conductor
asignado marca como completado el viaje que tiene en curso.

- El viaje pasa de `in_progress` a `completed` y queda registrada la hora de
  finalización en `completed_at`.
- Se recalcula la tarifa final en `final_fare` con la misma
  `CalculateFareAction` que la tarifa estimada al pedir el viaje (ver
  ".claude/STANDARDS.md", sección "Cálculo de tarifas"), pero con un
  `RouteEstimate` distinto: como no hay tracking persistido de la distancia
  realmente recorrida, se reusa `estimated_distance_meters` (la distancia
  cotizada al pedir el viaje) y se reemplaza la duración estimada por el
  tiempo real transcurrido entre `started_at` y el momento de completar.
- Autorización: solo el conductor **asignado a ese viaje** puede
  completarlo (`RidePolicy::complete()`), mismo criterio que `start()`. Sin
  conductor asignado es **403**; con conductor asignado pero en otro estado
  es **422** (`CompleteRideRequest`).
- `RideResource` y el schema `Ride` de `openapi.yaml` publican los nuevos
  campos `completed_at` y `final_fare`, siempre presentes y `null` hasta
  que corresponda, mismo criterio que `started_at`.
- Migración nueva agrega `completed_at` (timestamp nullable) y `final_fare`
  (integer nullable) a `rides`.

Fuera de alcance (explícito en el issue): el procesamiento del cobro en sí
(historia "Pagar el viaje al finalizar", que todavía no existe en el
backlog implementado — no hay `ChargeRideAction`).

## Cómo se probó

- SDD → TDD → implementación siguiendo `laravel-feature-workflow`: el spec
  OpenAPI se actualizó primero (`openapi.yaml`), después los tests
  (Feature + Unit), confirmados en rojo antes de escribir la
  implementación.
- `tests/Feature/Rides/CompleteRideTest.php`: contrato HTTP completo (happy
  path, hora de finalización, recálculo de tarifa con un ejemplo numérico
  verificado a mano, campos siempre presentes y `null` antes de completar,
  403 para conductor no asignado / pasajero / viaje sin conductor, 422 por
  cada estado no válido, 404, 401).
- `tests/Unit/Actions/Rides/CompleteRideActionTest.php`: la Action invocada
  directo, incluyendo dos escenarios de tarifa (uno por encima del mínimo,
  otro que cae en el piso).
- `tests/Unit/Policies/RidePolicyTest.php`: casos nuevos para
  `RidePolicy::complete()`.
- Ajustado `tests/Feature/Rides/RequestRideTest.php` (`assertExactJson`) para
  incluir los dos campos nuevos que ahora publica `RideResource`.
- `php artisan test`: 554/554 en verde. `./vendor/bin/pint --test`: sin
  errores. `php vendor/bin/phpstan analyse`: sin errores (nivel configurado
  en `phpstan.neon`).
- `php artisan route:list --path=api/v1/rides` verificado a mano contra los
  paths de `openapi.yaml` (todas las rutas de rides, incluida la nueva,
  coinciden).

**Nota de entorno**: no hay intérprete de Python instalado en esta máquina,
así que no pude correr `static_conformance.py` / `dynamic_conformance.py`
de la skill `laravel-feature-workflow`. Sustituí esa validación con la
verificación manual de rutas de arriba y con la suite de tests Feature, que
ejercita el stack HTTP real (routing, middleware, Form Request, Resource) y
ya cubre la forma exacta de la respuesta contra los mismos valores que
documenté como ejemplo en el spec.

## Decisiones y riesgos

- **Fuente del "trayecto realmente recorrido"**: el issue y el propio
  `Ride` (comentario existente en el modelo) dicen que la tarifa final se
  recalcula con el trayecto real, pero no hay ningún mecanismo hoy que lo
  capture (la ubicación del conductor solo viaja por broadcast, no se
  persiste). Decidí reusar la distancia estimada al pedir el viaje +
  duración real (`started_at` → `now()`), que es lo mínimo consistente con
  los datos que sí existen, sin gastar cuota del proveedor de mapas
  volviendo a consultarlo. Si se decide capturar distancia real en el
  futuro, es un cambio acotado al `RouteEstimate` que arma
  `CompleteRideAction`, no al resto del flujo.
- No se agregó lock/transacción en `CompleteRideAction`, mismo criterio que
  `StartRideAction`: el único que puede competir por esta fila es el mismo
  conductor tocando el botón dos veces, y el Form Request ya valida el
  estado antes.