### PR TITLE
feat(#60): exponer consulta del vehículo del conductor (GET /me/vehicle)

### DIFF
--- a/app/Http/Controllers/Api/V1/Vehicles/ShowVehicleController.php
+++ b/app/Http/Controllers/Api/V1/Vehicles/ShowVehicleController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Vehicles;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Vehicles\ShowVehicleRequest;
+use App\Http\Resources\VehicleResource;
+
+/**
+ * GET /api/v1/me/vehicle
+ *
+ * Devuelve la moto ya registrada del conductor autenticado.
+ *
+ * Qué vehículo se muestra no se decide acá: lo resuelve el Form Request por
+ * la relación con la cuenta del token, que es también quien ya respondió el
+ * 403 del rol y el 404 de la cuenta sin moto. No hay Action detrás y es a
+ * propósito, mismo criterio que `ShowProfileController`: leer un recurso ya
+ * resuelto no es un caso de uso de negocio, no decide nada y no cambia nada.
+ */
+class ShowVehicleController extends Controller
+{
+    public function __invoke(ShowVehicleRequest $request): VehicleResource
+    {
+        return new VehicleResource($request->vehicle());
+    }
+}

--- a/app/Http/Requests/Vehicles/ShowVehicleRequest.php
+++ b/app/Http/Requests/Vehicles/ShowVehicleRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Vehicles;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Http\FormRequest;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Entrada de GET /api/v1/me/vehicle — ver openapi.yaml.
+ */
+class ShowVehicleRequest extends FormRequest
+{
+    private ?Vehicle $vehicle = null;
+
+    /**
+     * Mismo orden que `UpdateVehicleRequest::authorize()` y mismo motivo: el
+     * rol pesa antes que el recurso, así que el pasajero se lleva 403 y no
+     * 404 aunque tampoco tenga vehículo.
+     */
+    public function authorize(): bool
+    {
+        $driver = $this->user();
+
+        if (! $driver instanceof User || ! $driver->can('create', Vehicle::class)) {
+            return false;
+        }
+
+        return $driver->can('view', $this->vehicle());
+    }
+
+    /**
+     * La moto de la cuenta autenticada, o 404 si todavía no registró
+     * ninguna. Mismo criterio que `UpdateVehicleRequest::vehicle()`: se
+     * resuelve por la relación y nunca por un id de la entrada.
+     */
+    public function vehicle(): Vehicle
+    {
+        if ($this->vehicle instanceof Vehicle) {
+            return $this->vehicle;
+        }
+
+        $driver = $this->user();
+        $vehicle = $driver instanceof User ? $driver->vehicle : null;
+
+        if (! $vehicle instanceof Vehicle) {
+            throw new NotFoundHttpException('No tienes un vehículo registrado.');
+        }
+
+        return $this->vehicle = $vehicle;
+    }
+
+    /**
+     * Un GET no trae cuerpo, y el único dato que decide esta operación es el
+     * vehículo de la cuenta autenticada.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Policies/VehiclePolicy.php
+++ b/app/Policies/VehiclePolicy.php
@@ -49,4 +49,17 @@ class VehiclePolicy
     {
         return $user->isDriver() && $vehicle->user_id === $user->getKey();
     }
+
+    /**
+     * Consultar los datos de una moto es del conductor **dueño** de esa moto.
+     *
+     * Misma regla que `update()` y mismo motivo: `GET /me/vehicle` tampoco
+     * lleva id en la ruta, así que hoy no existe una request capaz de traer
+     * acá el vehículo de otra persona, pero la garantía se escribe igual en
+     * la Policy y no en la forma de la ruta de hoy.
+     */
+    public function view(User $user, Vehicle $vehicle): bool
+    {
+        return $user->isDriver() && $vehicle->user_id === $user->getKey();
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1804,16 +1804,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -1850,7 +1850,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -1907,7 +1907,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",
@@ -2571,16 +2571,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.5",
+            "version": "v1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
+                "reference": "c54350438cd6914616f790a49cb424605f421562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
-                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "url": "https://api.github.com/repos/nette/schema/zipball/c54350438cd6914616f790a49cb424605f421562",
+                "reference": "c54350438cd6914616f790a49cb424605f421562",
                 "shasum": ""
             },
             "require": {
@@ -2632,9 +2632,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.5"
+                "source": "https://github.com/nette/schema/tree/v1.3.6"
             },
-            "time": "2026-02-23T03:47:12+00:00"
+            "time": "2026-08-16T21:58:41+00:00"
         },
         {
             "name": "nette/utils",
@@ -9656,5 +9656,5 @@
         "php": "^8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -588,6 +588,81 @@ paths:
               example:
                 message: Too Many Attempts.
   /me/vehicle:
+    get:
+      tags:
+        - Vehicles
+      operationId: showVehicle
+      summary: Consultar los datos de mi vehículo
+      description: >-
+        Devuelve la moto ya registrada del conductor que envía el token. Es la
+        única forma de leerla fuera del instante en que se acaba de registrar
+        o actualizar en la misma sesión: ni `GET /me` ni ningún otro endpoint
+        la embeben.
+
+        Cuelga de `/me` como el alta y la actualización: se llega a ella por
+        el token, nunca por un id propio. Que no haya id en la ruta es lo que
+        hace estructuralmente imposible pedir la moto de otro conductor; la
+        propiedad se comprueba igual con `VehiclePolicy`, que es donde vive la
+        autorización de negocio.
+
+        Requiere un token vigente y rol `driver`. Un conductor que todavía no
+        registró su moto recibe 404, para que el cliente pueda distinguir
+        "no tiene vehículo" de un error real.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Vehículo de la cuenta autenticada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Vehicle"
+              example:
+                data:
+                  plate: ABC12D
+                  model: Bajaj Boxer CT 100
+                  year: 2022
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: >-
+            La cuenta autenticada no es de conductor. No es que le falte
+            registrar la moto, es que operar vehículos no es de su rol.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: >-
+            La cuenta es de conductor pero todavía no tiene vehículo
+            registrado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No tienes un vehículo registrado.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
     post:
       tags:
         - Vehicles

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Api\V1\Rides\ShowRideHistoryController;
 use App\Http\Controllers\Api\V1\Rides\ShowRideReceiptController;
 use App\Http\Controllers\Api\V1\Rides\StartRideController;
 use App\Http\Controllers\Api\V1\Vehicles\RegisterVehicleController;
+use App\Http\Controllers\Api\V1\Vehicles\ShowVehicleController;
 use App\Http\Controllers\Api\V1\Vehicles\UpdateVehicleController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\Facades\Route;
@@ -87,6 +88,14 @@ Route::prefix('v1')->group(function () {
     // conductores puedan registrarlo no se declara acá con un middleware de
     // rol, sino con `VehiclePolicy` (ver .claude/STANDARDS.md: la autorización
     // de negocio va en Policies, no en el token ni en la ruta).
+    // Consultar la moto ya registrada (historia técnica #60): es la única
+    // forma de leerla fuera del instante en que se acaba de registrar o
+    // actualizar en la misma sesión. Mismo criterio que el alta y la
+    // actualización: se llega a ella por el token, nunca por un id propio.
+    Route::middleware('auth:api')
+        ->get('me/vehicle', ShowVehicleController::class)
+        ->name('vehicles.show');
+
     Route::middleware('auth:api')
         ->post('me/vehicle', RegisterVehicleController::class)
         ->name('vehicles.store');

--- a/tests/Feature/Vehicles/ShowVehicleTest.php
+++ b/tests/Feature/Vehicles/ShowVehicleTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Vehicles;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/me/vehicle — ver openapi.yaml.
+ *
+ * Lo que fija esta suite es que el vehículo devuelto es siempre el de la
+ * cuenta del token, que el shape es el mismo que el de `POST`/`PATCH` sobre
+ * el mismo recurso, y el orden de los rechazos: 403 el rol, 404 la cuenta de
+ * conductor sin vehículo todavía.
+ */
+class ShowVehicleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/vehicle';
+
+    public function test_devuelve_el_vehiculo_del_conductor_autenticado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create([
+            'user_id' => $conductor->id,
+            'plate' => 'ABC12D',
+            'model' => 'Bajaj Boxer CT 100',
+            'year' => 2022,
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    'plate' => 'ABC12D',
+                    'model' => 'Bajaj Boxer CT 100',
+                    'year' => 2022,
+                ],
+            ]);
+    }
+
+    public function test_la_respuesta_no_publica_el_id_de_la_fila_ni_el_dueno(): void
+    {
+        // Mismo criterio que el alta y la actualización: al vehículo se llega
+        // por la cuenta que manda el token, nunca por un id propio.
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk();
+
+        $respuesta->assertJsonMissingPath('data.id');
+        $respuesta->assertJsonMissingPath('data.user_id');
+    }
+
+    public function test_no_devuelve_el_vehiculo_de_otro_conductor(): void
+    {
+        $otro = User::factory()->driver()->create();
+        Vehicle::factory()->create([
+            'user_id' => $otro->id,
+            'plate' => 'JJJ11J',
+            'model' => 'Honda CB 110',
+            'year' => 2020,
+        ]);
+
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id, 'plate' => 'ABC12D']);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonPath('data.plate', 'ABC12D');
+    }
+
+    public function test_responde_404_si_el_conductor_todavia_no_registro_su_vehiculo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertNotFound()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_consultar_un_vehiculo(): void
+    {
+        // 403 y no 404: para el pasajero no es que le falte registrar la
+        // moto, es que operar vehículos no es de su rol. Mismo trato que en
+        // el alta y la actualización.
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson(self::URI)
+            ->assertForbidden()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_sin_token(): void
+    {
+        $this->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_con_un_token_ilegible(): void
+    {
+        $this->withToken('no-es-un-jwt')
+            ->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_rechaza_la_consulta_con_un_token_expirado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        Vehicle::factory()->create(['user_id' => $conductor->id]);
+        $token = JWTAuth::fromUser($conductor);
+
+        $this->travel(30)->minutes();
+
+        $this->withToken($token)
+            ->getJson(self::URI)
+            ->assertUnauthorized()
+            ->assertJsonStructure(['message']);
+    }
+}

--- a/tests/Unit/Policies/VehiclePolicyTest.php
+++ b/tests/Unit/Policies/VehiclePolicyTest.php
@@ -60,4 +60,28 @@ class VehiclePolicyTest extends TestCase
 
         $this->assertFalse($pasajero->can('update', $vehiculo));
     }
