### PR TITLE
feat(#26): ver recibo del viaje completado

### DIFF
--- a/.claude/STANDARDS.md
+++ b/.claude/STANDARDS.md
@@ -868,7 +868,10 @@ no `float`/`double`.
   redondeo en 0 revientan al resolver el servicio, no al cobrarle a un pasajero real.
 - `App\DTOs\FareBreakdown` — el resultado: total **y desglose**. El desglose no es
   decorativo; cuando el cobro final no coincide con lo estimado (trayecto distinto,
-  espera) hay que poder explicar la diferencia sin recalcular a mano.
+  espera) hay que poder explicar la diferencia sin recalcular a mano. Por eso
+  `ChargeRideAction` lo persiste tal cual en `payments` (historia #26) en vez de
+  descartarlo después de sumarlo: recalcularlo al leer el recibo mostraría un desglose
+  distinto si `config/fares.php` cambió después del cobro.
 - La Action recibe `RouteEstimate` y los segundos de espera. **No conoce HTTP ni el
   modelo `Ride`**, así que sirve igual desde un controller, un job o un test.
 

--- a/app/Actions/Payments/ChargeRideAction.php
+++ b/app/Actions/Payments/ChargeRideAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Payments;
 
+use App\DTOs\FareBreakdown;
 use App\Enums\PaymentStatus;
 use App\Exceptions\PaymentProcessingFailed;
 use App\Models\Payment;
@@ -16,8 +17,9 @@ use Illuminate\Support\Facades\Log;
  * Procesa el cobro de un viaje recién completado (historia #25).
  *
  * La invoca `CompleteRideAction` justo después de persistir `final_fare`: el
- * monto a cobrar sale de ahí, no se recalcula acá. No conoce HTTP ni cómo se
- * llegó al viaje, mismo criterio que el resto de las Actions.
+ * monto a cobrar y su desglose salen de la misma `FareBreakdown` que produjo
+ * ese `final_fare`, no se recalculan acá. No conoce HTTP ni cómo se llegó al
+ * viaje, mismo criterio que el resto de las Actions.
  *
  * Un fallo del proveedor de pago (`PaymentProcessingFailed`) no se deja
  * propagar: se atrapa acá y el pago queda `failed`. Que el cobro no se pueda
@@ -34,7 +36,7 @@ final readonly class ChargeRideAction
      * de `ride_id` en la tabla `payments` respalda esto mismo si dos
      * llamadas llegaran a la vez.
      */
-    public function handle(Ride $ride): Payment
+    public function handle(Ride $ride, FareBreakdown $fare): Payment
     {
         $existing = $ride->payment;
 
@@ -46,8 +48,14 @@ final readonly class ChargeRideAction
 
         $payment = Payment::create([
             'ride_id' => $ride->id,
-            'amount' => $ride->final_fare,
-            'currency' => $ride->currency,
+            'amount' => $fare->total,
+            'currency' => $fare->currency,
+            'base_fare' => $fare->base,
+            'distance_fare' => $fare->distance,
+            'time_fare' => $fare->time,
+            'waiting_fee' => $fare->waiting,
+            'subtotal' => $fare->subtotal,
+            'minimum_applied' => $fare->minimumApplied,
             'status' => $status,
             'processed_at' => $processedAt,
         ]);

--- a/app/Actions/Rides/CompleteRideAction.php
+++ b/app/Actions/Rides/CompleteRideAction.php
@@ -52,10 +52,13 @@ final readonly class CompleteRideAction
         ]);
 
         // El cobro se procesa acá, ya con `final_fare` persistido (historia
-        // #25). Un fallo del proveedor de pago no interrumpe esta Action ni
-        // deja el viaje sin completar: `ChargeRideAction` lo atrapa y
-        // devuelve un `Payment` en `failed`.
-        $this->chargeRide->handle($ride);
+        // #25), pasándole el mismo `$fare` que lo produjo: es el desglose que
+        // `ChargeRideAction` persiste en el pago para el recibo (historia
+        // #26), y recalcularlo ahí duplicaría la fórmula sin necesidad. Un
+        // fallo del proveedor de pago no interrumpe esta Action ni deja el
+        // viaje sin completar: `ChargeRideAction` lo atrapa y devuelve un
+        // `Payment` en `failed`.
+        $this->chargeRide->handle($ride, $fare);
 
         // Cierra el ciclo de vida para el pasajero que sigue el viaje por el
         // canal privado (historia #21).

--- a/app/Http/Controllers/Api/V1/Rides/ShowRideReceiptController.php
+++ b/app/Http/Controllers/Api/V1/Rides/ShowRideReceiptController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\ShowRideReceiptRequest;
+use App\Http\Resources\RideReceiptResource;
+use App\Models\Ride;
+
+/**
+ * GET /api/v1/rides/{ride}/receipt
+ *
+ * Devuelve el desglose del cobro de un viaje completado (historia #26): lo
+ * que el pasajero pagó y por qué concepto.
+ *
+ * No hay Action detrás, mismo criterio que `ShowRideController`: leer un
+ * viaje y su pago ya resueltos no decide ni cambia nada, y envolverlo en una
+ * Action sería un pasamanos. La Policy —`RidePolicy::viewReceipt()`— y que
+ * el viaje tenga recibo disponible los resuelve `ShowRideReceiptRequest`.
+ */
+class ShowRideReceiptController extends Controller
+{
+    public function __invoke(ShowRideReceiptRequest $request, Ride $ride): RideReceiptResource
+    {
+        return new RideReceiptResource($ride->loadMissing('payment'));
+    }
+}

--- a/app/Http/Requests/Rides/ShowRideReceiptRequest.php
+++ b/app/Http/Requests/Rides/ShowRideReceiptRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de GET /api/v1/rides/{ride}/receipt — ver openapi.yaml.
+ */
+class ShowRideReceiptRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `ShowRideRequest`: un id inexistente sale como 404 antes de que se
+     * evalúe `authorize()`. Que un viaje ajeno responda 403 y no 404 es a
+     * propósito, mismo criterio que `ShowRideRequest`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewReceipt', $this->ride()) ?? false;
+    }
+
+    /**
+     * Un GET no trae cuerpo, y el único dato que decide esta operación es el
+     * viaje de la ruta.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectRideWithoutReceipt(...),
+        ];
+    }
+
+    /**
+     * El recibo solo existe una vez que el viaje terminó y se procesó su
+     * cobro: acá no es un problema de permisos —el pasajero sigue siendo el
+     * dueño— sino de que todavía no hay nada que mostrar, por eso es 422 y
+     * no 403 ni 404. Mismo criterio que `rejectRideNotAccepted()` en
+     * `StartRideRequest`, con el error bajo la clave `ride`.
+     */
+    private function rejectRideWithoutReceipt(Validator $validator): void
+    {
+        $ride = $this->ride();
+
+        if ($ride->status !== RideStatus::Completed || $ride->payment === null) {
+            $validator->errors()->add(
+                'ride',
+                'El recibo todavía no está disponible para este viaje.',
+            );
+        }
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Resources/RideReceiptResource.php
+++ b/app/Http/Resources/RideReceiptResource.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Ride;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el recibo de un viaje completado según el schema `RideReceipt` de
+ * openapi.yaml (historia #26).
+ *
+ * A diferencia de `payment` embebido en `RideResource` —que solo publica
+ * `status` porque el monto y la moneda ya están en el viaje que lo
+ * contiene—, acá el recibo es el recurso principal de la respuesta, así que
+ * sí repite `currency` y expone el desglose completo que produjo el cobro.
+ *
+ * @property-read Ride $resource
+ */
+class RideReceiptResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $payment = $this->resource->payment;
+
+        return [
+            'ride_id' => $this->resource->id,
+            'currency' => $payment->currency,
+            'base_fare' => $payment->base_fare,
+            'distance_fare' => $payment->distance_fare,
+            'time_fare' => $payment->time_fare,
+            'waiting_fee' => $payment->waiting_fee,
+            'subtotal' => $payment->subtotal,
+            'minimum_applied' => $payment->minimum_applied,
+            'total' => $payment->amount,
+            'payment_status' => $payment->status->value,
+            'completed_at' => $this->resource->completed_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -16,13 +16,25 @@ use Illuminate\Support\Carbon;
  *
  * Un viaje tiene a lo sumo un pago: `ChargeRideAction` es la única que
  * escribe esta tabla, y lo hace una sola vez por viaje (ver el índice único
- * de `ride_id` en la migración). No tiene Policy propia porque no se expone
- * por ningún endpoint todavía — se consulta a través de `Ride::payment()`,
- * bajo la misma autorización que ya resuelve `RidePolicy` para el viaje.
+ * de `ride_id` en la migración). No tiene Policy propia — se expone a través
+ * del recibo del viaje (`GET /rides/{id}/receipt`, historia #26), bajo la
+ * misma autorización que ya resuelve `RidePolicy` para el viaje.
+ *
+ * `base_fare`, `distance_fare`, `time_fare`, `waiting_fee`, `subtotal` y
+ * `minimum_applied` son la `FareBreakdown` que produjo `amount`, persistida
+ * tal cual la calculó `CalculateFareAction` al completar el viaje: es lo que
+ * el recibo necesita mostrar, y no algo que valga la pena recalcular al leer
+ * (ver la migración que agregó estas columnas).
  *
  * @property int $ride_id
  * @property int $amount
  * @property string $currency
+ * @property int $base_fare
+ * @property int $distance_fare
+ * @property int $time_fare
+ * @property int $waiting_fee
+ * @property int $subtotal
+ * @property bool $minimum_applied
  * @property PaymentStatus $status
  * @property Carbon|null $processed_at
  */
@@ -30,6 +42,12 @@ use Illuminate\Support\Carbon;
     'ride_id',
     'amount',
     'currency',
+    'base_fare',
+    'distance_fare',
+    'time_fare',
+    'waiting_fee',
+    'subtotal',
+    'minimum_applied',
     'status',
     'processed_at',
 ])]
