### PR TITLE
feat(#62): subir y consultar documentos de verificación del conductor

### DIFF
--- a/app/Actions/Documents/UploadDriverDocumentAction.php
+++ b/app/Actions/Documents/UploadDriverDocumentAction.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Documents;
+
+use App\DTOs\DriverDocumentUpload;
+use App\Enums\DocumentStatus;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Guarda el documento de un conductor y lo deja pendiente de revisión.
+ *
+ * Un documento por tipo y conductor (índice único de `driver_documents`):
+ * volver a subir el mismo tipo reemplaza el archivo y la fila existentes en
+ * vez de acumular versiones, y el documento vuelve a `Pending` aunque ya
+ * hubiera sido aprobado o rechazado —es un archivo distinto, así que hay que
+ * revisarlo de nuevo.
+ *
+ * El archivo se guarda en el disco `local` (privado, `storage/app/private`):
+ * son documentos de identidad, y ese disco no se sirve por una URL pública
+ * como el disco `public`.
+ */
+final class UploadDriverDocumentAction
+{
+    public function handle(DriverProfile $profile, DriverDocumentUpload $upload): DriverDocument
+    {
+        $existente = $profile->documents()->where('type', $upload->type)->first();
+
+        if ($existente instanceof DriverDocument) {
+            Storage::disk('local')->delete($existente->path);
+        }
+
+        $path = $upload->file->store("driver-documents/{$profile->id}", 'local');
+
+        return $profile->documents()->updateOrCreate(
+            ['type' => $upload->type],
+            [
+                'path' => $path,
+                'status' => DocumentStatus::Pending,
+                'rejection_reason' => null,
+                'reviewed_at' => null,
+            ],
+        );
+    }
+}

--- a/app/DTOs/DriverDocumentUpload.php
+++ b/app/DTOs/DriverDocumentUpload.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Enums\DocumentType;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * El documento que un conductor sube para su verificación, ya validado.
+ *
+ * No lleva el conductor dueño, mismo criterio que `VehicleRegistration`: de
+ * quién es el documento lo decide quien invoca la Action —el guard, en el
+ * caso del endpoint— y nunca la entrada.
+ */
+final readonly class DriverDocumentUpload
+{
+    public function __construct(
+        public DocumentType $type,
+        public UploadedFile $file,
+    ) {}
+}

--- a/app/Enums/DocumentStatus.php
+++ b/app/Enums/DocumentStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Estado de revisión de un documento subido por un conductor.
+ *
+ * Los valores viajan tal cual a `driver_documents.status`.
+ */
+enum DocumentStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+}

--- a/app/Enums/DocumentType.php
+++ b/app/Enums/DocumentType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Los documentos que un conductor debe subir para quedar verificado.
+ *
+ * `Identidad` cubre cédula, cédula de extranjería o PTP indistintamente: no
+ * se distingue cuál de los tres es en esta etapa, porque para la verificación
+ * lo único que importa es que la persona pueda identificarse, no el tipo de
+ * documento con el que lo hace.
+ *
+ * Licencia de conducción y SOAT quedan fuera del alcance actual a propósito
+ * (decisión de negocio): hoy solo cédula/tarjeta de propiedad son
+ * obligatorias para operar. Si el negocio decide exigirlas más adelante, se
+ * agregan acá y a `required()`.
+ *
+ * Los valores viajan tal cual a `driver_documents.type`, y junto con
+ * `driver_profile_id` sostienen el índice único que garantiza un solo
+ * documento vigente de cada tipo por conductor (ver la migración): volver a
+ * subir el mismo tipo reemplaza el anterior, no lo duplica.
+ */
+enum DocumentType: string
+{
+    case Identidad = 'identidad';
+    case TarjetaPropiedad = 'tarjeta_propiedad';
+
+    /**
+     * Los documentos exigidos hoy para quedar verificado. Un conductor queda
+     * `Verified` cuando cada uno de estos tiene un `DriverDocument` en estado
+     * `Approved` (ver `DriverVerificationStatus`).
+     *
+     * @return array<int, self>
+     */
+    public static function required(): array
+    {
+        return [self::Identidad, self::TarjetaPropiedad];
+    }
+}

