### PR TITLE
feat(#27): calificar al conductor al finalizar el viaje

### DIFF
--- a/app/Actions/Rides/RateDriverAction.php
+++ b/app/Actions/Rides/RateDriverAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Rides;
+
+use App\Enums\RatedRole;
+use App\Models\Ride;
+use App\Models\RideRating;
+
+/**
+ * Registra la calificación que el pasajero da al conductor de un viaje ya
+ * completado (historia #27).
+ *
+ * El viaje llega resuelto y validado: que sea del pasajero autenticado lo
+ * garantiza `RidePolicy::rateDriver()` y que esté `completed` sin
+ * calificación previa lo garantiza `RateDriverRequest`, mismo reparto que en
+ * `CompleteRideAction`.
+ */
+final readonly class RateDriverAction
+{
+    public function handle(Ride $ride, int $score, ?string $comment): RideRating
+    {
+        return $ride->driverRating()->create([
+            'rated_role' => RatedRole::Driver,
+            'score' => $score,
+            'comment' => $comment,
+        ]);
+    }
+}

--- a/app/Enums/RatedRole.php
+++ b/app/Enums/RatedRole.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * A quién califica una fila de `ride_ratings`: al conductor (historia #27) o
+ * al pasajero (historia #28) de ese mismo viaje.
+ *
+ * Los valores viajan tal cual a `ride_ratings.rated_role`. Junto con
+ * `ride_id`, sostienen el índice único que impide que la misma dirección se
+ * registre dos veces para un viaje (ver la migración).
+ */
+enum RatedRole: string
+{
+    case Driver = 'driver';
+    case Passenger = 'passenger';
+}

--- a/app/Http/Controllers/Api/V1/Rides/RateDriverController.php
+++ b/app/Http/Controllers/Api/V1/Rides/RateDriverController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Actions\Rides\RateDriverAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\RateDriverRequest;
+use App\Http\Resources\RideRatingResource;
+use App\Models\Ride;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/rides/{ride}/rate-driver
+ *
+ * Registra la calificación del pasajero al conductor de un viaje completado
+ * (historia #27). Que el pasajero autenticado sea el dueño del viaje lo
+ * resuelve `RidePolicy::rateDriver()` desde `RateDriverRequest`, y que el
+ * viaje esté `completed` sin calificación previa, el propio Form Request.
+ */
+class RateDriverController extends Controller
+{
+    public function __invoke(
+        RateDriverRequest $request,
+        RateDriverAction $rateDriver,
+        Ride $ride,
+    ): JsonResponse {
+        $rating = $rateDriver->handle($ride, $request->score(), $request->comment());
+
+        return (new RideRatingResource($rating))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Rides/RateDriverRequest.php
+++ b/app/Http/Requests/Rides/RateDriverRequest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/rides/{ride}/rate-driver — ver openapi.yaml.
+ */
+class RateDriverRequest extends FormRequest
+{
+    /**
+     * El viaje llega resuelto por el binding implícito de la ruta, igual que
+     * en `CompleteRideRequest`: un id inexistente sale como 404 antes de que
+     * se evalúe `authorize()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('rateDriver', $this->ride()) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'score' => ['required', 'integer', 'between:1,5'],
+            'comment' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectRideNotCompleted(...),
+            $this->rejectRideAlreadyRated(...),
+        ];
+    }
+
+    /**
+     * Que el viaje no esté `completed` no es un problema de permisos —el
+     * pasajero sigue siendo el dueño— sino de en qué punto del ciclo de vida
+     * está: por eso es 422 y no 403, mismo criterio que
+     * `rejectRideNotInProgress()` en `CompleteRideRequest`.
+     */
+    private function rejectRideNotCompleted(Validator $validator): void
+    {
+        if ($this->ride()->status !== RideStatus::Completed) {
+            $validator->errors()->add(
+                'ride',
+                'Solo se puede calificar al conductor de un viaje completado.',
+            );
+        }
+    }
+
+    /**
+     * Una sola calificación del conductor por viaje (historia #27, criterio
+     * de aceptación #2). El índice único de `ride_ratings` respalda esto
+     * mismo a nivel de base si dos llamadas llegaran a la vez.
+     */
+    private function rejectRideAlreadyRated(Validator $validator): void
+    {
+        if ($this->ride()->driverRating !== null) {
+            $validator->errors()->add(
+                'ride',
+                'Ya existe una calificación del conductor para este viaje.',
+            );
+        }
+    }
+
+    public function score(): int
+    {
+        return $this->integer('score');
+    }
+
+    public function comment(): ?string
+    {
+        return $this->string('comment')->value() ?: null;
+    }
+
+    public function ride(): Ride
+    {
+        /** @var Ride */
+        return $this->route('ride');
+    }
+}

--- a/app/Http/Resources/RideRatingResource.php
+++ b/app/Http/Resources/RideRatingResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\RideRating;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa la calificación de un viaje según el schema `RideRating` de
+ * openapi.yaml (historia #27).
+ *
+ * @property-read RideRating $resource
+ */
+class RideRatingResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'ride_id' => $this->resource->ride_id,
+            'score' => $this->resource->score,
+            'comment' => $this->resource->comment,
+            'rated_at' => $this->resource->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Ride.php
+++ b/app/Models/Ride.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\RatedRole;
 use App\Enums\RideStatus;
 use App\Policies\RidePolicy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -112,5 +113,16 @@ class Ride extends Model
     public function payment(): HasOne
     {
         return $this->hasOne(Payment::class);
+    }
+
+    /**
+     * La calificación que el pasajero dio al conductor, o `null` mientras no
+     * la haya registrado (historia #27).
+     *
+     * @return HasOne<RideRating, $this>
+     */
+    public function driverRating(): HasOne
+    {
+        return $this->hasOne(RideRating::class)->where('rated_role', RatedRole::Driver);
     }
 }

--- a/app/Models/RideRating.php
+++ b/app/Models/RideRating.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\RatedRole;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * La calificación de una de las dos partes de un viaje completado, dada por
+ * la otra: al conductor (historia #27) o al pasajero (historia #28).
+ *
+ * A lo sumo una fila por `ride_id` y `rated_role` (ver el índice único de la
+ * migración): quién calificó y a quién se deducen del viaje —`passenger_id`
+ * y `driver_id`— y no se repiten acá.
+ *
+ * @property int $ride_id
+ * @property RatedRole $rated_role
+ * @property int $score
+ * @property string|null $comment
+ */
+#[Fillable(['ride_id', 'rated_role', 'score', 'comment'])]
+class RideRating extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'rated_role' => RatedRole::class,
+            'score' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Ride, $this>
+     */
+    public function ride(): BelongsTo
+    {
+        return $this->belongsTo(Ride::class);
+    }
+}

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -166,4 +166,21 @@ class RidePolicy
             && $ride->driver_id !== null
             && $ride->driver_id === $user->getKey();
     }
+
+    /**
+     * Calificar al conductor es del pasajero **dueño** de ese viaje (historia
+     * #27), mismo criterio que `cancel()`: se comprueba el rol además de la
+     * propiedad, porque nada impide que una fila apunte a una cuenta que dejó
+     * de ser pasajero.
+     *
+     * Que el viaje no esté `completed`, o que el pasajero ya lo haya
+     * calificado, no se decide acá: eso es 422 y lo resuelve
+     * `RateDriverRequest`, porque el permiso de calificar lo tiene y lo que
+     * falla es el momento del ciclo de vida o que ya no queda nada por
+     * registrar.
+     */
+    public function rateDriver(User $user, Ride $ride): bool
+    {
+        return $user->isPassenger() && $ride->passenger_id === $user->getKey();
+    }
 }

--- a/database/factories/RideRatingFactory.php
+++ b/database/factories/RideRatingFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\RatedRole;
+use App\Models\Ride;
+use App\Models\RideRating;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RideRating>
+ */
+class RideRatingFactory extends Factory
+{
+    /**
+     * Por defecto la calificación del conductor (historia #27), que es la
+     * única dirección que produce hoy algún flujo de la API.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'ride_id' => Ride::factory(),
+            'rated_role' => RatedRole::Driver,
+            'score' => fake()->numberBetween(1, 5),
+            'comment' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_01_150000_create_ride_ratings_table.php
+++ b/database/migrations/2026_08_01_150000_create_ride_ratings_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ride_ratings', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('ride_id')->constrained('rides')->cascadeOnDelete();
+
+            // `driver` (historia #27) o `passenger` (historia #28): a quién
+            // califica esta fila, no quién la escribió. `unique()` junto con
+            // `ride_id` respalda a nivel de base la misma regla que el Form
+            // Request ya valida antes de escribir —una sola calificación por
+            // dirección y viaje—, mismo criterio que `ride_id` en `payments`.
+            $table->string('rated_role', 20);
+
+            $table->unsignedTinyInteger('score');
+            $table->text('comment')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['ride_id', 'rated_role']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ride_ratings');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1905,6 +1905,124 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /rides/{id}/rate-driver:
+    post:
+      tags:
+        - Rides
+      operationId: rateDriver
+      summary: Calificar al conductor al finalizar el viaje
+      description: >-
+        Registra la calificación que el pasajero da al conductor de un viaje
+        ya completado (historia #27): una puntuación de 1 a 5 y un comentario
+        opcional, asociados al viaje y al conductor asignado.
+
+        Solo el pasajero **dueño** del viaje puede calificarlo: cualquier
+        otra cuenta —el conductor asignado u otro pasajero— recibe **403**.
+        Que el viaje no esté `completed`, o que el pasajero ya lo haya
+        calificado antes, es en cambio **422**: el permiso lo tiene, lo que
+        falla es el momento del ciclo de vida o que ya no queda nada por
+        registrar.
+
+        No calcula ni expone el promedio de calificación del conductor; eso
+        se cubre en una historia aparte.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador del viaje completado a calificar.
+          schema:
+            type: integer
+          example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - score
+              properties:
+                score:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                  description: Puntuación de 1 (peor) a 5 (mejor).
+                  example: 5
+                comment:
+                  type: string
+                  nullable: true
+                  description: Comentario libre y opcional sobre el servicio.
+                  example: Muy puntual y buen trato.
+            example:
+              score: 5
+              comment: Muy puntual y buen trato.
+      responses:
+        "201":
+          description: La calificación quedó registrada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RideRating"
+              example:
+                data:
+                  ride_id: 1
+                  score: 5
+                  comment: Muy puntual y buen trato.
+                  rated_at: "2026-07-31T14:20:05+00:00"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            El viaje no le pertenece a la cuenta autenticada (incluye al
+            conductor asignado).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe ningún viaje con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "No query results for model [App\\Models\\Ride] 1."
+        "422":
+          description: >-
+            El viaje no está `completed`, la puntuación está fuera de 1 a 5,
+            o el pasajero ya calificó a este conductor por este viaje.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Ya existe una calificación del conductor para este viaje.
+                errors:
+                  ride:
+                    - Ya existe una calificación del conductor para este viaje.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
 components:
   securitySchemes:
     bearerAuth:
@@ -2740,6 +2858,37 @@ components:
           format: date-time
           description: Momento en que el conductor marcó el viaje como completado.
           example: "2026-07-31T14:19:05+00:00"
+    RideRating:
+      type: object
+      description: >-
+        La calificación que el pasajero da al conductor de un viaje ya
+        completado (historia #27). Se basta sola, sin depender de que el
+        cliente ya tenga el viaje cargado, mismo criterio que `RideReceipt`.
+      required:
+        - ride_id
+        - score
+        - rated_at
+      properties:
+        ride_id:
+          type: integer
+          description: Identificador del viaje al que pertenece esta calificación.
+          example: 1
+        score:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: Puntuación de 1 (peor) a 5 (mejor) que dio el pasajero.
+          example: 5
+        comment:
+          type: string
+          nullable: true
+          description: Comentario libre que dejó el pasajero, o `null` si no dejó ninguno.
+          example: Muy puntual y buen trato.
+        rated_at:
+          type: string
+          format: date-time
+          description: Momento en que se registró la calificación.
+          example: "2026-07-31T14:20:05+00:00"
     BroadcastAuthRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CompleteRideController;
 use App\Http\Controllers\Api\V1\Rides\CreateRideController;
 use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
+use App\Http\Controllers\Api\V1\Rides\RateDriverController;
 use App\Http\Controllers\Api\V1\Rides\ShareRideLocationController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideReceiptController;
@@ -195,4 +196,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->get('rides/{ride}/receipt', ShowRideReceiptController::class)
         ->name('rides.receipt');
+
+    // Calificar al conductor de un viaje completado (historia #27). Cuelga
+    // de `{ride}` como el recibo, y no de `me`: se direcciona por el viaje
+    // concreto. Es exclusivo del pasajero dueño —el conductor no se
+    // autocalifica—, y lo decide `RidePolicy::rateDriver()` desde
+    // `RateDriverRequest`. Que el viaje no esté `completed`, o que ya tenga
+    // calificación, es 422, resuelto en el mismo Form Request.
+    Route::middleware('auth:api')
+        ->post('rides/{ride}/rate-driver', RateDriverController::class)
+        ->name('rides.rate-driver');
 });

--- a/tests/Feature/Rides/RateDriverTest.php
+++ b/tests/Feature/Rides/RateDriverTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RatedRole;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\RideRating;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/rides/{id}/rate-driver — ver openapi.yaml.
+ *
+ * Historia #27: el pasajero dueño de un viaje completado califica al
+ * conductor asignado con una puntuación de 1 a 5 y un comentario opcional.
+ */
+class RateDriverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_dueno_califica_al_conductor_de_su_viaje_completado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), [
+                'score' => 5,
+                'comment' => 'Muy puntual y buen trato.',
+            ])
+            ->assertCreated();
+
+        $respuesta->assertJsonPath('data.ride_id', $viaje->id);
+        $respuesta->assertJsonPath('data.score', 5);
+        $respuesta->assertJsonPath('data.comment', 'Muy puntual y buen trato.');
+        $this->assertNotNull($respuesta->json('data.rated_at'));
+
+        $this->assertDatabaseHas('ride_ratings', [
+            'ride_id' => $viaje->id,
+            'rated_role' => RatedRole::Driver->value,
+            'score' => 5,
+            'comment' => 'Muy puntual y buen trato.',
+        ]);
+    }
+
+    public function test_el_comentario_es_opcional(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), ['score' => 4])
+            ->assertCreated();
+
+        $respuesta->assertJsonPath('data.comment', null);
+        $this->assertDatabaseHas('ride_ratings', [
+            'ride_id' => $viaje->id,
+            'score' => 4,
+            'comment' => null,
+        ]);
+    }
+
+    public function test_rechaza_una_puntuacion_fuera_de_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), ['score' => 6])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('score');
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), ['score' => 0])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('score');
+
+        $this->assertDatabaseMissing('ride_ratings', ['ride_id' => $viaje->id]);
+    }
+
+    public function test_rechaza_una_segunda_calificacion_del_mismo_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+        RideRating::factory()->for($viaje)->create(['rated_role' => RatedRole::Driver]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), ['score' => 3])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertSame(1, RideRating::query()->where('ride_id', $viaje->id)->count());
+    }
+
+    #[DataProvider('estadosSinCalificacion')]
+    public function test_rechaza_un_viaje_que_no_esta_completado(RideStatus $estado): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => $estado,
+            'driver_id' => $conductor->id,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson($this->uri($viaje), ['score' => 5])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ride');
+
+        $this->assertDatabaseMissing('ride_ratings', ['ride_id' => $viaje->id]);
+    }
+
+    public function test_rechaza_a_un_pasajero_que_no_es_dueno_del_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $dueno = User::factory()->create();
+        $otroPasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($dueno, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($otroPasajero))
+            ->postJson($this->uri($viaje), ['score' => 5])
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseMissing('ride_ratings', ['ride_id' => $viaje->id]);
+    }
+
+    public function test_rechaza_al_conductor_asignado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson($this->uri($viaje), ['score' => 5])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('ride_ratings', ['ride_id' => $viaje->id]);
+    }
+
+    public function test_responde_404_cuando_el_viaje_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson('/api/v1/rides/999999/rate-driver', ['score' => 5])
+            ->assertNotFound();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => $conductor->id,
+            'completed_at' => now(),
+        ]);
+
+        $this->postJson($this->uri($viaje), ['score' => 5])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+
+        $this->assertDatabaseMissing('ride_ratings', ['ride_id' => $viaje->id]);
+    }
+
+    private function uri(Ride $viaje): string
+    {
+        return "/api/v1/rides/{$viaje->id}/rate-driver";
+    }
+
+    /**
+     * @return array<string, array{RideStatus}>
+     */
+    public static function estadosSinCalificacion(): array
+    {
+        return [
+            RideStatus::Requested->value => [RideStatus::Requested],
+            RideStatus::Accepted->value => [RideStatus::Accepted],
+            RideStatus::InProgress->value => [RideStatus::InProgress],
+            RideStatus::Cancelled->value => [RideStatus::Cancelled],
+        ];
+    }
+}