@@ -41,6 +59,12 @@ class Payment extends Model
     {
         return [
             'amount' => 'integer',
+            'base_fare' => 'integer',
+            'distance_fare' => 'integer',
+            'time_fare' => 'integer',
+            'waiting_fee' => 'integer',
+            'subtotal' => 'integer',
+            'minimum_applied' => 'boolean',
             'status' => PaymentStatus::class,
             'processed_at' => 'datetime',
         ];

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -55,6 +55,24 @@ class RidePolicy
     }
 
     /**
+     * Ver el recibo de un viaje es del pasajero **dueño** de ese viaje
+     * (historia #26): es él quien pagó y quien necesita el desglose para
+     * verificar el cobro, no el conductor que lo llevó.
+     *
+     * A diferencia de `view()`, acá el conductor asignado queda afuera a
+     * propósito: el recibo es un documento de lo que se le cobró al
+     * pasajero, no del viaje en sí, y el conductor ya conoce lo que le
+     * corresponde por otra vía. Mismo criterio que `view()` en cuanto a no
+     * comprobar además el rol: esto solo lee lo que esa misma persona ya
+     * pagó, y quitarle el acceso porque después se registró como conductor
+     * sería un efecto secundario que nadie pidió.
+     */
+    public function viewReceipt(User $user, Ride $ride): bool
+    {
+        return $ride->passenger_id === $user->getKey();
+    }
+
+    /**
      * Cancelar un viaje es del pasajero **dueño** de ese viaje (historia #16),
      * o del conductor **asignado** a ese viaje (historia #23) — mismo
      * endpoint, dos operaciones distintas: `CancelRideAction` decide si

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -23,10 +23,22 @@ class PaymentFactory extends Factory
      */
     public function definition(): array
     {
+        $base = 1500;
+        $distance = fake()->numberBetween(10, 200) * 50;
+        $time = fake()->numberBetween(5, 100) * 10;
+        $waiting = 0;
+        $subtotal = $base + $distance + $time + $waiting;
+
         return [
             'ride_id' => Ride::factory(),
-            'amount' => fake()->numberBetween(60, 600) * 50,
+            'amount' => $subtotal,
             'currency' => 'COP',
+            'base_fare' => $base,
+            'distance_fare' => $distance,
+            'time_fare' => $time,
+            'waiting_fee' => $waiting,
+            'subtotal' => $subtotal,
+            'minimum_applied' => false,
             'status' => PaymentStatus::Paid,
             'processed_at' => now(),
         ];

--- a/database/migrations/2026_08_01_134502_add_fare_breakdown_to_payments_table.php
+++ b/database/migrations/2026_08_01_134502_add_fare_breakdown_to_payments_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            // El desglose que produjo `amount` (historia #26): la misma
+            // `FareBreakdown` que ya calculaba `CompleteRideAction` para
+            // `final_fare`, pero hasta ahora se descartaba después de sumarla.
+            // Sin esto, el recibo tendría que recalcularla al leerla, y un
+            // cambio posterior en config/fares.php haría que un viaje viejo
+            // mostrara un desglose que nunca fue el que se cobró — mismo
+            // motivo por el que `estimated_fare` y `final_fare` se guardan en
+            // vez de recalcularse (ver rides).
+            $table->unsignedInteger('base_fare')->after('currency');
+            $table->unsignedInteger('distance_fare')->after('base_fare');
+            $table->unsignedInteger('time_fare')->after('distance_fare');
+            $table->unsignedInteger('waiting_fee')->after('time_fare');
+            $table->unsignedInteger('subtotal')->after('waiting_fee');
+
+            // `true` cuando el subtotal no llegaba al mínimo configurado y el
+            // cobro lo determinó ese piso en vez de la suma de conceptos
+            // (ver `FareBreakdown::$minimumApplied`).
+            $table->boolean('minimum_applied')->after('subtotal');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->dropColumn([
+                'base_fare',
+                'distance_fare',
+                'time_fare',
+                'waiting_fee',
+                'subtotal',
+                'minimum_applied',
+            ]);
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1805,6 +1805,106 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/{id}/receipt:
+    get:
+      tags:
+        - Rides
+      operationId: showRideReceipt
+      summary: Ver el recibo de un viaje completado
+      description: >-
+        Devuelve el desglose del cobro de un viaje completado (historia
+        #26): tarifa base, distancia, tiempo, espera y el monto total, para
+        que el pasajero pueda verificar cuánto se le cobró y por qué
+        concepto.
+
+        Solo el pasajero **dueño** del viaje puede verlo: a diferencia de
+        `GET /rides/{id}`, el conductor asignado también recibe **403** —el
+        recibo es lo que se le cobró al pasajero, no un dato del viaje en
+        sí. Que el viaje no esté `completed`, o que todavía no tenga un
+        pago procesado, es en cambio **422**: el permiso lo tiene, lo que
+        falta es que el ciclo de vida llegue a ese punto.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje completado.
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: El recibo del viaje.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RideReceipt"
+              example:
+                data:
+                  ride_id: 1
+                  currency: COP
+                  base_fare: 1500
+                  distance_fare: 5937
+                  time_fare: 1000
+                  waiting_fee: 0
+                  subtotal: 8437
+                  minimum_applied: false
+                  total: 8450
+                  payment_status: paid
+                  completed_at: "2026-07-31T14:19:05+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El viaje no le pertenece a la cuenta autenticada (incluye al
+            conductor asignado).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "422":
+          description: >-
+            El viaje no está `completed`, o todavía no tiene un pago
+            procesado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: El recibo todavía no está disponible para este viaje.
+                errors:
+                  ride:
+                    - El recibo todavía no está disponible para este viaje.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -2556,6 +2656,90 @@ components:
             - paid
             - failed
           example: paid
+    RideReceipt:
+      type: object
+      description: >-
+        El recibo de un viaje completado (historia #26): el desglose que
+        produjo el cobro publicado en `Ride.payment` / `Ride.final_fare`.
+
+        A diferencia de `Payment` embebido en `Ride`, acá sí repite
+        `currency` y `total`: este objeto es el recurso principal de la
+        respuesta y tiene que bastarse solo, sin depender de que el cliente
+        ya tenga el viaje cargado.
+      required:
+        - ride_id
+        - currency
+        - base_fare
+        - distance_fare
+        - time_fare
+        - waiting_fee
+        - subtotal
+        - minimum_applied
+        - total
+        - payment_status
+        - completed_at
+      properties:
+        ride_id:
+          type: integer
+          description: Identificador del viaje al que pertenece este recibo.
+          example: 1
+        currency:
+          type: string
+          description: Código ISO 4217 de tres letras de la moneda de los montos.
+          example: COP
+        base_fare:
+          type: integer
+          description: >-
+            Lo que cuesta el viaje antes de moverse, entero en la unidad
+            mínima de `currency` (ver config/fares.php).
+          example: 1500
+        distance_fare:
+          type: integer
+          description: Cargo por la distancia realmente recorrida.
+          example: 5937
+        time_fare:
+          type: integer
+          description: Cargo por el tiempo en ruta realmente transcurrido.
+          example: 1000
+        waiting_fee:
+          type: integer
+          description: >-
+            Cargo por espera solicitada por el pasajero con el viaje ya
+            aceptado, fuera de la duración del trayecto. Hoy siempre vale 0:
+            ninguna historia implementada todavía registra tiempo de espera.
+          example: 0
+        subtotal:
+          type: integer
+          description: >-
+            Suma de `base_fare`, `distance_fare`, `time_fare` y
+            `waiting_fee`, antes de aplicar el piso mínimo y el redondeo.
+          example: 8437
+        minimum_applied:
+          type: boolean
+          description: >-
+            `true` cuando `subtotal` no llegaba al mínimo configurado y
+            `total` quedó determinado por ese piso en vez de la suma de
+            conceptos.
+          example: false
+        total:
+          type: integer
+          description: >-
+            Monto cobrado, entero en la unidad mínima de `currency`. Es el
+            mismo valor que `Ride.final_fare` para este viaje.
+          example: 8450
+        payment_status:
+          type: string
+          description: Resultado del cobro, mismo significado que `Payment.status`.
+          enum:
+            - pending
+            - paid
+            - failed
+          example: paid
+        completed_at:
+          type: string
+          format: date-time
+          description: Momento en que el conductor marcó el viaje como completado.
+          example: "2026-07-31T14:19:05+00:00"
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Rides\ShareRideLocationController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideController;
+use App\Http\Controllers\Api\V1\Rides\ShowRideReceiptController;
 use App\Http\Controllers\Api\V1\Rides\StartRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
@@ -183,4 +184,15 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('rides/{ride}/location', ShareRideLocationController::class)
         ->name('rides.location');
+
+    // Recibo del viaje completado (historia #26). Cuelga de `{ride}` como
+    // `show` y `cancel`, y no de `me`: se direcciona por el viaje concreto,
+    // no por la cuenta. A diferencia de `show`, es exclusivo del pasajero
+    // dueño —el conductor no lo ve—, y lo decide `RidePolicy::viewReceipt()`
+    // desde `ShowRideReceiptRequest`. Que el viaje no esté `completed` o
+    // todavía no tenga pago procesado es 422, resuelto en el mismo Form
+    // Request.
+    Route::middleware('auth:api')
+        ->get('rides/{ride}/receipt', ShowRideReceiptController::class)
+        ->name('rides.receipt');
 });