--- a/app/Enums/DriverVerificationStatus.php
+++ b/app/Enums/DriverVerificationStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Estado de verificación general del conductor, calculado a partir de sus
+ * `DriverDocument` (ver `DocumentType::required()`).
+ *
+ * Un conductor recién registrado empieza en `Pending` (default de la
+ * migración de `driver_profiles`). Que solo un conductor `Verified` pueda
+ * marcarse disponible es una regla de negocio pendiente de conectar en
+ * `UpdateDriverAvailabilityAction`, no algo que este enum imponga por sí solo.
+ */
+enum DriverVerificationStatus: string
+{
+    case Pending = 'pending';
+    case Verified = 'verified';
+    case Rejected = 'rejected';
+}

--- a/app/Http/Controllers/Api/V1/Documents/ShowDriverDocumentsController.php
+++ b/app/Http/Controllers/Api/V1/Documents/ShowDriverDocumentsController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Documents;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Documents\ShowDriverDocumentsRequest;
+use App\Http\Resources\DriverVerificationResource;
+
+/**
+ * GET /api/v1/me/documents
+ *
+ * Estado de verificación del conductor autenticado: qué documentos ya subió,
+ * en qué estado quedó cada uno, y el estado general.
+ */
+class ShowDriverDocumentsController extends Controller
+{
+    public function __invoke(ShowDriverDocumentsRequest $request): DriverVerificationResource
+    {
+        return new DriverVerificationResource($request->driverProfile()->load('documents'));
+    }
+}

--- a/app/Http/Controllers/Api/V1/Documents/UploadDriverDocumentController.php
+++ b/app/Http/Controllers/Api/V1/Documents/UploadDriverDocumentController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Documents;
+
+use App\Actions\Documents\UploadDriverDocumentAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Documents\UploadDriverDocumentRequest;
+use App\Http\Resources\DriverDocumentResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/me/documents
+ *
+ * Sube (o reemplaza) uno de los documentos de verificación del conductor
+ * autenticado: documento de identidad o tarjeta de propiedad del motocarro
+ * (ver `DocumentType`).
+ */
+class UploadDriverDocumentController extends Controller
+{
+    public function __invoke(
+        UploadDriverDocumentRequest $request,
+        UploadDriverDocumentAction $uploadDocument,
+    ): JsonResponse {
+        $document = $uploadDocument->handle($request->driverProfile(), $request->toUpload());
+
+        return (new DriverDocumentResource($document))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Documents/ShowDriverDocumentsRequest.php
+++ b/app/Http/Requests/Documents/ShowDriverDocumentsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Documents;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Entrada de GET /api/v1/me/documents — ver openapi.yaml.
+ */
+class ShowDriverDocumentsRequest extends FormRequest
+{
+    private ?DriverProfile $driverProfile = null;
+
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewAny', DriverDocument::class) ?? false;
+    }
+
+    /**
+     * Mismo criterio defensivo que `UploadDriverDocumentRequest::driverProfile()`.
+     */
+    public function driverProfile(): DriverProfile
+    {
+        if ($this->driverProfile instanceof DriverProfile) {
+            return $this->driverProfile;
+        }
+
+        $user = $this->user();
+        $profile = $user instanceof User ? $user->driverProfile : null;
+
+        if (! $profile instanceof DriverProfile) {
+            throw new NotFoundHttpException(
+                'No tienes un perfil de conductor.',
+            );
+        }
+
+        return $this->driverProfile = $profile;
+    }
+}

--- a/app/Http/Requests/Documents/UploadDriverDocumentRequest.php
+++ b/app/Http/Requests/Documents/UploadDriverDocumentRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Documents;
+
+use App\DTOs\DriverDocumentUpload;
+use App\Enums\DocumentType;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Validation\Rules\Enum;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Entrada de POST /api/v1/me/documents — ver openapi.yaml.
+ */
+class UploadDriverDocumentRequest extends FormRequest
+{
+    private ?DriverProfile $driverProfile = null;
+
+    /**
+     * Basta con el rol: `DriverDocumentPolicy::upload()` no depende de una
+     * fila (no hay id en la ruta), mismo criterio que
+     * `VehiclePolicy::create()` en `RegisterVehicleRequest`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('upload', DriverDocument::class) ?? false;
+    }
+
+    /**
+     * El perfil de la cuenta autenticada. Todo conductor tiene uno desde el
+     * registro (`RegisterDriverAction` crea cuenta y perfil juntos), pero se
+     * resuelve por la relación y no se asume, mismo criterio defensivo que
+     * `UpdateDriverAvailabilityRequest::driverProfile()`.
+     */
+    public function driverProfile(): DriverProfile
+    {
+        if ($this->driverProfile instanceof DriverProfile) {
+            return $this->driverProfile;
+        }
+
+        $user = $this->user();
+        $profile = $user instanceof User ? $user->driverProfile : null;
+
+        if (! $profile instanceof DriverProfile) {
+            throw new NotFoundHttpException(
+                'No tienes un perfil de conductor.',
+            );
+        }
+
+        return $this->driverProfile = $profile;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', new Enum(DocumentType::class)],
+            // 5 MB alcanza de sobra para una foto de documento; mimes ya
+            // descarta cualquier cosa que no sea imagen o PDF antes de
+            // guardarlo en disco.
+            'file' => ['required', 'file', 'mimes:jpg,jpeg,png,pdf', 'max:5120'],
+        ];
+    }
+
+    public function toUpload(): DriverDocumentUpload
+    {
+        /** @var UploadedFile $file */
+        $file = $this->file('file');
+
+        return new DriverDocumentUpload(
+            type: DocumentType::from($this->string('type')->toString()),
+            file: $file,
+        );
+    }
+}