+
+    public function test_el_conductor_puede_ver_su_propio_vehiculo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $vehiculo = Vehicle::factory()->create(['user_id' => $conductor->id]);
+
+        $this->assertTrue($conductor->can('view', $vehiculo));
+    }
+
+    public function test_el_conductor_no_puede_ver_el_vehiculo_de_otro_conductor(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        $ajeno = Vehicle::factory()->create(['user_id' => User::factory()->driver()]);
+
+        $this->assertFalse($conductor->can('view', $ajeno));
+    }
+
+    public function test_el_pasajero_no_puede_ver_un_vehiculo_aunque_figure_como_dueno(): void
+    {
+        $pasajero = User::factory()->create();
+        $vehiculo = Vehicle::factory()->create(['user_id' => $pasajero->id]);
+
+        $this->assertFalse($pasajero->can('view', $vehiculo));
+    }
 }


### PR DESCRIPTION
Closes #60

## Qué hace

Agrega `GET /api/v1/me/vehicle` para consultar la moto ya registrada del
conductor autenticado. Hoy `/me/vehicle` solo tenía `POST` (registrar) y
`PATCH` (actualizar); no había ninguna forma de leerla, ni siquiera embebida
en `GET /me`.

- `App\Policies\VehiclePolicy::view()` (nuevo): misma regla que `update()` —
  conductor dueño de esa moto.