--- a/tests/Feature/Rides/ShowRideReceiptTest.php
+++ b/tests/Feature/Rides/ShowRideReceiptTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Payment;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/rides/{id}/receipt — ver openapi.yaml.
+ *
+ * Historia #26: el pasajero dueño de un viaje completado consulta el
+ * desglose de lo que se le cobró.
+ */
+class ShowRideReceiptTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_dueno_ve_el_recibo_de_su_viaje_completado(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'currency' => 'COP',
+            'final_fare' => 8450,
+            'completed_at' => now(),
+        ]);
+        Payment::factory()->for($viaje)->create([
+            'amount' => 8450,
+            'currency' => 'COP',
+            'base_fare' => 1500,
+            'distance_fare' => 5937,
+            'time_fare' => 1000,
+            'waiting_fee' => 0,
+            'subtotal' => 8437,
+            'minimum_applied' => false,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.ride_id', $viaje->id);
+        $respuesta->assertJsonPath('data.currency', 'COP');
+        $respuesta->assertJsonPath('data.base_fare', 1500);
+        $respuesta->assertJsonPath('data.distance_fare', 5937);
+        $respuesta->assertJsonPath('data.time_fare', 1000);
+        $respuesta->assertJsonPath('data.waiting_fee', 0);
+        $respuesta->assertJsonPath('data.subtotal', 8437);
+        $respuesta->assertJsonPath('data.minimum_applied', false);
+        $respuesta->assertJsonPath('data.total', 8450);
+        $respuesta->assertJsonPath('data.payment_status', 'paid');
+        $this->assertNotNull($respuesta->json('data.completed_at'));
+    }
+
+    public function test_rechaza_un_viaje_que_no_pertenece_al_pasajero_autenticado(): void
+    {
+        $dueno = User::factory()->create();
+        $otroPasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($dueno, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'final_fare' => 8450,
+            'completed_at' => now(),
+        ]);
+        Payment::factory()->for($viaje)->create();
+
+        $this->withToken(JWTAuth::fromUser($otroPasajero))
+            ->getJson($this->uri($viaje))
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_al_conductor_asignado(): void
+    {
+        // El recibo es del pasajero que pagó, no del conductor que llevó el
+        // viaje (historia #26): a diferencia de `ShowRideController`, acá el
+        // conductor asignado tampoco puede verlo.
+        $pasajero = User::factory()->create();
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'final_fare' => 8450,
+            'completed_at' => now(),
+        ]);
+        Payment::factory()->for($viaje)->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson($this->uri($viaje))
+            ->assertForbidden();
+    }
+
+    #[DataProvider('estadosSinRecibo')]
+    public function test_rechaza_un_viaje_que_no_esta_completado(RideStatus $estado): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => $estado,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+    }
+
+    public function test_rechaza_un_viaje_completado_sin_pago_registrado(): void
+    {
+        // No debería ocurrir en producción —`CompleteRideAction` siempre
+        // dispara el cobro—, pero el Form Request no asume que `payment`
+        // exista solo porque el estado es `completed`.
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'final_fare' => 8450,
+            'completed_at' => now(),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson($this->uri($viaje))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson('/api/v1/rides/999999/receipt')
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'final_fare' => 8450,
+            'completed_at' => now(),
+        ]);
+        Payment::factory()->for($viaje)->create();
+
+        $this->getJson($this->uri($viaje))
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/receipt";
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosSinRecibo(): array
+    {
+        return [
+            RideStatus::Requested->value => [RideStatus::Requested],
+            RideStatus::Accepted->value => [RideStatus::Accepted],
+            RideStatus::InProgress->value => [RideStatus::InProgress],
+            RideStatus::Cancelled->value => [RideStatus::Cancelled],
+        ];
+    }
+}