--- a/app/Http/Resources/DriverDocumentResource.php
+++ b/app/Http/Resources/DriverDocumentResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DriverDocument;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el documento recién subido. No lleva el `id` de la fila ni el
+ * `driver_profile_id`, mismo criterio que `VehicleResource`: se llega al
+ * documento por la cuenta del token, nunca por un id propio.
+ *
+ * @property-read DriverDocument $resource
+ */
+class DriverDocumentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'type' => $this->resource->type->value,
+            'status' => $this->resource->status->value,
+            'uploaded_at' => $this->resource->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Resources/DriverVerificationResource.php
+++ b/app/Http/Resources/DriverVerificationResource.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Enums\DocumentType;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
+
+/**
+ * Serializa el estado de verificación de un conductor: el estado general y el
+ * detalle de cada uno de los documentos exigidos por `DocumentType::required()`,
+ * lo haya subido o no.
+ *
+ * @property-read DriverProfile $resource
+ */
+class DriverVerificationResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Collection<string, DriverDocument> $subidosPorTipo */
+        $subidosPorTipo = $this->resource->documents->keyBy(
+            fn (DriverDocument $documento): string => $documento->type->value,
+        );
+
+        return [
+            'verification_status' => $this->resource->verification_status->value,
+            'documents' => collect(DocumentType::required())
+                ->map(function (DocumentType $tipo) use ($subidosPorTipo): array {
+                    $documento = $subidosPorTipo->get($tipo->value);
+
+                    return [
+                        'type' => $tipo->value,
+                        'status' => $documento?->status->value,
+                        'rejection_reason' => $documento?->rejection_reason,
+                        'uploaded_at' => $documento?->created_at?->toISOString(),
+                    ];
+                })
+                ->values(),
+        ];
+    }
+}

--- a/app/Models/DriverDocument.php
+++ b/app/Models/DriverDocument.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\DocumentStatus;
+use App\Enums\DocumentType;
+use App\Policies\DriverDocumentPolicy;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * Un documento subido por un conductor para su verificación (documento de
+ * identidad o tarjeta de propiedad del motocarro; ver `DocumentType`).
+ *
+ * `path` apunta al disco `local` —privado, nunca servido por una URL
+ * pública como el disco `public`— porque son documentos de identidad.
+ *
+ * @property DocumentType $type
+ * @property string $path
+ * @property DocumentStatus $status
+ * @property string|null $rejection_reason
+ * @property Carbon|null $reviewed_at
+ */
+#[Fillable(['driver_profile_id', 'type', 'path', 'status', 'rejection_reason', 'reviewed_at'])]
+#[UsePolicy(DriverDocumentPolicy::class)]
+class DriverDocument extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'type' => DocumentType::class,
+            'status' => DocumentStatus::class,
+            'reviewed_at' => 'datetime',
+        ];
+    }
+
+    public function driverProfile(): BelongsTo
+    {
+        return $this->belongsTo(DriverProfile::class);
+    }
+}