--- a/tests/Unit/Actions/Rides/RateDriverActionTest.php
+++ b/tests/Unit/Actions/Rides/RateDriverActionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Rides;
+
+use App\Actions\Rides\RateDriverAction;
+use App\Enums\RatedRole;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ */
+class RateDriverActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registra_la_calificacion_asociada_al_viaje(): void
+    {
+        $viaje = $this->viajeCompletado();
+
+        $rating = $this->app->make(RateDriverAction::class)->handle($viaje, 5, 'Excelente servicio.');
+
+        $this->assertSame($viaje->id, $rating->ride_id);
+        $this->assertSame(RatedRole::Driver, $rating->rated_role);
+        $this->assertSame(5, $rating->score);
+        $this->assertSame('Excelente servicio.', $rating->comment);
+    }
+
+    public function test_el_comentario_puede_quedar_en_null(): void
+    {
+        $viaje = $this->viajeCompletado();
+
+        $rating = $this->app->make(RateDriverAction::class)->handle($viaje, 3, null);
+
+        $this->assertNull($rating->comment);
+    }
+
+    public function test_persiste_la_fila_en_la_base(): void
+    {
+        $viaje = $this->viajeCompletado();
+
+        $rating = $this->app->make(RateDriverAction::class)->handle($viaje, 4, null);
+
+        $this->assertDatabaseHas('ride_ratings', [
+            'id' => $rating->id,
+            'ride_id' => $viaje->id,
+            'rated_role' => RatedRole::Driver->value,
+            'score' => 4,
+        ]);
+    }
+
+    private function viajeCompletado(): Ride
+    {
+        return Ride::factory()->create([
+            'status' => RideStatus::Completed,
+            'driver_id' => User::factory()->driver(),
+            'completed_at' => now(),
+        ]);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -191,4 +191,38 @@ class RidePolicyTest extends TestCase
 
         $this->assertTrue($pasajero->fresh()->can('view', $viaje));
     }
