### PR TITLE
feat(#30): ver historial de viajes y ganancias (conductor)

### DIFF
--- a/app/Actions/Drivers/SummarizeDriverEarningsAction.php
+++ b/app/Actions/Drivers/SummarizeDriverEarningsAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Drivers;
+
+use App\DTOs\DriverEarningsSummary;
+use App\Enums\RideStatus;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+/**
+ * Calcula cuánto ganó un conductor en un rango de fechas y cuántos viajes
+ * completados componen ese total (historia #30).
+ *
+ * Solo cuentan los viajes `completed` cuyo `completed_at` cae dentro del
+ * rango (inclusive en ambos extremos): uno cancelado o todavía activo no le
+ * generó ingreso al conductor. La moneda sale de `config('fares.currency')`
+ * y no del viaje: es la misma para todos los viajes de la plataforma (ver
+ * `FareSchedule`), y un conductor sin viajes en el rango igual necesita saber
+ * en qué moneda leer un total en cero.
+ */
+final readonly class SummarizeDriverEarningsAction
+{
+    public function handle(User $driver, Carbon $from, Carbon $to): DriverEarningsSummary
+    {
+        $rango = [$from->copy()->startOfDay(), $to->copy()->endOfDay()];
+
+        $totalEarned = (int) $driver->driverRides()
+            ->where('status', RideStatus::Completed)
+            ->whereBetween('completed_at', $rango)
+            ->sum('final_fare');
+
+        $completedRides = $driver->driverRides()
+            ->where('status', RideStatus::Completed)
+            ->whereBetween('completed_at', $rango)
+            ->count();
+
+        return new DriverEarningsSummary(
+            from: $from,
+            to: $to,
+            currency: config('fares.currency'),
+            totalEarned: $totalEarned,
+            completedRides: $completedRides,
+        );
+    }
+}

--- a/app/DTOs/DriverEarningsSummary.php
+++ b/app/DTOs/DriverEarningsSummary.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * Lo que ganó un conductor en un rango de fechas: el total y cuántos viajes
+ * completados lo componen (historia #30).
+ *
+ * `totalEarned` es la suma de `final_fare` de esos viajes, no un monto ya
+ * liquidado: la transferencia real al conductor es un flujo aparte, fuera de
+ * alcance de esta historia (ver el issue).
+ */
+final readonly class DriverEarningsSummary
+{
+    public function __construct(
+        public Carbon $from,
+        public Carbon $to,
+        public string $currency,
+        public int $totalEarned,
+        public int $completedRides,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/Drivers/ShowDriverEarningsController.php
+++ b/app/Http/Controllers/Api/V1/Drivers/ShowDriverEarningsController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Drivers;
+
+use App\Actions\Drivers\SummarizeDriverEarningsAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Drivers\ShowDriverEarningsRequest;
+use App\Http\Resources\DriverEarningsSummaryResource;
+
+/**
+ * GET /api/v1/me/earnings
+ *
+ * Resumen de lo que ganó el conductor autenticado en un rango de fechas:
+ * total y número de viajes completados (historia #30). Complementa
+ * `GET /me/rides`, que trae el detalle viaje por viaje; este endpoint no
+ * liquida ni transfiere nada, solo lee.
+ */
+class ShowDriverEarningsController extends Controller
+{
+    public function __invoke(
+        ShowDriverEarningsRequest $request,
+        SummarizeDriverEarningsAction $summarize,
+    ): DriverEarningsSummaryResource {
+        $resumen = $summarize->handle($request->user(), $request->from(), $request->to());
+
+        return new DriverEarningsSummaryResource($resumen);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Rides/ShowRideHistoryController.php
+++ b/app/Http/Controllers/Api/V1/Rides/ShowRideHistoryController.php
@@ -12,17 +12,18 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 /**
  * GET /api/v1/me/rides
  *
- * Devuelve los viajes del pasajero autenticado, del más reciente al más
- * antiguo (historia #29). Es la vista con la que consulta y audita sus
- * viajes pasados; no trae filtros por fecha o estado, eso queda para una
- * historia aparte.
+ * Devuelve los viajes de la cuenta autenticada, del más reciente al más
+ * antiguo: los que pidió, si es pasajero (historia #29), o los que le
+ * asignaron, si es conductor (historia #30). No trae filtros por fecha o
+ * estado, eso queda para una historia aparte; el resumen de ganancias del
+ * conductor en un rango de fechas es un endpoint propio
+ * (`GET /me/earnings`, `ShowDriverEarningsController`).
  *
  * No hay Action detrás, mismo criterio que `ShowRideController`: leer los
  * viajes ya acotados a la cuenta del token no decide ni cambia nada. Sí hay
  * Policy, a diferencia de `ShowProfileController` —acá el rol sí importa,
- * porque el mismo path va a servir el historial de ganancias del conductor
- * (historia #30)— y la resuelve `RidePolicy::viewHistory()` desde
- * `ShowRideHistoryRequest`.
+ * porque decide **qué relación** se consulta— y la resuelve
+ * `RidePolicy::viewHistory()` desde `ShowRideHistoryRequest`.
  */
 class ShowRideHistoryController extends Controller
 {
@@ -41,8 +42,11 @@ class ShowRideHistoryController extends Controller
             self::MAX_PER_PAGE,
         );
 
-        $viajes = $request->user()
-            ->rides()
+        $usuario = $request->user();
+
+        $relacion = $usuario->isDriver() ? $usuario->driverRides() : $usuario->rides();
+
+        $viajes = $relacion
             ->with('driver')
             ->latest()
             ->paginate($perPage)

--- a/app/Http/Requests/Drivers/ShowDriverEarningsRequest.php
+++ b/app/Http/Requests/Drivers/ShowDriverEarningsRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Drivers;
+
+use App\Models\Ride;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
+
+/**
+ * Entrada de GET /api/v1/me/earnings — ver openapi.yaml.
+ */
+class ShowDriverEarningsRequest extends FormRequest
+{
+    /**
+     * Autorización por clase y no por instancia, mismo criterio que
+     * `ShowRideHistoryRequest`: no hay una fila concreta que resolver, la
+     * consulta ya viene acotada a la cuenta del token. Lo decide
+     * `RidePolicy::viewEarnings()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewEarnings', Ride::class) ?? false;
+    }
+
+    /**
+     * `to` valida `after_or_equal:from` para que el criterio de aceptación
+     * ("from posterior a to es 422") salga del validador de Laravel en vez de
+     * una comprobación manual en el controller.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'from' => ['required', 'date'],
+            'to' => ['required', 'date', 'after_or_equal:from'],
+        ];
+    }
+
+    public function from(): Carbon
+    {
+        return Carbon::parse((string) $this->input('from'));
+    }
+
+    public function to(): Carbon
+    {
+        return Carbon::parse((string) $this->input('to'));
+    }
+}

--- a/app/Http/Resources/DriverEarningsSummaryResource.php
+++ b/app/Http/Resources/DriverEarningsSummaryResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\DTOs\DriverEarningsSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa un resumen de ganancias de conductor según el schema
+ * `DriverEarningsSummary` de openapi.yaml.
+ *
+ * @property-read DriverEarningsSummary $resource
+ */
+class DriverEarningsSummaryResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'from' => $this->resource->from->toDateString(),
+            'to' => $this->resource->to->toDateString(),
+            'currency' => $this->resource->currency,
+            'total_earned' => $this->resource->totalEarned,
+            'completed_rides' => $this->resource->completedRides,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,6 +68,18 @@ class User extends Authenticatable implements JWTSubject
         return $this->hasMany(Ride::class, 'passenger_id');
     }
 
+    /**
+     * Los viajes que esta cuenta aceptó como conductor (historia #30). Sirve
+     * el mismo historial que `rides()` del lado del pasajero, y además la
+     * base de la que se agregan las ganancias en `SummarizeDriverEarningsAction`.
+     *
+     * @return HasMany<Ride, $this>
+     */
+    public function driverRides(): HasMany
+    {
+        return $this->hasMany(Ride::class, 'driver_id');
+    }
+
     public function isDriver(): bool
     {
         return $this->role === UserRole::Driver;

--- a/app/Policies/RidePolicy.php
+++ b/app/Policies/RidePolicy.php
@@ -185,14 +185,28 @@ class RidePolicy
     }
 
     /**
-     * Ver el propio historial de viajes es del rol pasajero (historia #29),
-     * mismo criterio que `create()`: no depende de una fila concreta porque
-     * la consulta ya viene acotada a la cuenta autenticada, así que no existe
-     * la pregunta "¿de quién es este viaje?" que sí resuelven `view()` o
-     * `cancel()`.
+     * Ver el propio historial de viajes es de cualquier cuenta autenticada:
+     * el pasajero ve los que pidió (historia #29), el conductor ve los que le
+     * asignaron (historia #30). Mismo criterio que `create()` para no
+     * depender de una fila concreta: la consulta ya viene acotada a la cuenta
+     * autenticada (`User::rides()` o `User::driverRides()` según el rol, ver
+     * `ShowRideHistoryController`), así que no existe la pregunta "¿de quién
+     * es este viaje?" que sí resuelven `view()` o `cancel()`.
      */
     public function viewHistory(User $user): bool
     {
-        return $user->isPassenger();
+        return $user->isPassenger() || $user->isDriver();
+    }
+
+    /**
+     * Ver el resumen de ganancias por rango de fechas es del rol conductor
+     * (historia #30): es a él a quien le corresponde el monto de cada viaje,
+     * el pasajero ya vio lo que pagó en su propio historial y en el recibo
+     * (historia #26). No depende de una fila concreta, mismo criterio que
+     * `viewHistory()`: la consulta ya viene acotada a la cuenta autenticada.
+     */
+    public function viewEarnings(User $user): bool
+    {
+        return $user->isDriver();
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -921,10 +921,13 @@ paths:
       operationId: listMyRides
       summary: Ver el historial de viajes propios
       description: >-
-        Devuelve los viajes del pasajero autenticado, ordenados del más
-        reciente al más antiguo (historia #29). Es la vista con la que el
-        pasajero consulta y audita sus viajes pasados; no trae filtros por
-        fecha o estado ni exportación — se evalúan como historias aparte.
+        Devuelve los viajes de la cuenta autenticada, ordenados del más
+        reciente al más antiguo: los que pidió, si es pasajero (historia #29),
+        o los que le asignaron, si es conductor (historia #30). Es la vista
+        con la que cada cuenta consulta y audita sus viajes pasados; no trae
+        filtros por fecha o estado ni exportación — se evalúan como historias
+        aparte. Para el conductor, el resumen de ganancias en un rango de
+        fechas es un endpoint aparte (`GET /me/earnings`).
 
         Una cuenta sin viajes previos recibe **200** con `data` en una lista
         vacía, no un error.
@@ -1028,17 +1031,6 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Unauthenticated.
-        "403":
-          description: >-
-            La cuenta autenticada no es de pasajero. El historial de
-            ganancias del conductor es la historia #30, con su propio
-            endpoint.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                message: This action is unauthorized.
         "422":
           description: >-
             `page` o `per_page` no son enteros positivos (por ejemplo, texto
@@ -1052,6 +1044,107 @@ paths:
                 errors:
                   per_page:
                     - The per page field must be an integer.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /me/earnings:
+    get:
+      tags:
+        - Drivers
+      operationId: showDriverEarnings
+      summary: Ver el resumen de ganancias del conductor en un rango de fechas
+      description: >-
+        Devuelve cuánto ganó el conductor autenticado en un rango de fechas, y
+        cuántos viajes completados componen ese total (historia #30). Es el
+        complemento de `GET /me/rides` para hacer seguimiento de ingresos, no
+        el detalle viaje por viaje.
+
+        `from` y `to` son obligatorios y se toman como fechas completas (todo
+        el día), inclusive en ambos extremos. Solo cuentan los viajes en
+        estado `completed` cuyo `completed_at` cae dentro del rango; un viaje
+        `cancelled` o todavía activo no suma nada.
+
+        No se hace liquidación ni transferencia real del monto: es solo un
+        resumen de lectura, el flujo de pago al conductor queda fuera de
+        alcance de esta historia.
+
+        Requiere un token vigente y rol `driver`: una cuenta de pasajero
+        recibe 403, mismo criterio que `PATCH /me/availability`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: Fecha inicial del rango (inclusive).
+          schema:
+            type: string
+            format: date
+          example: "2026-07-01"
+        - name: to
+          in: query
+          required: true
+          description: Fecha final del rango (inclusive).
+          schema:
+            type: string
+            format: date
+          example: "2026-07-31"
+      responses:
+        "200":
+          description: Resumen de ganancias del conductor en el rango solicitado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/DriverEarningsSummary"
+              example:
+                data:
+                  from: "2026-07-01"
+                  to: "2026-07-31"
+                  currency: COP
+                  total_earned: 182400
+                  completed_rides: 21
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no es de conductor. El historial de viajes
+            del pasajero es la historia #29, con su propio endpoint
+            (`GET /me/rides`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: >-
+            Falta `from` o `to`, alguna no es una fecha válida, o `from` es
+            posterior a `to`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The to field must be a date after or equal to from.
+                errors:
+                  to:
+                    - The to field must be a date after or equal to from.
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:
@@ -2721,6 +2814,45 @@ components:
             en el monto final, que se recalcula al completar el viaje con el
             trayecto realmente recorrido.
           example: true
+    DriverEarningsSummary:
+      type: object
+      description: >-
+        Lo que ganó un conductor en un rango de fechas, junto con el número de
+        viajes completados que componen ese total (historia #30). No incluye
+        el detalle viaje por viaje — eso es `GET /me/rides` — ni implica que
+        el monto ya se haya liquidado al conductor.
+      required:
+        - from
+        - to
+        - currency
+        - total_earned
+        - completed_rides
+      properties:
+        from:
+          type: string
+          format: date
+          description: Fecha inicial del rango solicitado (inclusive).
+          example: "2026-07-01"
+        to:
+          type: string
+          format: date
+          description: Fecha final del rango solicitado (inclusive).
+          example: "2026-07-31"
+        currency:
+          type: string
+          description: Código ISO 4217 de tres letras de la moneda del monto.
+          example: COP
+        total_earned:
+          type: integer
+          description: >-
+            Suma de `final_fare` de los viajes completados del conductor en
+            el rango, entero en la unidad mínima de `currency` (ver la nota
+            sobre dinero en config/fares.php).
+          example: 182400
+        completed_rides:
+          type: integer
+          description: Número de viajes completados que componen `total_earned`.
+          example: 21
     RideRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Drivers\ShowDriverEarningsController;
 use App\Http\Controllers\Api\V1\Drivers\UpdateDriverAvailabilityController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
@@ -108,16 +109,25 @@ Route::prefix('v1')->group(function () {
         ->patch('me/availability', UpdateDriverAvailabilityController::class)
         ->name('drivers.availability');
 
-    // Historial de viajes del pasajero autenticado (historia #29). Cuelga de
-    // `me` como el vehículo y la disponibilidad: se llega por el token, nunca
-    // por un id propio, así que estructuralmente no existe forma de leer el
-    // historial de otra cuenta. Que solo los pasajeros lo consulten hoy no lo
-    // decide un middleware de rol acá, sino `RidePolicy::viewHistory()` desde
-    // `ShowRideHistoryRequest`; el mismo path servirá el historial de
-    // ganancias del conductor (historia #30).
+    // Historial de viajes de la cuenta autenticada: los que pidió, si es
+    // pasajero (historia #29), o los que le asignaron, si es conductor
+    // (historia #30). Cuelga de `me` como el vehículo y la disponibilidad: se
+    // llega por el token, nunca por un id propio, así que estructuralmente no
+    // existe forma de leer el historial de otra cuenta. Qué relación se
+    // consulta según el rol no lo decide un middleware acá, sino
+    // `RidePolicy::viewHistory()` y `ShowRideHistoryController`.
     Route::middleware('auth:api')
         ->get('me/rides', ShowRideHistoryController::class)
         ->name('rides.history');
+
+    // Resumen de ganancias del conductor por rango de fechas (historia #30).
+    // Cuelga de `me` mismo criterio que el historial: se llega por el token,
+    // nunca por un id propio. Que solo los conductores lo consulten no lo
+    // decide un middleware de rol acá, sino `RidePolicy::viewEarnings()` desde
+    // `ShowDriverEarningsRequest`.
+    Route::middleware('auth:api')
+        ->get('me/earnings', ShowDriverEarningsController::class)
+        ->name('drivers.earnings');
 
     // La solicitud de viaje (historia #15). Es un recurso propio y no un
     // sub-recurso de `me`: se direcciona por su id —es el `{rideId}` del canal

--- a/tests/Feature/Drivers/ShowDriverEarningsTest.php
+++ b/tests/Feature/Drivers/ShowDriverEarningsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Drivers;
+
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/me/earnings — ver openapi.yaml.
+ *
+ * Historia #30: el conductor hace seguimiento de sus ingresos por rango de
+ * fechas. Es el complemento de `GET /me/rides`
+ * (`tests/Feature/Rides/ShowRideHistoryTest.php`), no un reemplazo.
+ */
+class ShowDriverEarningsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/earnings';
+
+    public function test_el_conductor_ve_el_total_ganado_y_los_viajes_completados_del_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 9000,
+            'completed_at' => Carbon::parse('2026-07-10 12:00:00'),
+        ]);
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 8500,
+            'completed_at' => Carbon::parse('2026-07-20 12:00:00'),
+        ]);
+        // Fuera del rango solicitado: no debería sumar.
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 5000,
+            'completed_at' => Carbon::parse('2026-06-15 12:00:00'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=2026-07-01&to=2026-07-31')
+            ->assertOk()
+            ->assertJsonPath('data.from', '2026-07-01')
+            ->assertJsonPath('data.to', '2026-07-31')
+            ->assertJsonPath('data.currency', 'COP')
+            ->assertJsonPath('data.total_earned', 17500)
+            ->assertJsonPath('data.completed_rides', 2);
+    }
+
+    public function test_un_conductor_sin_viajes_completados_en_el_rango_recibe_cero(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=2026-07-01&to=2026-07-31')
+            ->assertOk()
+            ->assertJsonPath('data.total_earned', 0)
+            ->assertJsonPath('data.completed_rides', 0);
+    }
+
+    public function test_no_incluye_ganancias_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Ride::factory()->create([
+            'driver_id' => User::factory()->driver(),
+            'status' => RideStatus::Completed,
+            'final_fare' => 9000,
+            'completed_at' => Carbon::parse('2026-07-10 12:00:00'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=2026-07-01&to=2026-07-31')
+            ->assertOk()
+            ->assertJsonPath('data.total_earned', 0)
+            ->assertJsonPath('data.completed_rides', 0);
+    }
+
+    public function test_rechaza_un_rango_con_from_posterior_a_to(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=2026-07-31&to=2026-07-01')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('to');
+    }
+
+    public function test_rechaza_from_ausente(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?to=2026-07-31')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('from');
+    }
+
+    public function test_rechaza_to_ausente(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=2026-07-01')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('to');
+    }
+
+    public function test_rechaza_una_fecha_que_no_es_valida(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI.'?from=no-es-una-fecha&to=2026-07-31')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('from');
+    }
+
+    public function test_rechaza_a_un_pasajero(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->getJson(self::URI.'?from=2026-07-01&to=2026-07-31')
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $this->getJson(self::URI.'?from=2026-07-01&to=2026-07-31')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+}

--- a/tests/Feature/Rides/ShowRideHistoryTest.php
+++ b/tests/Feature/Rides/ShowRideHistoryTest.php
@@ -15,8 +15,10 @@ use Tymon\JWTAuth\Facades\JWTAuth;
  * Contrato de GET /api/v1/me/rides — ver openapi.yaml.
  *
  * Historia #29: el pasajero consulta y audita sus viajes pasados. El mismo
- * path servirá el historial del conductor (historia #30), pero eso es fuera
- * de alcance acá.
+ * path sirve también el historial del conductor (historia #30, ver los tests
+ * `test_el_conductor_ve_*` más abajo); el resumen de ganancias en un rango de
+ * fechas es un endpoint aparte (`GET /me/earnings`,
+ * `tests/Feature/Drivers/ShowDriverEarningsTest.php`).
  */
 class ShowRideHistoryTest extends TestCase
 {
@@ -118,14 +120,81 @@ class ShowRideHistoryTest extends TestCase
             ->assertJsonValidationErrors('per_page');
     }
 
-    public function test_rechaza_a_un_conductor(): void
+    public function test_el_conductor_ve_su_historial_ordenado_del_mas_reciente_al_mas_antiguo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $viejo = Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'created_at' => now()->subDays(2),
+        ]);
+        $reciente = Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'created_at' => now()->subHour(),
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk();
+
+        $respuesta->assertJsonPath('data.0.id', $reciente->id);
+        $respuesta->assertJsonPath('data.1.id', $viejo->id);
+    }
+
+    public function test_el_conductor_sin_viajes_asignados_recibe_una_lista_vacia_con_200(): void
     {
         $conductor = User::factory()->driver()->create();
 
         $this->withToken(JWTAuth::fromUser($conductor))
             ->getJson('/api/v1/me/rides')
-            ->assertForbidden()
-            ->assertJsonStructure(['message']);
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+    }
+
+    public function test_el_historial_del_conductor_no_incluye_viajes_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Ride::factory()->create(['driver_id' => User::factory()->driver()]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    /**
+     * Un viaje sin conductor asignado (`requested`, todavía en el pool) no es
+     * de nadie del lado del conductor: no debería aparecer en el historial de
+     * ningún conductor solo porque ninguno lo tomó todavía.
+     */
+    public function test_el_historial_del_conductor_no_incluye_viajes_sin_conductor_asignado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Ride::factory()->create(['driver_id' => null]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_el_historial_del_conductor_incluye_el_monto_ganado_de_cada_viaje(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $viaje = Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 9100,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson('/api/v1/me/rides')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $viaje->id)
+            ->assertJsonPath('data.0.final_fare', 9100);
     }
 
     public function test_rechaza_la_solicitud_sin_token(): void

--- a/tests/Unit/Actions/Drivers/SummarizeDriverEarningsActionTest.php
+++ b/tests/Unit/Actions/Drivers/SummarizeDriverEarningsActionTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Drivers;
+
+use App\Actions\Drivers\SummarizeDriverEarningsAction;
+use App\Enums\RideStatus;
+use App\Models\Ride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * La Action invocada directo, sin pasar por HTTP (ver .claude/STANDARDS.md).
+ *
+ * Historia #30: cuánto ganó un conductor en un rango de fechas y cuántos
+ * viajes completados componen ese total.
+ */
+class SummarizeDriverEarningsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_suma_el_monto_ganado_de_los_viajes_completados_en_el_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 9000,
+            'completed_at' => Carbon::parse('2026-07-10 12:00:00'),
+        ]);
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 8500,
+            'completed_at' => Carbon::parse('2026-07-20 12:00:00'),
+        ]);
+
+        $resumen = $this->action()->handle(
+            $conductor,
+            Carbon::parse('2026-07-01'),
+            Carbon::parse('2026-07-31'),
+        );
+
+        $this->assertSame(17500, $resumen->totalEarned);
+        $this->assertSame(2, $resumen->completedRides);
+    }
+
+    public function test_no_cuenta_viajes_completados_fuera_del_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 9000,
+            'completed_at' => Carbon::parse('2026-06-30 23:59:59'),
+        ]);
+
+        $resumen = $this->action()->handle(
+            $conductor,
+            Carbon::parse('2026-07-01'),
+            Carbon::parse('2026-07-31'),
+        );
+
+        $this->assertSame(0, $resumen->totalEarned);
+        $this->assertSame(0, $resumen->completedRides);
+    }
+
+    /**
+     * El rango es inclusive en ambos extremos: un viaje completado en
+     * cualquier momento del último día del rango sí cuenta.
+     */
+    public function test_incluye_el_dia_completo_de_los_extremos_del_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Completed,
+            'final_fare' => 5000,
+            'completed_at' => Carbon::parse('2026-07-31 23:59:00'),
+        ]);
+
+        $resumen = $this->action()->handle(
+            $conductor,
+            Carbon::parse('2026-07-01'),
+            Carbon::parse('2026-07-31'),
+        );
+
+        $this->assertSame(5000, $resumen->totalEarned);
+        $this->assertSame(1, $resumen->completedRides);
+    }
+
+    public function test_no_cuenta_viajes_cancelados_ni_activos_en_el_rango(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::Cancelled,
+            'final_fare' => null,
+        ]);
+        Ride::factory()->create([
+            'driver_id' => $conductor->id,
+            'status' => RideStatus::InProgress,
+            'final_fare' => null,
+        ]);
+
+        $resumen = $this->action()->handle(
+            $conductor,
+            Carbon::parse('2026-01-01'),
+            Carbon::parse('2026-12-31'),
+        );
+
+        $this->assertSame(0, $resumen->totalEarned);
+        $this->assertSame(0, $resumen->completedRides);
+    }
+
+    public function test_no_cuenta_viajes_completados_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        Ride::factory()->create([
+            'driver_id' => User::factory()->driver(),
+            'status' => RideStatus::Completed,
+            'final_fare' => 9000,
+            'completed_at' => Carbon::parse('2026-07-10 12:00:00'),
+        ]);
+
+        $resumen = $this->action()->handle(
+            $conductor,
+            Carbon::parse('2026-07-01'),
+            Carbon::parse('2026-07-31'),
+        );
+
+        $this->assertSame(0, $resumen->totalEarned);
+        $this->assertSame(0, $resumen->completedRides);
+    }
+
+    private function action(): SummarizeDriverEarningsAction
+    {
+        return $this->app->make(SummarizeDriverEarningsAction::class);
+    }
+}