--- a/app/Models/DriverProfile.php
+++ b/app/Models/DriverProfile.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\DriverVerificationStatus;
 use App\Policies\DriverProfilePolicy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -18,6 +20,7 @@ use Illuminate\Support\Carbon;
  * @property float|null $longitude
  * @property Carbon|null $location_updated_at
  * @property int $cancellation_count
+ * @property DriverVerificationStatus $verification_status
  */
 #[Fillable(['user_id', 'license_number', 'is_available', 'latitude', 'longitude', 'location_updated_at'])]
 #[UsePolicy(DriverProfilePolicy::class)]
@@ -33,11 +36,25 @@ class DriverProfile extends Model
             'longitude' => 'float',
             'location_updated_at' => 'datetime',
             'cancellation_count' => 'integer',
+            'verification_status' => DriverVerificationStatus::class,
         ];
     }
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Los documentos de verificación subidos por este conductor (cédula,
+     * licencia, SOAT, tarjeta de propiedad). No fillable a propósito: solo
+     * `UploadDriverDocumentAction` y la revisión de un administrador pueden
+     * cambiar `verification_status`, nunca la entrada del cliente.
+     *
+     * @return HasMany<DriverDocument, $this>
+     */
+    public function documents(): HasMany
+    {
+        return $this->hasMany(DriverDocument::class);
     }
 }

--- a/app/Policies/DriverDocumentPolicy.php
+++ b/app/Policies/DriverDocumentPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Quién puede subir y consultar los documentos de verificación de un
+ * conductor.
+ *
+ * A diferencia de `VehiclePolicy`, no hay una fila que comprobar como dueña:
+ * `POST /me/documents` y `GET /me/documents` no llevan id, y el documento (si
+ * existe) siempre pertenece al perfil de la cuenta del token. Por eso basta
+ * con el rol, mismo criterio que `VehiclePolicy::create()`.
+ */
+class DriverDocumentPolicy
+{
+    public function upload(User $user): bool
+    {
+        return $user->isDriver();
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $user->isDriver();
+    }
+}