--- a/tests/Unit/Actions/Payments/ChargeRideActionTest.php
+++ b/tests/Unit/Actions/Payments/ChargeRideActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions\Payments;
 
 use App\Actions\Payments\ChargeRideAction;
+use App\DTOs\FareBreakdown;
 use App\Enums\PaymentStatus;
 use App\Enums\RideStatus;
 use App\Exceptions\PaymentProcessingFailed;
@@ -21,15 +22,22 @@ class ChargeRideActionTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_crea_un_pago_pagado_con_el_monto_y_la_moneda_del_viaje(): void
+    public function test_crea_un_pago_pagado_con_el_monto_el_desglose_y_la_moneda_del_viaje(): void
     {
         $viaje = $this->viajeCompletado(montoFinal: 8450, moneda: 'COP');
+        $desglose = $this->desglose(moneda: 'COP', total: 8450);
 
-        $pago = $this->action()->handle($viaje);
+        $pago = $this->action()->handle($viaje, $desglose);
 
         $this->assertSame($viaje->id, $pago->ride_id);
         $this->assertSame(8450, $pago->amount);
         $this->assertSame('COP', $pago->currency);
+        $this->assertSame($desglose->base, $pago->base_fare);
+        $this->assertSame($desglose->distance, $pago->distance_fare);
+        $this->assertSame($desglose->time, $pago->time_fare);
+        $this->assertSame($desglose->waiting, $pago->waiting_fee);
+        $this->assertSame($desglose->subtotal, $pago->subtotal);
+        $this->assertSame($desglose->minimumApplied, $pago->minimum_applied);
         $this->assertSame(PaymentStatus::Paid, $pago->status);
         $this->assertNotNull($pago->processed_at);
         $this->assertDatabaseCount('payments', 1);
@@ -48,7 +56,7 @@ class ChargeRideActionTest extends TestCase
         };
         $this->app->instance(PaymentGateway::class, $gateway);
 
