### PR TITLE
feat(#25): pagar el viaje al finalizar

### DIFF
--- a/app/Actions/Payments/ChargeRideAction.php
+++ b/app/Actions/Payments/ChargeRideAction.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Payments;
+
+use App\Enums\PaymentStatus;
+use App\Exceptions\PaymentProcessingFailed;
+use App\Models\Payment;
+use App\Models\Ride;
+use App\Services\Payments\PaymentGateway;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Procesa el cobro de un viaje recién completado (historia #25).
+ *
+ * La invoca `CompleteRideAction` justo después de persistir `final_fare`: el
+ * monto a cobrar sale de ahí, no se recalcula acá. No conoce HTTP ni cómo se
+ * llegó al viaje, mismo criterio que el resto de las Actions.
+ *
+ * Un fallo del proveedor de pago (`PaymentProcessingFailed`) no se deja
+ * propagar: se atrapa acá y el pago queda `failed`. Que el cobro no se pueda
+ * procesar es un problema del pago, no del viaje —el conductor ya hizo el
+ * trayecto—, así que no puede impedir que el viaje quede `completed`.
+ */
+final readonly class ChargeRideAction
+{
+    public function __construct(private PaymentGateway $gateway) {}
+
+    /**
+     * Idempotente: si el viaje ya tiene un pago (reintento duplicado), lo
+     * devuelve tal cual en vez de procesar un segundo cobro. El índice único
+     * de `ride_id` en la tabla `payments` respalda esto mismo si dos
+     * llamadas llegaran a la vez.
+     */
+    public function handle(Ride $ride): Payment
+    {
+        $existing = $ride->payment;
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        [$status, $processedAt] = $this->process($ride);
+
+        $payment = Payment::create([
+            'ride_id' => $ride->id,
+            'amount' => $ride->final_fare,
+            'currency' => $ride->currency,
+            'status' => $status,
+            'processed_at' => $processedAt,
+        ]);
+
+        // `$ride->payment` de la línea de arriba ya dejó la relación
+        // cacheada en `null` sobre esta misma instancia; sin esto, quien
+        // siga usando este `$ride` (p. ej. `CompleteRideController` armando
+        // la respuesta) seguiría viendo `payment: null` pese a que la fila
+        // ya existe.
+        $ride->setRelation('payment', $payment);
+
+        return $payment;
+    }
+
+    /**
+     * @return array{0: PaymentStatus, 1: Carbon|null}
+     */
+    private function process(Ride $ride): array
+    {
+        try {
+            $this->gateway->charge($ride);
+        } catch (PaymentProcessingFailed $e) {
+            Log::error('No se pudo procesar el cobro del viaje.', [
+                'ride_id' => $ride->id,
+                'reason' => $e->getMessage(),
+            ]);
+
+            return [PaymentStatus::Failed, null];
+        }
+
+        return [PaymentStatus::Paid, now()];
+    }
+}

--- a/app/Actions/Rides/CompleteRideAction.php
+++ b/app/Actions/Rides/CompleteRideAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Rides;
 
 use App\Actions\Payments\CalculateFareAction;
+use App\Actions\Payments\ChargeRideAction;
 use App\DTOs\RouteEstimate;
 use App\Enums\RideStatus;
 use App\Events\Realtime\RideStatusChanged;
@@ -12,7 +13,7 @@ use App\Models\Ride;
 
 /**
  * Marca como completado un viaje que el conductor asignado tiene en curso
- * (historia #24) y recalcula la tarifa final.
+ * (historia #24), recalcula la tarifa final y dispara su cobro.
  *
  * El viaje llega resuelto y validado: que sea del conductor autenticado lo
  * garantiza `RidePolicy::complete()` y que siga en `in_progress` lo
@@ -30,7 +31,10 @@ use App\Models\Ride;
  */
 final readonly class CompleteRideAction
 {
-    public function __construct(private CalculateFareAction $calculateFare) {}
+    public function __construct(
+        private CalculateFareAction $calculateFare,
+        private ChargeRideAction $chargeRide,
+    ) {}
 
     public function handle(Ride $ride): Ride
     {
@@ -47,9 +51,14 @@ final readonly class CompleteRideAction
             'final_fare' => $fare->total,
         ]);
 
+        // El cobro se procesa acá, ya con `final_fare` persistido (historia
+        // #25). Un fallo del proveedor de pago no interrumpe esta Action ni
+        // deja el viaje sin completar: `ChargeRideAction` lo atrapa y
+        // devuelve un `Payment` en `failed`.
+        $this->chargeRide->handle($ride);
+
         // Cierra el ciclo de vida para el pasajero que sigue el viaje por el
-        // canal privado (historia #21); el cobro en sí queda fuera de esta
-        // historia (lo resuelve "Pagar el viaje al finalizar").
+        // canal privado (historia #21).
         RideStatusChanged::dispatch($ride->id, $ride->status, $ride->driver_id);
 
         return $ride;

--- a/app/Enums/PaymentStatus.php
+++ b/app/Enums/PaymentStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Estado del cobro de un viaje completado (historia #25).
+ *
+ * Los valores viajan tal cual a `payments.status` y al campo `status` del
+ * schema `Payment` de openapi.yaml, mismo criterio que `RideStatus`.
+ */
+enum PaymentStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Failed = 'failed';
+}

--- a/app/Exceptions/PaymentProcessingFailed.php
+++ b/app/Exceptions/PaymentProcessingFailed.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * El proveedor de pago no pudo procesar el cobro de un viaje.
+ *
+ * A diferencia de `RouteEstimationFailed`, quien atrapa esta excepción
+ * (`ChargeRideAction`) no la vuelve a lanzar: la traduce a un `Payment` en
+ * estado `failed` para que un cobro rechazado no le impida al conductor
+ * cerrar el viaje (historia #25).
+ */
+final class PaymentProcessingFailed extends RuntimeException
+{
+    public static function rejectedByProvider(string $provider, string $reason): self
+    {
+        return new self("El proveedor de pago '{$provider}' rechazó el cobro: {$reason}");
+    }
+
+    public static function providerUnreachable(string $provider, string $reason): self
+    {
+        return new self("No se pudo contactar al proveedor de pago '{$provider}': {$reason}");
+    }
+}

--- a/app/Http/Resources/RideResource.php
+++ b/app/Http/Resources/RideResource.php
@@ -71,6 +71,16 @@ class RideResource extends JsonResource
             // criterio de siempre presente que el resto de los campos que
             // nacen a mitad del ciclo de vida.
             'final_fare' => $this->resource->final_fare,
+            // El procesamiento del cobro (historia #25), distinto de
+            // `final_fare`: ese es el monto a cobrar, esto es si el cobro se
+            // hizo. `null` hasta que `CompleteRideAction` dispara
+            // `ChargeRideAction`, mismo criterio que el resto de los campos
+            // que nacen a mitad del ciclo de vida. No repite `amount` ni
+            // `currency`: ya están en `final_fare` y `currency` arriba, y el
+            // pago no puede valer algo distinto.
+            'payment' => $this->resource->payment === null
+                ? null
+                : ['status' => $this->resource->payment->status->value],
         ];
     }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\PaymentStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * El cobro de un viaje completado (historia #25).
+ *
+ * Un viaje tiene a lo sumo un pago: `ChargeRideAction` es la única que
+ * escribe esta tabla, y lo hace una sola vez por viaje (ver el índice único
+ * de `ride_id` en la migración). No tiene Policy propia porque no se expone
+ * por ningún endpoint todavía — se consulta a través de `Ride::payment()`,
+ * bajo la misma autorización que ya resuelve `RidePolicy` para el viaje.
+ *
+ * @property int $ride_id
+ * @property int $amount
+ * @property string $currency
+ * @property PaymentStatus $status
+ * @property Carbon|null $processed_at
+ */
+#[Fillable([
+    'ride_id',
+    'amount',
+    'currency',
+    'status',
+    'processed_at',
+])]
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'integer',
+            'status' => PaymentStatus::class,
+            'processed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Ride, $this>
+     */
+    public function ride(): BelongsTo
+    {
+        return $this->belongsTo(Ride::class);
+    }
+}

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 
 /**
@@ -101,5 +102,15 @@ class Ride extends Model
     public function driver(): BelongsTo
     {
         return $this->belongsTo(User::class, 'driver_id');
+    }
+
+    /**
+     * El cobro del viaje, o `null` hasta que se completa (historia #25).
+     *
+     * @return HasOne<Payment, $this>
+     */
+    public function payment(): HasOne
+    {
+        return $this->hasOne(Payment::class);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 use App\DTOs\FareSchedule;
 use App\Services\Maps\GoogleRoutesEstimator;
 use App\Services\Maps\RouteEstimator;
+use App\Services\Payments\NullPaymentGateway;
+use App\Services\Payments\PaymentGateway;
 use App\Services\Realtime\EloquentNearbyDriverFinder;
 use App\Services\Realtime\EloquentRideParticipants;
 use App\Services\Realtime\NearbyDriverFinder;
@@ -25,9 +27,22 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->registerRouteEstimator();
+        $this->registerPaymentGateway();
         $this->registerFareSchedule();
         $this->registerRideParticipants();
         $this->registerNearbyDriverFinder();
+    }
+
+    /**
+     * Proveedor de pago que procesa el cobro de un viaje completado (historia
+     * #25). Todavía no hay un proveedor real decidido —ver "Fuera de
+     * alcance" en el issue—, así que apunta a `NullPaymentGateway`, que da
+     * todo cobro por exitoso. Cambiar de proveedor real es reemplazar este
+     * binding, mismo criterio que `registerRouteEstimator()`.
+     */
+    private function registerPaymentGateway(): void
+    {
+        $this->app->singleton(PaymentGateway::class, NullPaymentGateway::class);
     }
 
     /**

--- a/app/Services/Payments/NullPaymentGateway.php
+++ b/app/Services/Payments/NullPaymentGateway.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payments;
+
+use App\Models\Ride;
+
+/**
+ * Implementación de `PaymentGateway` mientras no hay un proveedor real
+ * integrado (historia #25: "el método de pago concreto ... no está decidido
+ * todavía").
+ *
+ * Todo cobro se da por exitoso de inmediato — no hay red de por medio, así
+ * que no hay nada que pueda rechazarlo ni quedar inalcanzable. El día que se
+ * decida un proveedor real (tarjeta, billetera), se reemplaza el binding en
+ * `AppServiceProvider` sin tocar `ChargeRideAction`, mismo criterio que
+ * `GoogleRoutesEstimator` reemplazó a cualquier estimador previo.
+ */
+final class NullPaymentGateway implements PaymentGateway
+{
+    public function charge(Ride $ride): void {}
+}