--- a/tests/Unit/Policies/RidePolicyTest.php
+++ b/tests/Unit/Policies/RidePolicyTest.php
@@ -231,8 +231,24 @@ class RidePolicyTest extends TestCase
         $this->assertTrue(User::factory()->create()->can('viewHistory', Ride::class));
     }
 
-    public function test_el_conductor_no_puede_ver_el_historial_por_este_metodo(): void
+    /**
+     * El mismo path (`GET /me/rides`) sirve también el historial de viajes
+     * asignados del conductor (historia #30): no depende de una fila
+     * concreta, mismo criterio que el pasajero, porque la consulta ya viene
+     * acotada a la cuenta autenticada.
+     */
+    public function test_el_conductor_tambien_puede_ver_su_historial_de_viajes(): void
     {
-        $this->assertFalse(User::factory()->driver()->create()->can('viewHistory', Ride::class));
+        $this->assertTrue(User::factory()->driver()->create()->can('viewHistory', Ride::class));
+    }
+
+    public function test_el_conductor_puede_ver_el_resumen_de_sus_ganancias(): void
+    {
+        $this->assertTrue(User::factory()->driver()->create()->can('viewEarnings', Ride::class));
+    }
+
+    public function test_el_pasajero_no_puede_ver_el_resumen_de_ganancias(): void
+    {
+        $this->assertFalse(User::factory()->create()->can('viewEarnings', Ride::class));
     }
 }