- `App\Http\Requests\Vehicles\ShowVehicleRequest`: resuelve el vehículo por
  la relación con la cuenta del token (nunca por id), 403 si el rol no es
  conductor, 404 si el conductor todavía no tiene vehículo.
- `App\Http\Controllers\Api\V1\Vehicles\ShowVehicleController`: sin Action
  detrás, mismo criterio que `ShowProfileController` — leer un recurso ya
  resuelto no es un caso de uso de negocio.
- Ruta `GET me/vehicle` registrada antes del `POST` existente.
- `openapi.yaml` documentado con el mismo shape que `POST`/`PATCH`.

## Cómo se probé

- `tests/Feature/Vehicles/ShowVehicleTest.php` (nuevo): un test por criterio
  de aceptación del issue — 200 con el shape esperado, 404 sin vehículo, 403
  para pasajero, 401 sin token/token inválido/expirado, y que no filtra
  `id`/`user_id` ni el vehículo de otro conductor.
- `tests/Unit/Policies/VehiclePolicyTest.php`: casos para `view()` (dueño,
  no dueño, pasajero).
- Suite completa: `php artisan test` → 631 tests, 1793 assertions, todo en
  verde.
- `./vendor/bin/pint --test` sin errores.
- `php vendor/bin/phpstan analyse --memory-limit=1G` (nivel del proyecto) →
  0 errores.

## Decisiones y riesgos

- Se agregó `VehiclePolicy::view()` como método nuevo (no se reutilizó
  `update()`) para que la intención de cada regla quede explícita, aunque
  hoy la lógica sea idéntica — es el mismo criterio que ya separa `create()`
  de `update()` en la misma Policy.
- No se corrieron los scripts de conformidad de
  `laravel-feature-workflow`/`laravel-api-review`/`laravel-security-review`
  (`static_conformance.py`, `architecture_check.py`, `security_check.py`):
  esta corrida no tuvo Python disponible en el entorno (solo el stub de
  Microsoft Store). Se compensó con una revisión manual: el endpoint replica
  exactamente el patrón ya usado (y ya revisado) en
  `UpdateVehicleController`/`UpdateVehicleRequest`, sin Action nueva, sin
  campos sensibles nuevos, sin SQL crudo ni mass assignment. Recomiendo que
  el revisor corra esos scripts si tiene Python disponible.