### PR TITLE
feat(#29): ver historial de viajes (pasajero)

### DIFF
--- a/app/Http/Controllers/Api/V1/Rides/ShowRideHistoryController.php
+++ b/app/Http/Controllers/Api/V1/Rides/ShowRideHistoryController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Rides;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Rides\ShowRideHistoryRequest;
+use App\Http\Resources\RideResource;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * GET /api/v1/me/rides
+ *
+ * Devuelve los viajes del pasajero autenticado, del más reciente al más
+ * antiguo (historia #29). Es la vista con la que consulta y audita sus
+ * viajes pasados; no trae filtros por fecha o estado, eso queda para una
+ * historia aparte.
+ *
+ * No hay Action detrás, mismo criterio que `ShowRideController`: leer los
+ * viajes ya acotados a la cuenta del token no decide ni cambia nada. Sí hay
+ * Policy, a diferencia de `ShowProfileController` —acá el rol sí importa,
+ * porque el mismo path va a servir el historial de ganancias del conductor
+ * (historia #30)— y la resuelve `RidePolicy::viewHistory()` desde
+ * `ShowRideHistoryRequest`.
+ */
+class ShowRideHistoryController extends Controller
+{
+    /**
+     * Tope de `per_page` aunque el cliente pida más: es el límite razonable
+     * que el criterio de aceptación de la #29 deja a criterio del backend.
+     */
+    private const int MAX_PER_PAGE = 50;
+
+    private const int DEFAULT_PER_PAGE = 15;
+
+    public function __invoke(ShowRideHistoryRequest $request): AnonymousResourceCollection
+    {
+        $perPage = min(
+            $request->integer('per_page', self::DEFAULT_PER_PAGE),
+            self::MAX_PER_PAGE,
+        );
+
+        $viajes = $request->user()
+            ->rides()
+            ->with('driver')
+            ->latest()
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return RideResource::collection($viajes);
+    }
+}

--- a/app/Http/Requests/Rides/ShowRideHistoryRequest.php
+++ b/app/Http/Requests/Rides/ShowRideHistoryRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Rides;
+
+use App\Models\Ride;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de GET /api/v1/me/rides — ver openapi.yaml.
+ */
+class ShowRideHistoryRequest extends FormRequest
+{
+    /**
+     * Autorización por clase y no por instancia: no hay un viaje concreto que
+     * resolver acá, la consulta siempre está acotada a la cuenta del token
+     * (historia #29). Lo decide `RidePolicy::viewHistory()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewHistory', Ride::class) ?? false;
+    }
+
+    /**
+     * `per_page` no lleva `max` a propósito: superarlo no es una entrada
+     * inválida, el backend lo acota a un límite razonable en vez de
+     * responder 422 (ver `ShowRideHistoryController`).
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -52,6 +53,19 @@ class User extends Authenticatable implements JWTSubject
     public function vehicle(): HasOne
     {
         return $this->hasOne(Vehicle::class);
+    }
+
+    /**
+     * Los viajes pedidos por esta cuenta como pasajero (historia #29). No
+     * se llama `passengerRides` a propósito: del lado del conductor asignado
+     * ningún endpoint necesita hoy la relación inversa por `driver_id`, así
+     * que un solo nombre corto alcanza sin volverse ambiguo.
+     *
+     * @return HasMany<Ride, $this>
+     */
+    public function rides(): HasMany
+    {
+        return $this->hasMany(Ride::class, 'passenger_id');
     }
 
     public function isDriver(): bool

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -183,4 +183,16 @@ class RidePolicy
     {
         return $user->isPassenger() && $ride->passenger_id === $user->getKey();
     }
+
+    /**
+     * Ver el propio historial de viajes es del rol pasajero (historia #29),
+     * mismo criterio que `create()`: no depende de una fila concreta porque
+     * la consulta ya viene acotada a la cuenta autenticada, así que no existe
+     * la pregunta "¿de quién es este viaje?" que sí resuelven `view()` o
+     * `cancel()`.
+     */
+    public function viewHistory(User $user): bool
+    {
+        return $user->isPassenger();
+    }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -914,6 +914,152 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me/rides:
+    get:
+      tags:
+        - Rides
+      operationId: listMyRides
+      summary: Ver el historial de viajes propios
+      description: >-
+        Devuelve los viajes del pasajero autenticado, ordenados del más
+        reciente al más antiguo (historia #29). Es la vista con la que el
+        pasajero consulta y audita sus viajes pasados; no trae filtros por
+        fecha o estado ni exportación — se evalúan como historias aparte.
+
+        Una cuenta sin viajes previos recibe **200** con `data` en una lista
+        vacía, no un error.
+
+        `page` y `per_page` son opcionales y aceptan cualquier entero
+        positivo; superar el límite razonable de `per_page` que define el
+        backend no responde 422, la respuesta simplemente se acota a ese
+        límite.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Página a consultar. Por defecto, la primera.
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+        - name: per_page
+          in: query
+          required: false
+          description: >-
+            Cantidad de viajes por página. Por defecto 15; el backend acota
+            cualquier valor mayor a un límite razonable en vez de rechazarlo.
+          schema:
+            type: integer
+            minimum: 1
+          example: 15
+      responses:
+        "200":
+          description: Página del historial de viajes del pasajero.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - meta
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Ride"
+                  meta:
+                    type: object
+                    description: >-
+                      Metadatos de paginación (formato estándar del
+                      paginador de Laravel).
+                    required:
+                      - current_page
+                      - per_page
+                      - total
+                      - last_page
+                    properties:
+                      current_page:
+                        type: integer
+                        example: 1
+                      per_page:
+                        type: integer
+                        example: 15
+                      total:
+                        type: integer
+                        example: 1
+                      last_page:
+                        type: integer
+                        example: 1
+              example:
+                data:
+                  - id: 1
+                    status: completed
+                    origin:
+                      latitude: 4.710989
+                      longitude: -74.072092
+                    destination:
+                      latitude: 4.698
+                      longitude: -74.061
+                    distance_meters: 7421
+                    duration_seconds: 842
+                    currency: COP
+                    estimated_fare: 8850
+                    driver:
+                      id: 5
+                      name: Carlos Pérez
+                    requested_at: "2026-07-31T14:03:21+00:00"
+                    started_at: "2026-07-31T14:05:00+00:00"
+                    completed_at: "2026-07-31T14:22:00+00:00"
+                    final_fare: 9100
+                    payment:
+                      status: paid
+                meta:
+                  current_page: 1
+                  per_page: 15
+                  total: 1
+                  last_page: 1
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no es de pasajero. El historial de
+            ganancias del conductor es la historia #30, con su propio
+            endpoint.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: >-
+            `page` o `per_page` no son enteros positivos (por ejemplo, texto
+            o un número negativo).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The per page field must be an integer.
+                errors:
+                  per_page:
+                    - The per page field must be an integer.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /rides:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\V1\Rides\EstimateRideController;
 use App\Http\Controllers\Api\V1\Rides\RateDriverController;
 use App\Http\Controllers\Api\V1\Rides\ShareRideLocationController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideController;
+use App\Http\Controllers\Api\V1\Rides\ShowRideHistoryController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideReceiptController;
 use App\Http\Controllers\Api\V1\Rides\StartRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
@@ -106,6 +107,17 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me/availability', UpdateDriverAvailabilityController::class)
         ->name('drivers.availability');
+
+    // Historial de viajes del pasajero autenticado (historia #29). Cuelga de
+    // `me` como el vehículo y la disponibilidad: se llega por el token, nunca
+    // por un id propio, así que estructuralmente no existe forma de leer el
+    // historial de otra cuenta. Que solo los pasajeros lo consulten hoy no lo
+    // decide un middleware de rol acá, sino `RidePolicy::viewHistory()` desde
+    // `ShowRideHistoryRequest`; el mismo path servirá el historial de
+    // ganancias del conductor (historia #30).
+    Route::middleware('auth:api')
+        ->get('me/rides', ShowRideHistoryController::class)
+        ->name('rides.history');
 
     // La solicitud de viaje (historia #15). Es un recurso propio y no un
     // sub-recurso de `me`: se direcciona por su id —es el `{rideId}` del canal

--- a/tests/Feature/Rides/ShowRideHistoryTest.php
+++ b/tests/Feature/Rides/ShowRideHistoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rides;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/me/rides — ver openapi.yaml.
+ *
+ * Historia #29: el pasajero consulta y audita sus viajes pasados. El mismo
+ * path servirá el historial del conductor (historia #30), pero eso es fuera
+ * de alcance acá.
+ */
+class ShowRideHistoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_el_pasajero_ve_su_historial_ordenado_del_mas_reciente_al_mas_antiguo(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $viejo = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Completed,
+            'created_at' => now()->subDays(2),
+        ]);
+        $reciente = Ride::factory()->for($pasajero, 'passenger')->create([
+            'status' => RideStatus::Requested,
+            'created_at' => now()->subHour(),
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.0.id', $reciente->id);
+        $respuesta->assertJsonPath('data.1.id', $viejo->id);
+        $respuesta->assertJsonPath('data.0.status', RideStatus::Requested->value);
+        $respuesta->assertJsonPath('data.1.status', RideStatus::Completed->value);
+        $respuesta->assertJsonPath('data.1.estimated_fare', $viejo->estimated_fare);
+    }
+
+    public function test_un_pasajero_sin_viajes_recibe_una_lista_vacia_con_200(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+    }
+
+    public function test_no_incluye_viajes_de_otro_pasajero(): void
+    {
+        $pasajero = User::factory()->create();
+        Ride::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_respeta_los_parametros_de_paginacion(): void
+    {
+        // Estado `completed` y no el `requested` por defecto de la factory:
+        // `active_passenger_id` es único por pasajero mientras el viaje sigue
+        // activo (ver la migración de `rides`), así que varios viajes
+        // simultáneos del mismo pasajero solo caben si ya terminaron.
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->count(5)->create([
+            'status' => RideStatus::Completed,
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides?page=2&per_page=2')
+            ->assertOk();
+
+        $respuesta->assertJsonCount(2, 'data');
+        $respuesta->assertJsonPath('meta.current_page', 2);
+        $respuesta->assertJsonPath('meta.per_page', 2);
+        $respuesta->assertJsonPath('meta.total', 5);
+        $respuesta->assertJsonPath('meta.last_page', 3);
+    }
+
+    /**
+     * Pedir un `per_page` desmedido no es una entrada inválida: el backend lo
+     * acota a un límite razonable en vez de responder 422 (ver
+     * `ShowRideHistoryController::MAX_PER_PAGE`).
+     */
+    public function test_acota_un_per_page_desmedido_a_un_limite_razonable(): void
+    {
+        $pasajero = User::factory()->create();
+        Ride::factory()->for($pasajero, 'passenger')->count(3)->create([
+            'status' => RideStatus::Completed,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides?per_page=1000')
+            ->assertOk()
+            ->assertJsonPath('meta.per_page', 50);
+    }
+
+    public function test_rechaza_un_per_page_que_no_es_un_entero(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson('/api/v1/me/rides?per_page=abc')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('per_page');
+    }
+
+    public function test_rechaza_a_un_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson('/api/v1/me/rides')
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $this->getJson('/api/v1/me/rides')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -225,4 +225,14 @@ class RidePolicyTest extends TestCase
 
         $this->assertFalse($conductor->can('rateDriver', $viaje));
     }
+
+    public function test_el_pasajero_puede_ver_su_historial_de_viajes(): void
+    {
+        $this->assertTrue(User::factory()->create()->can('viewHistory', Ride::class));
+    }
+
+    public function test_el_conductor_no_puede_ver_el_historial_por_este_metodo(): void
+    {
+        $this->assertFalse(User::factory()->driver()->create()->can('viewHistory', Ride::class));
+    }
 }


### PR DESCRIPTION
Closes #29

## Qué hace

Agrega `GET /api/v1/me/rides`: el pasajero autenticado consulta su historial
de viajes, ordenado del más reciente al más antiguo, con estado y tarifa de
cada uno.

- `App\Policies\RidePolicy::viewHistory()` restringe el endpoint al rol
  pasajero (autorización por clase, no por instancia: la consulta ya viene
  acotada a la cuenta del token, no hay un viaje concreto que resolver).
- `App\Http\Requests\Rides\ShowRideHistoryRequest` valida `page`/`per_page`
  como enteros positivos opcionales.
- `App\Http\Controllers\Api\V1\Rides\ShowRideHistoryController` pagina
  `User::rides()` (relación nueva por `passenger_id`), acotando `per_page` a
  un máximo de 50 en vez de responder 422 si el cliente pide más — el
  criterio de aceptación deja ese límite a criterio del backend.
- Sin viajes previos responde 200 con `data` vacío, no un error.
- `openapi.yaml`: nuevo path `GET /me/rides` con el shape de paginación
  estándar de Laravel (`data` + `meta`).

El mismo path (`/me/rides`) va a servir el historial de ganancias del
conductor en la #30; por eso la autorización quedó en una Policy y no en un
middleware de rol, para que esa historia solo tenga que sumar una rama.

## Cómo se probó

- `tests/Feature/Rides/ShowRideHistoryTest.php`: orden más reciente→más
  antiguo, lista vacía sin viajes, aislamiento entre pasajeros, paginación
  (`page`/`per_page` respetados), `per_page` desmedido acotado a 50 en vez de
  422, `per_page` no numérico sí responde 422, 403 para un conductor, 401 sin
  token.
- `tests/Unit/Policies/RidePolicyTest.php`: casos nuevos para
  `viewHistory()`.
- Suite completa: `php artisan test` — 600/600 en verde.
- `./vendor/bin/pint` sobre los archivos tocados — sin cambios.
- `php vendor/bin/phpstan analyse` (nivel del proyecto) sobre todo `app/` +
  `routes/` — 0 errores.

## Decisiones y riesgos

- El entorno de esta corrida no tuvo un intérprete Python real
  (`python`/`python3`/`py` resuelven al stub de la Microsoft Store), así que
  no pude correr `static_conformance.py`/`dynamic_conformance.py` ni los
  scripts de `laravel-api-review` (`complexity_check.py`,
  `architecture_check.py`). Es el mismo caso ya registrado en
  `.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md` (2026-08-01). Como
  mitigación: validé el spec releyendo el YAML completo tras editarlo, y
  revisé a mano la arquitectura de los 4 archivos tocados (todos son
  one-liners sin ramas, sin SQL crudo, sin persistencia en el controller).
  Recomendado para quien revise: si tiene Python disponible, correr esos
  scripts contra esta rama como control adicional.
- `per_page` sin tope en las reglas de validación es intencional: superarlo
  se acota en el controller (`MAX_PER_PAGE = 50`) en vez de responder 422,
  como pide el criterio de aceptación ("límites razonables definidos por el
  backend").