--- a/app/Services/Payments/PaymentGateway.php
+++ b/app/Services/Payments/PaymentGateway.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payments;
+
+use App\Exceptions\PaymentProcessingFailed;
+use App\Models\Ride;
+
+/**
+ * Contrato con el proveedor de pago que procesa el cobro de un viaje.
+ *
+ * `ChargeRideAction` depende de esta interfaz y nunca de una implementación
+ * concreta, mismo criterio que `RouteEstimator`: qué proveedor de pago se usa
+ * (efectivo conciliado aparte, tarjeta, billetera) no está decidido todavía
+ * (ver "Fuera de alcance" de la historia #25), y el punto de integración
+ * tiene que poder cambiar sin tocar `ChargeRideAction` ni `CompleteRideAction`.
+ */
+interface PaymentGateway
+{
+    /**
+     * Procesa el cobro de `$ride->final_fare`. No devuelve nada: el éxito es
+     * que el método retorne sin lanzar.
+     *
+     * @throws PaymentProcessingFailed si el proveedor rechaza el cobro o no
+     *                                 se lo puede contactar.
+     */
+    public function charge(Ride $ride): void;
+}

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\PaymentStatus;
+use App\Models\Payment;
+use App\Models\Ride;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Payment>
+ */
+class PaymentFactory extends Factory
+{
+    /**
+     * Por defecto un cobro ya pagado, asociado a un viaje nuevo: es el
+     * resultado normal de `ChargeRideAction` con el `PaymentGateway`
+     * configurado hoy (`NullPaymentGateway`, ver AppServiceProvider).
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'ride_id' => Ride::factory(),
+            'amount' => fake()->numberBetween(60, 600) * 50,
+            'currency' => 'COP',
+            'status' => PaymentStatus::Paid,
+            'processed_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_01_000003_create_payments_table.php
+++ b/database/migrations/2026_08_01_000003_create_payments_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+
+            // Un pago por viaje. `unique()` respalda a nivel de base la misma
+            // regla que `ChargeRideAction` ya verifica antes de escribir: un
+            // reintento duplicado (historia #25) no puede terminar en dos
+            // filas, y entre la consulta y el INSERT caben dos llamadas
+            // simultáneas, igual que `active_passenger_id` en `rides`. Se
+            // borra con el viaje: un pago sin viaje no es nada que conciliar.
+            $table->foreignId('ride_id')->unique()->constrained('rides')->cascadeOnDelete();
+
+            // Entero en la unidad mínima de `currency`, nunca float: ver la
+            // nota sobre dinero en .claude/STANDARDS.md. Es una copia del
+            // `final_fare` del viaje en el momento del cobro, no una
+            // referencia: si `final_fare` cambiara más adelante, el pago ya
+            // procesado no debería moverse con él.
+            $table->unsignedInteger('amount');
+            $table->string('currency', 3);
+
+            $table->string('status', 20)->index();
+
+            // Cuándo el proveedor confirmó el cobro. Nullable porque un pago
+            // `failed` no llegó a procesarse.
+            $table->timestamp('processed_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -984,6 +984,7 @@ paths:
                   started_at: null
                   completed_at: null
                   final_fare: null
+                  payment: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1179,6 +1180,7 @@ paths:
                   started_at: null
                   completed_at: null
                   final_fare: null
+                  payment: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1313,6 +1315,7 @@ paths:
                   started_at: null
                   completed_at: null
                   final_fare: null
+                  payment: null
                   cancellation_fee_applies: true
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -1423,6 +1426,7 @@ paths:
                   started_at: null
                   completed_at: null
                   final_fare: null
+                  payment: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1541,6 +1545,7 @@ paths:
                   started_at: "2026-07-31T14:09:05+00:00"
                   completed_at: null
                   final_fare: null
+                  payment: null
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -1610,9 +1615,12 @@ paths:
         ya se completó o se canceló) es en cambio **422**, porque el permiso
         lo tiene y lo que no corresponde es la transición.
 
-        El procesamiento del cobro en sí queda fuera de esta historia: acá
-        solo se calcula y persiste el monto a cobrar (la historia "Pagar el
-        viaje al finalizar" es quien lo procesa).
+        Completar el viaje también dispara su cobro (historia #25) por
+        `final_fare`, publicado en `payment`. Que el proveedor de pago
+        rechace el cobro no revierte la finalización ni responde un error:
+        el viaje igual queda `completed` y `payment.status` queda en
+        `failed` — el conductor ya hizo el trayecto, y un cobro que no se
+        pudo procesar se resuelve aparte, no reabriendo el viaje.
       security:
         - bearerAuth: []
       parameters:
@@ -1656,6 +1664,8 @@ paths:
                   started_at: "2026-07-31T14:09:05+00:00"
                   completed_at: "2026-07-31T14:19:05+00:00"
                   final_fare: 8450
+                  payment:
+                    status: paid
         "401":
           description: Falta el access token, es ilegible o ya venció.
           content:
@@ -2389,6 +2399,7 @@ components:
         - started_at
         - completed_at
         - final_fare
+        - payment
       properties:
         id:
           type: integer
@@ -2480,10 +2491,20 @@ components:
             Monto final del viaje, entero en la unidad mínima de `currency`,
             recalculado al completarlo (historia #24) con el trayecto
             realmente recorrido en vez del estimado al solicitarlo. Es
-            `null` mientras el viaje no esté `completed`; no es en sí mismo
-            un cobro procesado, solo el monto que corresponde cobrar (eso lo
-            resuelve la historia "Pagar el viaje al finalizar", fuera de
-            alcance de #24).
+            `null` mientras el viaje no esté `completed`. No es en sí mismo
+            el resultado del cobro —eso lo publica `payment`—, solo el monto
+            que corresponde cobrar.
+          example: null
+        payment:
+          allOf:
+            - $ref: "#/components/schemas/Payment"
+          nullable: true
+          description: >-
+            El cobro del viaje (historia #25), o `null` mientras el viaje no
+            esté `completed`. El campo está siempre presente, mismo criterio
+            que `driver` y `started_at`, para que el cliente no tenga que
+            distinguir "todavía no se completó" de "esta respuesta no lo
+            trae".
           example: null
     RideDriver:
       type: object
@@ -2510,6 +2531,31 @@ components:
           type: string
           description: Nombre con el que el conductor se registró.
           example: Carlos Pérez
+    Payment:
+      type: object
+      description: >-
+        El cobro de un viaje completado, visto desde el viaje (historia #25).
+
+        No repite `amount` ni `currency`: son el `final_fare` y `currency`
+        que ya trae el viaje que contiene este objeto, y el pago no puede
+        valer un monto distinto del que se calculó al completarlo.
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: >-
+            Resultado del cobro. `paid` cuando el proveedor de pago lo
+            confirmó, `failed` cuando lo rechazó o no se lo pudo contactar
+            —eso no bloquea que el viaje quede `completed`—. `pending` no lo
+            produce hoy ningún flujo (el cobro se procesa de forma síncrona
+            al completar el viaje), pero es parte del contrato para cuando
+            se integre un proveedor real asíncrono.
+          enum:
+            - pending
+            - paid
+            - failed
+          example: paid
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/tests/Feature/Rides/CompleteRideTest.php
+++ b/tests/Feature/Rides/CompleteRideTest.php
@@ -19,8 +19,9 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  *
  * Historia #24: el conductor que ya inició el viaje lo marca como
  * completado al llegar al destino. Cierra el ciclo de vida del viaje y
- * recalcula la tarifa final con el trayecto realmente recorrido; el cobro en
- * sí (historia "Pagar el viaje al finalizar") queda fuera de alcance.
+ * recalcula la tarifa final con el trayecto realmente recorrido. También
+ * dispara su cobro (historia #25, `ChargeRideAction`), publicado en
+ * `data.payment`.
  *
  * Completar publica el cambio de estado hacia el pasajero (historia #21); lo
  * que sale por el canal se prueba en `RideStatusChangedTest`. Acá el trait
@@ -47,6 +48,25 @@ class CompleteRideTest extends TestCase
             'id' => $viaje->id,
             'status' => RideStatus::Completed->value,
             'driver_id' => $conductor->id,
+        ]);
+    }
+
+    public function test_publica_el_cobro_del_viaje_al_completarlo(): void
+    {
+        // Sin un proveedor de pago real configurado (historia #25, "fuera de
+        // alcance"), el cobro resuelto por `NullPaymentGateway` siempre se
+        // confirma.
+        $conductor = User::factory()->driver()->create();
+        $viaje = $this->viajeEnCursoPor($conductor);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.payment.status', 'paid');
+        $this->assertDatabaseHas('payments', [
+            'ride_id' => $viaje->id,
+            'status' => 'paid',
         ]);
     }
 
@@ -106,9 +126,10 @@ class CompleteRideTest extends TestCase
             ->postJson("/api/v1/rides/{$viaje->id}/start")
             ->assertOk();
 
-        $respuesta->assertJsonStructure(['data' => ['completed_at', 'final_fare']]);
+        $respuesta->assertJsonStructure(['data' => ['completed_at', 'final_fare', 'payment']]);
         $respuesta->assertJsonPath('data.completed_at', null);
         $respuesta->assertJsonPath('data.final_fare', null);
+        $respuesta->assertJsonPath('data.payment', null);
     }
 
     public function test_rechaza_a_un_conductor_que_no_es_el_asignado(): void

--- a/tests/Feature/Rides/RequestRideTest.php
+++ b/tests/Feature/Rides/RequestRideTest.php
@@ -80,6 +80,9 @@ class RequestRideTest extends TestCase
                 // viaje recién nace, todavía muy lejos de completarse.
                 'completed_at' => null,
                 'final_fare' => null,
+                // Ídem para el cobro (historia #25): no hay nada que cobrar
+                // hasta que el viaje se completa.
+                'payment' => null,
             ],
         ]);
 

--- a/tests/Unit/Actions/Payments/ChargeRideActionTest.php
+++ b/tests/Unit/Actions/Payments/ChargeRideActionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Payments;
+
+use App\Actions\Payments\ChargeRideAction;
+use App\Enums\PaymentStatus;
+use App\Enums\RideStatus;
+use App\Exceptions\PaymentProcessingFailed;
+use App\Models\Payment;
+use App\Models\Ride;
+use App\Services\Payments\PaymentGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class ChargeRideActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_un_pago_pagado_con_el_monto_y_la_moneda_del_viaje(): void
+    {
+        $viaje = $this->viajeCompletado(montoFinal: 8450, moneda: 'COP');
+
+        $pago = $this->action()->handle($viaje);
+
+        $this->assertSame($viaje->id, $pago->ride_id);
+        $this->assertSame(8450, $pago->amount);
+        $this->assertSame('COP', $pago->currency);
+        $this->assertSame(PaymentStatus::Paid, $pago->status);
+        $this->assertNotNull($pago->processed_at);
+        $this->assertDatabaseCount('payments', 1);
+    }
+
+    public function test_marca_el_pago_como_failed_si_el_proveedor_rechaza_el_cobro(): void
+    {
+        $viaje = $this->viajeCompletado();
+
+        $gateway = new class implements PaymentGateway
+        {
+            public function charge(Ride $ride): void
+            {
+                throw PaymentProcessingFailed::rejectedByProvider('fake', 'fondos insuficientes');
+            }
+        };
+        $this->app->instance(PaymentGateway::class, $gateway);
+
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje);
+
+        $this->assertSame(PaymentStatus::Failed, $pago->status);
+        $this->assertNull($pago->processed_at);
+        $this->assertDatabaseCount('payments', 1);
+    }
+
+    public function test_un_fallo_del_proveedor_no_bloquea_que_se_registre_el_pago(): void
+    {
+        // Mismo caso que el test anterior, visto desde el ángulo del criterio
+        // de aceptación: la Action no lanza, siempre devuelve un `Payment`.
+        $viaje = $this->viajeCompletado();
+
+        $gateway = new class implements PaymentGateway
+        {
+            public function charge(Ride $ride): void
+            {
+                throw PaymentProcessingFailed::providerUnreachable('fake', 'timeout');
+            }
+        };
+        $this->app->instance(PaymentGateway::class, $gateway);
+
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje);
+
+        $this->assertInstanceOf(Payment::class, $pago);
+    }
+
+    public function test_un_viaje_con_pago_existente_no_genera_un_segundo_cobro(): void
+    {
+        $viaje = $this->viajeCompletado();
+        $pagoExistente = Payment::factory()->for($viaje)->create();
+
+        $gateway = new class implements PaymentGateway
+        {
+            public bool $llamado = false;
+
+            public function charge(Ride $ride): void
+            {
+                $this->llamado = true;
+            }
+        };
+        $this->app->instance(PaymentGateway::class, $gateway);
+
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje->refresh());
+
+        $this->assertFalse($gateway->llamado);
+        $this->assertSame($pagoExistente->id, $pago->id);
+        $this->assertDatabaseCount('payments', 1);
+    }
+
+    private function action(): ChargeRideAction
+    {
+        $this->app->instance(PaymentGateway::class, new class implements PaymentGateway
+        {
+            public function charge(Ride $ride): void {}
+        });
+
+        return $this->app->make(ChargeRideAction::class);
+    }
+
+    private function viajeCompletado(int $montoFinal = 8450, string $moneda = 'COP'): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::Completed,
+            'currency' => $moneda,
+            'final_fare' => $montoFinal,
+            'started_at' => now(),
+            'completed_at' => now(),
+        ]);
+    }
+}

--- a/tests/Unit/Actions/Rides/CompleteRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CompleteRideActionTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions\Rides;
 
 use App\Actions\Rides\CompleteRideAction;
+use App\Enums\PaymentStatus;
 use App\Enums\RideStatus;
+use App\Exceptions\PaymentProcessingFailed;
+use App\Models\Payment;
 use App\Models\Ride;
 use App\Models\User;
+use App\Services\Payments\PaymentGateway;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
@@ -97,6 +101,43 @@ class CompleteRideActionTest extends TestCase
         $this->app->make(CompleteRideAction::class)->handle($viaje);
 
         $this->assertSame($conductor->getKey(), $viaje->refresh()->driver_id);
+    }
+
+    public function test_registra_el_cobro_del_viaje_al_completarlo(): void
+    {
+        // Sin bindear un fake, resuelve `NullPaymentGateway` (ver
+        // AppServiceProvider), que da el cobro por exitoso.
+        $viaje = $this->viajeEnCurso(distanciaMetros: 1000);
+
+        $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        $pago = Payment::query()->where('ride_id', $viaje->id)->firstOrFail();
+        $this->assertSame(PaymentStatus::Paid, $pago->status);
+        $this->assertSame($viaje->refresh()->final_fare, $pago->amount);
+    }
+
+    public function test_un_cobro_rechazado_no_impide_completar_el_viaje(): void
+    {
+        // Historia #25, criterio de aceptación: un fallo en el procesamiento
+        // del cobro deja el viaje `completed` con el pago en `failed`, sin
+        // bloquear la finalización.
+        $viaje = $this->viajeEnCurso(distanciaMetros: 1000);
+
+        $this->app->instance(PaymentGateway::class, new class implements PaymentGateway
+        {
+            public function charge(Ride $ride): void
+            {
+                throw PaymentProcessingFailed::rejectedByProvider('fake', 'fondos insuficientes');
+            }
+        });
+
+        $resultado = $this->app->make(CompleteRideAction::class)->handle($viaje);
+
+        $this->assertSame(RideStatus::Completed, $resultado->status);
+        $this->assertSame(RideStatus::Completed, $viaje->refresh()->status);
+
+        $pago = Payment::query()->where('ride_id', $viaje->id)->firstOrFail();
+        $this->assertSame(PaymentStatus::Failed, $pago->status);
     }
 
     private function viajeEnCurso(int $distanciaMetros = 7421): Ride


### PR DESCRIPTION
Closes #25

## Qué hace

Registra el cobro de un viaje al completarlo (historia #25):

- `App\Actions\Payments\ChargeRideAction` (nueva): crea un `Payment`
  (`pending`/`paid`/`failed`) asociado al viaje, con el monto de
  `final_fare` y la moneda del viaje. Es idempotente: si el viaje ya tiene
  un pago (reintento duplicado), lo devuelve tal cual sin procesar un
  segundo cobro — respaldado además por un índice único de `ride_id` en la
  tabla `payments`.
- `App\Actions\Rides\CompleteRideAction` invoca `ChargeRideAction` justo
  después de persistir `final_fare`. Un fallo del proveedor de pago
  (`PaymentProcessingFailed`) se atrapa dentro de `ChargeRideAction` y no se
  deja propagar: el viaje queda `completed` igual, y el pago queda `failed`.
- `App\Services\Payments\PaymentGateway` (interfaz nueva) es el contrato con
  el proveedor de pago, mismo criterio que `RouteEstimator` para mapas. El
  método de pago concreto no está decidido todavía (fuera de alcance del
  issue), así que el binding en `AppServiceProvider` apunta a
  `NullPaymentGateway`, que confirma todo cobro de inmediato.
- `RideResource` publica el resultado en `data.payment` (`{status}`, `null`
  hasta que el viaje se completa). `openapi.yaml` documenta el nuevo schema
  `Payment` y el campo `payment` en `Ride`, y actualiza la descripción de
  `POST /rides/{id}/complete`.

## Cómo se probé

- `tests/Unit/Actions/Payments/ChargeRideActionTest.php`: pago creado con
  el monto/moneda del viaje, marcado `failed` si el proveedor rechaza el
  cobro, y no genera un segundo cargo si el viaje ya tiene pago.
- `tests/Unit/Actions/Rides/CompleteRideActionTest.php`: se agregan dos
  tests — el cobro se registra al completar, y un cobro rechazado no
  impide que el viaje quede `completed`.
- `tests/Feature/Rides/CompleteRideTest.php`: el contrato HTTP publica
  `data.payment.status` en la respuesta de completar.
- `tests/Feature/Rides/RequestRideTest.php`: se ajusta el `assertExactJson`
  existente para incluir `payment: null` (campo nuevo, siempre presente).
- Suite completa: `php vendor/bin/phpunit` → 561/561 en verde.
- `php vendor/bin/pint --test` sin errores.
- `php vendor/bin/phpstan analyse --memory-limit=1G` (nivel del proyecto,
  Larastan) sin errores.

**Limitación de este entorno**: no había Python disponible para correr
`static_conformance.py` / `dynamic_conformance.py` de la skill
`laravel-feature-workflow`, así que el spec de `openapi.yaml` no se validó
con esos scripts — sí se revisó a mano que todos los `example` existentes
de `Ride` (creación, aceptar, iniciar, ubicación, cancelar, completar)
incluyen el nuevo campo `payment` requerido, y que el nuevo schema `Payment`
sigue el mismo estilo que `RideDriver`.

## Decisiones y riesgos

- `payment` en `RideResource` solo publica `status`: no repite `amount` ni
  `currency`, que ya están en `final_fare`/`currency` del propio `Ride`.
- No se agregó un endpoint HTTP para el pago (p. ej. `GET
  /rides/{id}/payment`): el issue no lo pide, y `data.payment` alcanza para
  que el cliente sepa si el cobro se confirmó.
- `NullPaymentGateway` es un placeholder explícito, documentado como tal en
  su propio docblock y en el binding de `AppServiceProvider` — cambiar de
  proveedor real es reemplazar ese binding sin tocar `ChargeRideAction`.