+
+    public function test_el_pasajero_dueno_puede_calificar_al_conductor_de_su_viaje(): void
+    {
+        $pasajero = User::factory()->create();
+        $viaje = Ride::factory()->for($pasajero, 'passenger')->create();
+
+        $this->assertTrue($pasajero->can('rateDriver', $viaje));
+    }
+
+    public function test_otro_pasajero_no_puede_calificar_un_viaje_ajeno(): void
+    {
+        $viaje = Ride::factory()->create();
+
+        $this->assertFalse(User::factory()->create()->can('rateDriver', $viaje));
+    }
+
+    public function test_el_conductor_asignado_no_puede_calificarse_a_si_mismo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create(['driver_id' => $conductor->id]);
+
+        $this->assertFalse($conductor->can('rateDriver', $viaje));
+    }
+
+    public function test_un_conductor_no_puede_calificar_aunque_la_fila_apunte_a_su_cuenta_como_pasajero(): void
+    {
+        // Mismo criterio que `cancel()`: el rol se comprueba además de la
+        // propiedad, porque nada impide que una fila apunte a una cuenta que
+        // dejó de ser pasajero.
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->for($conductor, 'passenger')->create();
+
+        $this->assertFalse($conductor->can('rateDriver', $viaje));
+    }
 }


### PR DESCRIPTION
Closes #27