--- a/database/factories/DriverDocumentFactory.php
+++ b/database/factories/DriverDocumentFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\DocumentStatus;
+use App\Enums\DocumentType;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DriverDocument>
+ */
+class DriverDocumentFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'driver_profile_id' => DriverProfile::factory(),
+            'type' => fake()->randomElement(DocumentType::cases()),
+            'path' => 'driver-documents/fake/'.fake()->uuid().'.jpg',
+            'status' => DocumentStatus::Pending,
+        ];
+    }
+
+    public function approved(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => DocumentStatus::Approved,
+            'reviewed_at' => now(),
+        ]);
+    }
+
+    public function rejected(string $reason = 'Foto ilegible'): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => DocumentStatus::Rejected,
+            'rejection_reason' => $reason,
+            'reviewed_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_09_04_000001_create_driver_documents_table.php
+++ b/database/migrations/2026_09_04_000001_create_driver_documents_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('driver_documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('driver_profile_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->string('path');
+            $table->string('status')->default('pending');
+            $table->string('rejection_reason')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+
+            // Un documento vigente por tipo y conductor: volver a subir el
+            // mismo tipo reemplaza la fila existente (ver
+            // UploadDriverDocumentAction), nunca crea un duplicado.
+            $table->unique(['driver_profile_id', 'type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('driver_documents');
+    }
+};

--- a/database/migrations/2026_09_04_000002_add_verification_status_to_driver_profiles_table.php
+++ b/database/migrations/2026_09_04_000002_add_verification_status_to_driver_profiles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            $table->string('verification_status')->default('pending');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('driver_profiles', function (Blueprint $table) {
+            $table->dropColumn('verification_status');
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1031,10 +1031,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
               example:
-                message: The file must be a file of type: jpg, jpeg, png, pdf.
+                message: "The file must be a file of type: jpg, jpeg, png, pdf."
                 errors:
                   file:
-                    - The file must be a file of type: jpg, jpeg, png, pdf.
+                    - "The file must be a file of type: jpg, jpeg, png, pdf."
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -878,6 +878,171 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me/documents:
+    get:
+      tags:
+        - Documents
+      operationId: showDriverDocuments
+      summary: Consultar el estado de mis documentos de verificación
+      description: >-
+        Estado de verificación del conductor autenticado: qué documentos ya
+        subió, en qué estado quedó cada uno (`pending`, `approved`,
+        `rejected`), y el estado general de la cuenta.
+
+        Siempre lista los documentos exigidos hoy (`identidad`,
+        `tarjeta_propiedad`) aunque el conductor todavía no haya subido
+        alguno — ese documento aparece con `status: null`. Licencia de
+        conducción y SOAT no son obligatorios en esta etapa (decisión de
+        negocio) y por eso no aparecen en la lista.
+
+        Cuelga de `/me` como el vehículo: se llega por el token, nunca por un
+        id propio. Requiere un token vigente y rol `driver`.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Estado de verificación de la cuenta autenticada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/DriverVerification"
+              example:
+                data:
+                  verification_status: pending
+                  documents:
+                    - type: identidad
+                      status: approved
+                      rejection_reason: null
+                      uploaded_at: "2026-09-04T15:00:00.000000Z"
+                    - type: tarjeta_propiedad
+                      status: null
+                      rejection_reason: null
+                      uploaded_at: null
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es de conductor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+    post:
+      tags:
+        - Documents
+      operationId: uploadDriverDocument
+      summary: Subir (o reemplazar) un documento de verificación
+      description: >-
+        Sube uno de los documentos de verificación del conductor autenticado:
+        `identidad` (cédula, cédula de extranjería o PTP, indistintamente) o
+        `tarjeta_propiedad` del motocarro.
+
+        Volver a subir el mismo `type` **reemplaza** el archivo y la fila
+        existentes, no los duplica: no es un alta-o-reemplazo condicional
+        como el vehículo, es siempre un reemplazo. El documento vuelve a
+        quedar `pending` aunque el anterior ya hubiera sido `approved` o
+        `rejected` —es un archivo distinto, así que hay que revisarlo de
+        nuevo (ver historia técnica #64, revisión por un administrador).
+
+        El archivo se guarda en almacenamiento privado, nunca en una URL
+        servida públicamente: son documentos de identidad.
+
+        Requiere un token vigente y rol `driver`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - type
+                - file
+              properties:
+                type:
+                  type: string
+                  enum: [identidad, tarjeta_propiedad]
+                  example: identidad
+                file:
+                  type: string
+                  format: binary
+                  description: Imagen (jpg/jpeg/png) o PDF, hasta 5 MB.
+      responses:
+        "201":
+          description: Documento guardado, pendiente de revisión.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/DriverDocument"
+              example:
+                data:
+                  type: identidad
+                  status: pending
+                  uploaded_at: "2026-09-04T15:00:00.000000Z"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es de conductor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: >-
+            La entrada no pasó la validación: falta el archivo o el tipo, el
+            tipo no es uno de los exigidos hoy, o el archivo no es una imagen
+            o PDF de hasta 5 MB.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The file must be a file of type: jpg, jpeg, png, pdf.
+                errors:
+                  file:
+                    - The file must be a file of type: jpg, jpeg, png, pdf.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /me/availability:
     patch:
       tags:
@@ -2585,6 +2750,76 @@ components:
           type: integer
           description: Año del modelo.
           example: 2022
+    DriverDocument:
+      type: object
+      description: >-
+        Un documento de verificación recién subido por un conductor. No lleva
+        `id` ni `driver_profile_id`, mismo criterio que `Vehicle`: se llega a
+        él por la cuenta que envía el token, nunca por un id propio.
+      required:
+        - type
+        - status
+        - uploaded_at
+      properties:
+        type:
+          type: string
+          enum: [identidad, tarjeta_propiedad]
+          example: identidad
+        status:
+          type: string
+          enum: [pending, approved, rejected]
+          example: pending
+        uploaded_at:
+          type: string
+          format: date-time
+          example: "2026-09-04T15:00:00.000000Z"
+    DriverVerification:
+      type: object
+      description: >-
+        Estado de verificación de un conductor: el general de la cuenta y el
+        detalle de cada documento exigido hoy (`identidad`,
+        `tarjeta_propiedad`), lo haya subido o no.
+      required:
+        - verification_status
+        - documents
+      properties:
+        verification_status:
+          type: string
+          enum: [pending, verified, rejected]
+          description: >-
+            `verified` solo cuando **todos** los documentos exigidos están
+            `approved`. Pasa a `rejected` en cuanto un administrador rechaza
+            cualquiera de ellos (ver historia técnica #64).
+          example: pending
+        documents:
+          type: array
+          items:
+            type: object
+            required:
+              - type
+              - status
+              - rejection_reason
+              - uploaded_at
+            properties:
+              type:
+                type: string
+                enum: [identidad, tarjeta_propiedad]
+                example: identidad
+              status:
+                type: string
+                enum: [pending, approved, rejected]
+                nullable: true
+                description: "`null` si el conductor todavía no subió este documento."
+                example: approved
+              rejection_reason:
+                type: string
+                nullable: true
+                example: null
+              uploaded_at:
+                type: string
+                format: date-time
+                nullable: true
+                example: "2026-09-04T15:00:00.000000Z"
     LoginRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Documents\ShowDriverDocumentsController;
+use App\Http\Controllers\Api\V1\Documents\UploadDriverDocumentController;
 use App\Http\Controllers\Api\V1\Drivers\ShowDriverEarningsController;
 use App\Http\Controllers\Api\V1\Drivers\UpdateDriverAvailabilityController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
@@ -117,6 +119,23 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me/availability', UpdateDriverAvailabilityController::class)
         ->name('drivers.availability');
+
+    // Documentos de verificación del conductor: documento de identidad
+    // (cédula, cédula de extranjería o PTP) y tarjeta de propiedad del
+    // motocarro — los únicos obligatorios hoy (decisión de negocio; ver
+    // DocumentType). Cuelgan de `me` como el vehículo y la disponibilidad: se
+    // llega por el token, nunca por un id propio. Volver a subir un tipo ya
+    // existente lo reemplaza (ver UploadDriverDocumentAction), no lo
+    // duplica. Que solo un conductor `verified` pueda marcarse disponible es
+    // una regla pendiente de conectar en UpdateDriverAvailabilityAction, no
+    // algo que este endpoint imponga.
+    Route::middleware('auth:api')
+        ->post('me/documents', UploadDriverDocumentController::class)
+        ->name('documents.store');
+
+    Route::middleware('auth:api')
+        ->get('me/documents', ShowDriverDocumentsController::class)
+        ->name('documents.show');
 
     // Historial de viajes de la cuenta autenticada: los que pidió, si es
     // pasajero (historia #29), o los que le asignaron, si es conductor

--- a/tests/Feature/Documents/ShowDriverDocumentsTest.php
+++ b/tests/Feature/Documents/ShowDriverDocumentsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Documents;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/me/documents — ver openapi.yaml.
+ */
+class ShowDriverDocumentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/documents';
+
+    private function conductorConPerfil(): User
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        return $conductor->fresh();
+    }
+
+    public function test_lista_los_documentos_obligatorios_sin_subir_nada_todavia(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonPath('data.verification_status', 'pending')
+            ->assertJsonCount(2, 'data.documents');
+
+        $tipos = collect($respuesta->json('data.documents'))->pluck('type')->all();
+        $this->assertSame(['identidad', 'tarjeta_propiedad'], $tipos);
+
+        foreach ($respuesta->json('data.documents') as $documento) {
+            $this->assertNull($documento['status']);
+        }
+    }
+
+    public function test_muestra_el_estado_real_de_los_documentos_ya_subidos(): void
+    {
+        $conductor = $this->conductorConPerfil();
+        $perfil = $conductor->driverProfile;
+
+        DriverDocument::factory()->approved()->create(['driver_profile_id' => $perfil->id, 'type' => 'identidad']);
+        DriverDocument::factory()->rejected('Foto borrosa')->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'tarjeta_propiedad',
+        ]);
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->getJson(self::URI)
+            ->assertOk();
+
+        $porTipo = collect($respuesta->json('data.documents'))->keyBy('type');
+
+        $this->assertSame('approved', $porTipo['identidad']['status']);
+        $this->assertSame('rejected', $porTipo['tarjeta_propiedad']['status']);
+        $this->assertSame('Foto borrosa', $porTipo['tarjeta_propiedad']['rejection_reason']);
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_consultar_documentos_de_conductor(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson(self::URI)
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_consulta_sin_token(): void
+    {
+        $this->getJson(self::URI)->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Documents/UploadDriverDocumentTest.php
+++ b/tests/Feature/Documents/UploadDriverDocumentTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Documents;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/me/documents — ver openapi.yaml.
+ *
+ * Un conductor no queda verificado hasta que un administrador revisa sus
+ * documentos (historia pendiente); lo que fija esta suite es que el archivo
+ * quede del conductor dueño del token, en el disco privado, y que volver a
+ * subir el mismo tipo reemplace la fila y el archivo anteriores en vez de
+ * acumularlos.
+ */
+class UploadDriverDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/documents';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+    }
+
+    private function conductorConPerfil(): User
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        return $conductor->fresh();
+    }
+
+    /**
+     * `UploadedFile::fake()->create()` y no `->image()`: este último exige la
+     * extensión GD, que ni el entorno local ni el runner de CI (ver
+     * .github/workflows/ci.yml) tienen instalada.
+     */
+    private function archivoFalso(string $nombre = 'cedula.jpg'): UploadedFile
+    {
+        return UploadedFile::fake()->create($nombre, 100, 'image/jpeg');
+    }
+
+    public function test_sube_el_documento_y_lo_asocia_al_perfil_del_conductor(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'type' => 'identidad',
+                'file' => $this->archivoFalso(),
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.type', 'identidad')
+            ->assertJsonPath('data.status', 'pending');
+
+        $documento = DriverDocument::query()->first();
+
+        $this->assertNotNull($documento);
+        $this->assertSame($conductor->driverProfile->id, $documento->driver_profile_id);
+        Storage::disk('local')->assertExists($documento->path);
+    }
+
+    public function test_el_archivo_queda_en_el_disco_privado_y_no_en_el_publico(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'type' => 'tarjeta_propiedad',
+                'file' => $this->archivoFalso('tarjeta.jpg'),
+            ])
+            ->assertCreated();
+
+        $documento = DriverDocument::query()->firstOrFail();
+
+        // No es una ruta bajo `storage/` públicamente accesible: el path
+        // guardado es relativo al disco `local`, que sirve de `storage/app/private`.
+        $this->assertStringStartsWith('driver-documents/', $documento->path);
+    }
+
+    public function test_volver_a_subir_el_mismo_tipo_reemplaza_el_documento_anterior(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, ['type' => 'identidad', 'file' => $this->archivoFalso('cedula-vieja.jpg')])
+            ->assertCreated();
+
+        $rutaAnterior = DriverDocument::query()->firstOrFail()->path;
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, ['type' => 'identidad', 'file' => $this->archivoFalso('cedula-nueva.jpg')])
+            ->assertCreated();
+
+        $this->assertDatabaseCount('driver_documents', 1);
+        Storage::disk('local')->assertMissing($rutaAnterior);
+    }
+
+    public function test_un_documento_rechazado_vuelve_a_pending_al_resubirse(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        DriverDocument::factory()->rejected()->create([
+            'driver_profile_id' => $conductor->driverProfile->id,
+            'type' => 'tarjeta_propiedad',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'type' => 'tarjeta_propiedad',
+                'file' => $this->archivoFalso('tarjeta.jpg'),
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.status', 'pending');
+
+        $documento = DriverDocument::query()->firstOrFail();
+        $this->assertNull($documento->rejection_reason);
+    }
+
+    public function test_rechaza_un_tipo_de_archivo_no_permitido(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                'type' => 'identidad',
+                'file' => UploadedFile::fake()->create('cedula.exe', 100),
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('file');
+
+        $this->assertDatabaseCount('driver_documents', 0);
+    }
+
+    public function test_rechaza_un_tipo_de_documento_desconocido(): void
+    {
+        $conductor = $this->conductorConPerfil();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, [
+                // La licencia de conducción no es obligatoria hoy (decisión de
+                // negocio; ver DocumentType), así que sigue sin ser un tipo
+                // válido para este endpoint.
+                'type' => 'licencia',
+                'file' => $this->archivoFalso('doc.jpg'),
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('type');
+    }
+
+    public function test_la_cuenta_de_pasajero_no_puede_subir_documentos(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [
+                'type' => 'identidad',
+                'file' => $this->archivoFalso(),
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseCount('driver_documents', 0);
+    }
+
+    public function test_rechaza_la_subida_sin_token(): void
+    {
+        $this->postJson(self::URI, [
+            'type' => 'identidad',
+            'file' => $this->archivoFalso(),
+        ])->assertUnauthorized();
+    }
+}

--- a/tests/Unit/Actions/Documents/UploadDriverDocumentActionTest.php
+++ b/tests/Unit/Actions/Documents/UploadDriverDocumentActionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Documents;
+
+use App\Actions\Documents\UploadDriverDocumentAction;
+use App\DTOs\DriverDocumentUpload;
+use App\Enums\DocumentStatus;
+use App\Enums\DocumentType;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UploadDriverDocumentActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_el_documento_en_estado_pendiente(): void
+    {
+        Storage::fake('local');
+
+        $perfil = DriverProfile::factory()->create();
+        $action = new UploadDriverDocumentAction;
+
+        $documento = $action->handle($perfil, new DriverDocumentUpload(
+            type: DocumentType::Identidad,
+            file: UploadedFile::fake()->create('cedula.jpg', 100, 'image/jpeg'),
+        ));
+
+        $this->assertSame(DocumentStatus::Pending, $documento->status);
+        $this->assertSame($perfil->id, $documento->driver_profile_id);
+        Storage::disk('local')->assertExists($documento->path);
+    }
+
+    public function test_reemplazar_el_documento_borra_el_archivo_anterior(): void
+    {
+        Storage::fake('local');
+
+        $perfil = DriverProfile::factory()->create();
+        $action = new UploadDriverDocumentAction;
+
+        $primero = $action->handle($perfil, new DriverDocumentUpload(
+            type: DocumentType::TarjetaPropiedad,
+            file: UploadedFile::fake()->create('tarjeta-1.jpg', 100, 'image/jpeg'),
+        ));
+        $rutaAnterior = $primero->path;
+
+        $segundo = $action->handle($perfil, new DriverDocumentUpload(
+            type: DocumentType::TarjetaPropiedad,
+            file: UploadedFile::fake()->create('tarjeta-2.jpg', 100, 'image/jpeg'),
+        ));
+
+        $this->assertSame($primero->id, $segundo->id);
+        $this->assertSame(1, DriverDocument::query()->count());
+        Storage::disk('local')->assertMissing($rutaAnterior);
+    }
+}

--- a/tests/Unit/Policies/DriverDocumentPolicyTest.php
+++ b/tests/Unit/Policies/DriverDocumentPolicyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Policies;
+
+use App\Models\User;
+use App\Policies\DriverDocumentPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DriverDocumentPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_un_conductor_puede_subir_y_consultar_sus_documentos(): void
+    {
+        $policy = new DriverDocumentPolicy;
+        $conductor = User::factory()->driver()->create();
+
+        $this->assertTrue($policy->upload($conductor));
+        $this->assertTrue($policy->viewAny($conductor));
+    }
+
+    public function test_un_pasajero_no_puede_subir_ni_consultar_documentos_de_conductor(): void
+    {
+        $policy = new DriverDocumentPolicy;
+        $pasajero = User::factory()->create();
+
+        $this->assertFalse($policy->upload($pasajero));
+        $this->assertFalse($policy->viewAny($pasajero));
+    }
+}


### PR DESCRIPTION
## Resumen
- El conductor puede subir (o reemplazar) su documento de identidad y la tarjeta de propiedad del motocarro.
- El conductor puede consultar el estado de cada documento obligatorio (`GET /api/v1/me/documents`).
- Los archivos se guardan en el disco privado, no en uno público.

Closes #62

## Plan de pruebas
- [x] `php artisan test` — 663 tests en verde (647 previos + 16 nuevos).
- [x] `vendor/bin/pint --test` sin errores.
- [x] `vendor/bin/phpstan analyse` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)