-        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje);
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje, $this->desglose());
 
         $this->assertSame(PaymentStatus::Failed, $pago->status);
         $this->assertNull($pago->processed_at);
@@ -70,7 +78,7 @@ class ChargeRideActionTest extends TestCase
         };
         $this->app->instance(PaymentGateway::class, $gateway);
 
-        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje);
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje, $this->desglose());
 
         $this->assertInstanceOf(Payment::class, $pago);
     }
@@ -91,7 +99,7 @@ class ChargeRideActionTest extends TestCase
         };
         $this->app->instance(PaymentGateway::class, $gateway);
 
-        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje->refresh());
+        $pago = $this->app->make(ChargeRideAction::class)->handle($viaje->refresh(), $this->desglose());
 
         $this->assertFalse($gateway->llamado);
         $this->assertSame($pagoExistente->id, $pago->id);
@@ -117,5 +125,19 @@ class ChargeRideActionTest extends TestCase
             'started_at' => now(),
             'completed_at' => now(),
         ]);
+    }
+
+    private function desglose(string $moneda = 'COP', int $total = 8450): FareBreakdown
+    {
+        return new FareBreakdown(
+            currency: $moneda,
+            base: 1500,
+            distance: 5937,
+            time: 1000,
+            waiting: 0,
+            subtotal: 8437,
+            total: $total,
+            minimumApplied: false,
+        );
     }
 }