### PR DESCRIPTION
Closes #30

## Qué hace

Agrega `GET /api/v1/me/earnings`: el conductor autenticado consulta cuánto
ganó en un rango de fechas (`from`/`to`, obligatorios e inclusive en ambos
extremos) y cuántos viajes completados componen ese total.

También extiende `GET /api/v1/me/rides` (historia #29) para que el mismo
path sirva el historial de viajes **asignados** del conductor, tal como
quedó anotado explícitamente en el PR #58 (#29): "el mismo path va a
servir el historial de ganancias del conductor en la #30".

- `App\Policies\RidePolicy::viewHistory()` ahora admite pasajero **o**
  conductor (antes solo pasajero); se agrega `viewEarnings()`, exclusiva
  del rol conductor.
- `App\Models\User::driverRides()`: nueva relación `HasMany` por
  `driver_id`, contraparte de `rides()` (por `passenger_id`).
- `ShowRideHistoryController` elige `User::rides()` o
  `User::driverRides()` según el rol antes de paginar — sin Action
  detrás, mismo criterio que la versión de pasajero: leer lo ya acotado
  al token no decide nada.
- `App\Actions\Drivers\SummarizeDriverEarningsAction`: suma `final_fare`
  de los viajes `completed` del conductor cuyo `completed_at` cae en el
  rango (`whereBetween` con `startOfDay()`/`endOfDay()`, inclusive). La
  moneda sale de `config('fares.currency')`, no del viaje, porque es una
  sola para toda la plataforma (`FareSchedule`).
- `ShowDriverEarningsRequest` valida `from`/`to` obligatorios y `to` con
  `after_or_equal:from`, así que "`from` posterior a `to`" responde 422
  desde el validador de Laravel, sin comprobación manual en el
  controller.
- `openapi.yaml`: descripción de `/me/rides` actualizada (ya no hay un
  403 real, `UserRole` solo tiene `passenger`/`driver`, así que la Policy
  siempre es `true` para cualquier cuenta autenticada); nuevo path
  `/me/earnings` con el schema `DriverEarningsSummary`.

## Cómo se probó

- `tests/Feature/Rides/ShowRideHistoryTest.php`: se reemplaza
  `test_rechaza_a_un_conductor` (ya no aplica) por casos nuevos —
  historial del conductor ordenado más reciente→más antiguo, lista vacía
  sin viajes asignados, aislamiento entre conductores, no incluye viajes
  `requested` sin conductor asignado, incluye `final_fare` por viaje.
- `tests/Unit/Policies/RidePolicyTest.php`: casos nuevos para
  `viewHistory()` (conductor) y `viewEarnings()` (conductor sí, pasajero
  no).
- `tests/Feature/Drivers/ShowDriverEarningsTest.php`: total y conteo
  correctos dentro del rango, no suma fuera de rango, aislamiento entre
  conductores, `from` posterior a `to` → 422, `from`/`to` ausentes → 422,
  fecha inválida → 422, 403 para un pasajero, 401 sin token.
- `tests/Unit/Actions/Drivers/SummarizeDriverEarningsActionTest.php`:
  suma correcta, excluye fuera de rango, incluye el día completo de
  ambos extremos, excluye `cancelled`/`in_progress`, excluye viajes de
  otro conductor.
- Suite completa: `php artisan test` — 620/620 en verde.
- `./vendor/bin/pint --test` sobre los 14 archivos tocados — sin errores.
- `php -d memory_limit=1G vendor/bin/phpstan analyse app routes` (nivel
  del proyecto) — 0 errores.

## Decisiones y riesgos

- El entorno de esta corrida no tuvo un intérprete Python real
  (`python`/`python3`/`py` resuelven al stub de la Microsoft Store), así
  que no pude correr `static_conformance.py`/`dynamic_conformance.py` ni
  los scripts de `laravel-api-review`/`laravel-security-review`
  (`complexity_check.py`, `architecture_check.py`). Ya está registrado en
  `.claude/skills/laravel-feature-workflow/KNOWN_ERRORS.md`
  (2026-08-01). Mitigación: releí el YAML completo tras editarlo
  (`openapi.yaml`, indentación y refs verificados a mano contra bloques
  vecinos) y revisé a mano arquitectura/complejidad/seguridad de los 14
  archivos tocados — controllers finos delegando a una Action o a la
  relación ya acotada al token, sin SQL crudo, sin lógica de negocio en
  Models, sin campos sensibles nuevos expuestos, `$fillable` sin
  cambios. Recomendado para quien revise: si tiene Python disponible,
  correr esos scripts contra esta rama como control adicional.
- `viewHistory()` pasa a ser `true` para cualquier `UserRole` existente
  (solo hay `passenger`/`driver`): el 403 documentado antes en
  `/me/rides` ya no es alcanzable, así que se quitó de `openapi.yaml` en
  vez de dejar un caso de error que nunca ocurre.
- El "monto ganado" del conductor es `final_fare` completo del viaje, sin
  descontar comisión de la plataforma: no existe ese concepto todavía en
  el dominio (no hay `commission`/`platform_fee` en ningún lado del
  código), y el issue deja explícitamente fuera de alcance "liquidación y
  transferencia efectiva de las ganancias".
- `from`/`to` se toman como fecha completa (`startOfDay()`/`endOfDay()`),
  no como instante exacto: encaja con que la app móvil probablemente los
  mande como `YYYY-MM-DD` sin hora, y con el criterio de aceptación que
  habla de "rango de fechas", no de rango de instantes.