## Qué hace

Permite que el pasajero dueño de un viaje ya `completed` califique al
conductor asignado con `POST /api/v1/rides/{id}/rate-driver`: una puntuación
de 1 a 5 y un comentario opcional.

- `RateDriverAction` registra la calificación asociada al viaje, vía la
  nueva relación `Ride::driverRating()`.
- `RideRating` (tabla `ride_ratings`) guarda `rated_role` (`driver` /
  `passenger`, enum `RatedRole`) junto a `ride_id`, con índice único sobre
  ambas columnas — deja preparado el mismo modelo para calificar al
  pasajero (historia #28, fuera de alcance acá).
- `RidePolicy::rateDriver()` exige que el pasajero autenticado sea el dueño
  del viaje (403 en cualquier otro caso, incluido el conductor asignado).
- `RateDriverRequest` valida `score` (1-5, requerido) y `comment` (opcional,
  máx. 1000), y rechaza con 422 si el viaje no está `completed` o si ya
  tiene una calificación del conductor — mismo criterio de "momento del
  ciclo de vida, no permisos" que el resto de endpoints de `rides`.
- `RideRatingResource` serializa `ride_id`, `score`, `comment`, `rated_at`.
- `openapi.yaml` documenta el endpoint y el schema `RideRating`.

## Cómo se probó

- `php artisan test`: 590/590 tests en verde (incluye 9 casos nuevos en
  `RateDriverTest` cubriendo los 3 criterios de aceptación del issue —
  registro exitoso, comentario opcional, doble calificación, rango de
  puntuación, viaje no completado en cada estado no terminal, dueño
  incorrecto, conductor autocalificándose, viaje inexistente, sin token — más
  3 en `RateDriverActionTest` y 4 en `RidePolicyTest`).
- `vendor/bin/pint --test`: sin errores.
- `composer stan` (PHPStan/Larastan): sin errores.

No pude correr localmente los checks de arquitectura/seguridad/conformidad
de openapi.yaml basados en Python (`.claude/skills/*/scripts/*.py`) porque
este entorno no tiene Python instalado; quedan a cargo del pipeline de CI.

## Decisiones y riesgos

- El cálculo/exposición del promedio de calificación del conductor queda
  fuera de alcance (lo dice el propio issue #27); `RideRating` ya deja la
  fila lista para que esa historia solo tenga que agregarla.
- `driverRating()` en `Ride` filtra por `rated_role = driver` en vez de
  exponer una relación genérica a todas las calificaciones del viaje,
  porque hoy solo existe esa dirección; se puede añadir `passengerRating()`
  análoga cuando se implemente la historia #28.