### PR DESCRIPTION
Closes #26

## Qué hace

Agrega `GET /api/v1/rides/{id}/receipt`: el pasajero dueño de un viaje
`completed` consulta el desglose de lo que se le cobró (tarifa base,
distancia, tiempo, espera, subtotal, si se aplicó el mínimo, y el
total), más el estado del cobro y cuándo se completó el viaje.

- `RidePolicy::viewReceipt()` — solo el pasajero dueño; a diferencia
  de `view()`, el conductor asignado también recibe 403, porque el
  recibo es lo que se le cobró al pasajero, no un dato del viaje en
  sí.
- `ShowRideReceiptRequest` — 422 (`errors.ride`) si el viaje no está
  `completed` o todavía no tiene un pago registrado.
- `RideReceiptResource` / `ShowRideReceiptController` — sin Action
  detrás, mismo criterio que `ShowRideController`: es una lectura que
  no decide ni cambia nada.

El desglose (`FareBreakdown`) que calcula `CalculateFareAction` no se
persistía: `CompleteRideAction` lo usaba solo para escribir
`final_fare` y lo descartaba. Para no recalcularlo al leer el
recibo —lo que daría un resultado distinto si `config/fares.php`
cambió después del cobro—, `ChargeRideAction` ahora recibe la misma
`FareBreakdown` que produjo el total y la persiste en `payments`
(columnas nuevas: `base_fare`, `distance_fare`, `time_fare`,
`waiting_fee`, `subtotal`, `minimum_applied`, migración
`2026_08_01_134502_add_fare_breakdown_to_payments_table`).

Documentado en `openapi.yaml` (endpoint + schema `RideReceipt`) y en
`.claude/STANDARDS.md` (sección "Cálculo de tarifas").

## Cómo se probó

- `tests/Feature/Rides/ShowRideReceiptTest.php`: éxito con desglose
  completo, 403 para un pasajero ajeno, 403 para el conductor
  asignado, 422 por cada estado no completado (requested, accepted,
  in_progress, cancelled), 422 si el viaje está completado pero sin
  pago, 404 sin viaje, 401 sin token.
- `tests/Unit/Actions/Payments/ChargeRideActionTest.php` actualizado
  a la nueva firma de `ChargeRideAction::handle()`, verificando que
  el desglose persistido coincide con la `FareBreakdown` recibida.
- Suite completa: `php artisan test` → 571/571 en verde.
- `./vendor/bin/pint --test` sin errores.
- `phpstan analyse` (Larastan) sin errores.

## Decisiones y riesgos

- El recibo excluye al conductor a propósito (ver arriba); si el
  producto quiere que el conductor también vea su parte del cobro,
  eso es una historia aparte con su propia forma de negocio, no una
  extensión de este endpoint.
- No agrego `status`/`amount` genéricos redundantes en la respuesta:
  `total` y `payment_status` cubren lo que pide el criterio de
  aceptación (desglose + verificación del cobro).
- Fuera de alcance (declarado en el issue): envío del recibo por
  email o generación de PDF.