### PR TITLE
feat(#64): revisar y aprobar/rechazar documentos del conductor

### DIFF
--- a/app/Actions/Documents/ApproveDriverDocumentAction.php
+++ b/app/Actions/Documents/ApproveDriverDocumentAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Documents;
+
+use App\Enums\DocumentStatus;
+use App\Enums\DocumentType;
+use App\Enums\DriverVerificationStatus;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Support\Facades\Date;
+use RuntimeException;
+
+/**
+ * Aprueba un documento de verificación pendiente (historia técnica #64).
+ *
+ * Que el documento esté `pending` lo comprueba `ApproveDriverDocumentRequest`
+ * antes de llegar acá (422 si no lo está), mismo criterio que
+ * `CompleteRideAction` con el estado del viaje: esta Action asume una
+ * transición válida y no vuelve a validarla.
+ *
+ * Si con esta aprobación el conductor queda con **todos** los documentos
+ * exigidos (`DocumentType::required()`) en `approved`, su perfil pasa a
+ * `verified`. Si todavía falta alguno, el perfil no cambia: puede seguir
+ * `pending` (nunca vuelve de `rejected` a `verified` solo por una aprobación
+ * parcial, porque nada en este flujo pone a un perfil `rejected` a mitad de
+ * camino salvo un rechazo explícito).
+ */
+final class ApproveDriverDocumentAction
+{
+    public function handle(DriverDocument $document): DriverDocument
+    {
+        $document->update([
+            'status' => DocumentStatus::Approved,
+            'reviewed_at' => Date::now(),
+        ]);
+
+        $profile = $document->driverProfile;
+
+        // `driver_profile_id` es NOT NULL (ver la migración), así que esto
+        // siempre es cierto: la comprobación es para PHPStan, que no puede
+        // inferir el modelo relacionado de una propiedad dinámica, no un caso
+        // real. Mismo criterio que `RejectDriverDocumentAction`.
+        if (! $profile instanceof DriverProfile) {
+            throw new RuntimeException('DriverDocument sin driver_profile asociado.');
+        }
+
+        if ($this->tieneTodosLosDocumentosAprobados($profile)) {
+            $profile->verification_status = DriverVerificationStatus::Verified;
+            $profile->save();
+        }
+
+        return $document->refresh();
+    }
+
+    private function tieneTodosLosDocumentosAprobados(DriverProfile $profile): bool
+    {
+        $tiposAprobados = $profile->documents()
+            ->where('status', DocumentStatus::Approved)
+            ->pluck('type');
+
+        return collect(DocumentType::required())
+            ->every(fn (DocumentType $tipo): bool => $tiposAprobados->contains($tipo));
+    }
+}

--- a/app/Actions/Documents/RejectDriverDocumentAction.php
+++ b/app/Actions/Documents/RejectDriverDocumentAction.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Documents;
+
+use App\Enums\DocumentStatus;
+use App\Enums\DriverVerificationStatus;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Support\Facades\Date;
+use RuntimeException;
+
+/**
+ * Rechaza un documento de verificación pendiente, con un motivo (historia
+ * técnica #64).
+ *
+ * Que el documento esté `pending` lo comprueba `RejectDriverDocumentRequest`
+ * antes de llegar acá, mismo criterio que `ApproveDriverDocumentAction`.
+ *
+ * A diferencia de aprobar, rechazar **siempre** pone el perfil en `rejected`,
+ * sin comprobar el resto de los documentos: alcanza con que uno esté mal
+ * para que el conductor no pueda operar todavía, y el conductor corrige
+ * resubiendo ese documento (`POST /me/documents`, que vuelve a dejarlo
+ * `pending`).
+ */
+final class RejectDriverDocumentAction
+{
+    public function handle(DriverDocument $document, string $reason): DriverDocument
+    {
+        $document->update([
+            'status' => DocumentStatus::Rejected,
+            'rejection_reason' => $reason,
+            'reviewed_at' => Date::now(),
+        ]);
+
+        $profile = $document->driverProfile;
+
+        // `driver_profile_id` es NOT NULL (ver la migración), así que esto
+        // siempre es cierto: la comprobación es para PHPStan, que no puede
+        // inferir el modelo relacionado de una propiedad dinámica, no un caso
+        // real. Mismo criterio que `ApproveDriverDocumentAction`.
+        if (! $profile instanceof DriverProfile) {
+            throw new RuntimeException('DriverDocument sin driver_profile asociado.');
+        }
+
+        $profile->verification_status = DriverVerificationStatus::Rejected;
+        $profile->save();
+
+        return $document->refresh();
+    }
+}

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -8,4 +8,12 @@ enum UserRole: string
 {
     case Passenger = 'passenger';
     case Driver = 'driver';
+
+    /**
+     * Staff que revisa documentos de verificación de conductores (historia
+     * técnica #64). No tiene endpoint de registro propio: una cuenta admin se
+     * crea manualmente (seeder o `tinker`), nunca por un flujo público como
+     * `register/driver` o `register/passenger`.
+     */
+    case Admin = 'admin';
 }

--- a/app/Http/Controllers/Api/V1/Admin/ApproveDriverDocumentController.php
+++ b/app/Http/Controllers/Api/V1/Admin/ApproveDriverDocumentController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Actions\Documents\ApproveDriverDocumentAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ApproveDriverDocumentRequest;
+use App\Http\Resources\AdminDriverDocumentResource;
+use App\Models\DriverDocument;
+
+/**
+ * POST /api/v1/admin/documents/{document}/approve
+ *
+ * Aprueba un documento de verificación pendiente (historia técnica #64).
+ *
+ * El parámetro `DriverDocument $document` es lo que hace que Laravel
+ * resuelva el binding implícito de la ruta, igual que en
+ * `CompleteRideController`; sin él, `$request->document()` recibiría el id
+ * en crudo en vez del modelo.
+ */
+class ApproveDriverDocumentController extends Controller
+{
+    public function __invoke(
+        ApproveDriverDocumentRequest $request,
+        ApproveDriverDocumentAction $approveDocument,
+        DriverDocument $document,
+    ): AdminDriverDocumentResource {
+        $document = $approveDocument->handle($request->document());
+
+        return new AdminDriverDocumentResource($document->load('driverProfile.user'));
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/ListDriverDocumentsController.php
+++ b/app/Http/Controllers/Api/V1/Admin/ListDriverDocumentsController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ListDriverDocumentsRequest;
+use App\Http\Resources\AdminDriverDocumentResource;
+use App\Models\DriverDocument;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * GET /api/v1/admin/documents
+ *
+ * Lista los documentos de verificación de conductores para que un
+ * administrador los revise (historia técnica #64). Sin `status`, lista los
+ * `pending` — es la cola de trabajo del administrador.
+ */
+class ListDriverDocumentsController extends Controller
+{
+    public function __invoke(ListDriverDocumentsRequest $request): AnonymousResourceCollection
+    {
+        $documents = DriverDocument::query()
+            ->with('driverProfile.user')
+            ->where('status', $request->status())
+            ->latest()
+            ->get();
+
+        return AdminDriverDocumentResource::collection($documents);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/RejectDriverDocumentController.php
+++ b/app/Http/Controllers/Api/V1/Admin/RejectDriverDocumentController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Actions\Documents\RejectDriverDocumentAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\RejectDriverDocumentRequest;
+use App\Http\Resources\AdminDriverDocumentResource;
+use App\Models\DriverDocument;
+
+/**
+ * POST /api/v1/admin/documents/{document}/reject
+ *
+ * Rechaza un documento de verificación pendiente, con un motivo (historia
+ * técnica #64).
+ *
+ * El parámetro `DriverDocument $document` es lo que hace que Laravel
+ * resuelva el binding implícito de la ruta, mismo criterio que
+ * `ApproveDriverDocumentController`.
+ */
+class RejectDriverDocumentController extends Controller
+{
+    public function __invoke(
+        RejectDriverDocumentRequest $request,
+        RejectDriverDocumentAction $rejectDocument,
+        DriverDocument $document,
+    ): AdminDriverDocumentResource {
+        $document = $rejectDocument->handle($request->document(), $request->reason());
+
+        return new AdminDriverDocumentResource($document->load('driverProfile.user'));
+    }
+}

--- a/app/Http/Requests/Admin/ApproveDriverDocumentRequest.php
+++ b/app/Http/Requests/Admin/ApproveDriverDocumentRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\DocumentStatus;
+use App\Models\DriverDocument;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/admin/documents/{document}/approve — ver openapi.yaml.
+ */
+class ApproveDriverDocumentRequest extends FormRequest
+{
+    /**
+     * `{document}` resuelve por binding implícito de la ruta, igual que
+     * `{ride}` en `CompleteRideRequest`: un id inexistente sale como 404
+     * antes de que se evalúe `authorize()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('review', $this->document()) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * documento de la ruta.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectDocumentNotPending(...),
+        ];
+    }
+
+    /**
+     * Que el documento no esté `pending` no es un problema de permisos —el
+     * administrador sigue siéndolo— sino de en qué punto de revisión está:
+     * por eso es 422 y no 403, mismo criterio que
+     * `CompleteRideRequest::rejectRideNotInProgress()`, con el error bajo la
+     * clave `document`, que tampoco es un campo de la entrada.
+     */
+    private function rejectDocumentNotPending(Validator $validator): void
+    {
+        if ($this->document()->status !== DocumentStatus::Pending) {
+            $validator->errors()->add(
+                'document',
+                'Solo se puede revisar un documento pendiente.',
+            );
+        }
+    }
+
+    public function document(): DriverDocument
+    {
+        /** @var DriverDocument */
+        return $this->route('document');
+    }
+}

--- a/app/Http/Requests/Admin/ListDriverDocumentsRequest.php
+++ b/app/Http/Requests/Admin/ListDriverDocumentsRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\DocumentStatus;
+use App\Models\DriverDocument;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Entrada de GET /api/v1/admin/documents — ver openapi.yaml.
+ */
+class ListDriverDocumentsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('reviewAny', DriverDocument::class) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['sometimes', new Enum(DocumentStatus::class)],
+        ];
+    }
+
+    /**
+     * `pending` por defecto: es la cola de trabajo del administrador, y sin
+     * filtro explícito es lo único que le importa consultar.
+     */
+    public function status(): DocumentStatus
+    {
+        return $this->filled('status')
+            ? DocumentStatus::from($this->string('status')->toString())
+            : DocumentStatus::Pending;
+    }
+}

--- a/app/Http/Requests/Admin/RejectDriverDocumentRequest.php
+++ b/app/Http/Requests/Admin/RejectDriverDocumentRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\DocumentStatus;
+use App\Models\DriverDocument;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/admin/documents/{document}/reject — ver openapi.yaml.
+ */
+class RejectDriverDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('review', $this->document()) ?? false;
+    }
+
+    /**
+     * `reason` es obligatorio: sin motivo el conductor no sabría qué
+     * corregir antes de volver a subir el documento.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->rejectDocumentNotPending(...),
+        ];
+    }
+
+    /**
+     * Mismo criterio que `ApproveDriverDocumentRequest::rejectDocumentNotPending()`.
+     */
+    private function rejectDocumentNotPending(Validator $validator): void
+    {
+        if ($this->document()->status !== DocumentStatus::Pending) {
+            $validator->errors()->add(
+                'document',
+                'Solo se puede revisar un documento pendiente.',
+            );
+        }
+    }
+
+    public function document(): DriverDocument
+    {
+        /** @var DriverDocument */
+        return $this->route('document');
+    }
+
+    public function reason(): string
+    {
+        return $this->string('reason')->toString();
+    }
+}

--- a/app/Http/Resources/AdminDriverDocumentResource.php
+++ b/app/Http/Resources/AdminDriverDocumentResource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use RuntimeException;
+
+/**
+ * Serializa un documento tal como lo ve un administrador (historia técnica
+ * #64): a diferencia de `DriverDocumentResource`, sí lleva `id` —es por lo
+ * que se lo referencia en `/admin/documents/{document}/approve|reject`— y a
+ * qué conductor pertenece.
+ *
+ * @property-read DriverDocument $resource
+ */
+class AdminDriverDocumentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $perfil = $this->resource->driverProfile;
+
+        // `driver_profile_id` en `driver_documents` y `user_id` en
+        // `driver_profiles` son NOT NULL, así que esto siempre es cierto: la
+        // comprobación es para PHPStan, que no puede inferir el modelo
+        // relacionado de una propiedad dinámica, no un caso real. El
+        // controller siempre precarga `driverProfile.user` antes de construir
+        // este recurso.
+        if (! $perfil instanceof DriverProfile || ! $perfil->user instanceof User) {
+            throw new RuntimeException('DriverDocument sin driver_profile.user asociado.');
+        }
+
+        $conductor = $perfil->user;
+
+        return [
+            'id' => $this->resource->id,
+            'driver' => [
+                'id' => $conductor->id,
+                'name' => $conductor->name,
+            ],
+            'type' => $this->resource->type->value,
+            'status' => $this->resource->status->value,
+            'uploaded_at' => $this->resource->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -90,6 +90,11 @@ class User extends Authenticatable implements JWTSubject
         return $this->role === UserRole::Passenger;
     }
 
+    public function isAdmin(): bool
+    {
+        return $this->role === UserRole::Admin;
+    }
+
     /**
      * Identificador que viaja en el claim `sub` del JWT.
      */

--- a/app/Policies/DriverDocumentPolicy.php
+++ b/app/Policies/DriverDocumentPolicy.php
@@ -4,16 +4,24 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\DriverDocument;
 use App\Models\User;
 
 /**
- * Quién puede subir y consultar los documentos de verificación de un
- * conductor.
+ * Quién puede subir, consultar y revisar los documentos de verificación de
+ * un conductor.
  *
- * A diferencia de `VehiclePolicy`, no hay una fila que comprobar como dueña:
- * `POST /me/documents` y `GET /me/documents` no llevan id, y el documento (si
- * existe) siempre pertenece al perfil de la cuenta del token. Por eso basta
- * con el rol, mismo criterio que `VehiclePolicy::create()`.
+ * A diferencia de `VehiclePolicy`, `upload()`/`viewAny()` no comprueban una
+ * fila como dueña: `POST /me/documents` y `GET /me/documents` no llevan id,
+ * y el documento (si existe) siempre pertenece al perfil de la cuenta del
+ * token. Por eso basta con el rol, mismo criterio que `VehiclePolicy::create()`.
+ *
+ * `review()`/`reviewAny()` (historia técnica #64) tampoco dependen de la fila:
+ * cualquier administrador puede revisar cualquier documento, no hay noción de
+ * "documento propio" para ese rol. Se recibe la instancia igual, mismo
+ * criterio que el resto de las Policies de este proyecto, por si en el
+ * futuro la autorización de revisión llegara a depender de algo del
+ * documento (por ejemplo, un administrador limitado a cierta región).
  */
 class DriverDocumentPolicy
 {
@@ -25,5 +33,15 @@ class DriverDocumentPolicy
     public function viewAny(User $user): bool
     {
         return $user->isDriver();
+    }
+
+    public function reviewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function review(User $user, DriverDocument $document): bool
+    {
+        return $user->isAdmin();
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -45,4 +45,11 @@ class UserFactory extends Factory
             'role' => UserRole::Driver,
         ]);
     }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => UserRole::Admin,
+        ]);
+    }
 }

--- a/database/migrations/2026_09_05_000001_add_admin_to_users_role_enum.php
+++ b/database/migrations/2026_09_05_000001_add_admin_to_users_role_enum.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['passenger', 'driver', 'admin'])->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['passenger', 'driver'])->change();
+        });
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1043,6 +1043,270 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /admin/documents:
+    get:
+      tags:
+        - Documents
+      operationId: listAdminDriverDocuments
+      summary: Listar documentos de verificación para revisar
+      description: >-
+        Lista los documentos de verificación de conductores para que un
+        administrador los revise (historia técnica #64). Sin `status`, lista
+        los `pending`; con `status`, filtra por ese estado.
+
+        Requiere un token vigente y rol `admin`. No hay endpoint de registro
+        para este rol: una cuenta admin se crea manualmente.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [pending, approved, rejected]
+          example: pending
+      responses:
+        "200":
+          description: Documentos que coinciden con el filtro, más recientes primero.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AdminDriverDocument"
+              example:
+                data:
+                  - id: 10
+                    driver:
+                      id: 3
+                      name: Carlos Ramírez
+                    type: identidad
+                    status: pending
+                    uploaded_at: "2026-09-04T15:00:00.000000Z"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /admin/documents/{document}/approve:
+    post:
+      tags:
+        - Documents
+      operationId: approveDriverDocument
+      summary: Aprobar un documento de verificación
+      description: >-
+        Aprueba un documento `pending` de un conductor (historia técnica
+        #64). Si con esta aprobación el conductor queda con **todos** los
+        documentos exigidos (`identidad`, `tarjeta_propiedad`) en
+        `approved`, su `verification_status` pasa a `verified`.
+
+        Solo se puede aprobar un documento `pending`: uno ya `approved` o
+        `rejected` responde 422, porque revisar dos veces la misma fila no es
+        un caso soportado (el conductor tendría que volver a subirlo).
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: document
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 10
+      responses:
+        "200":
+          description: Documento aprobado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AdminDriverDocument"
+              example:
+                data:
+                  id: 10
+                  driver:
+                    id: 3
+                    name: Carlos Ramírez
+                  type: identidad
+                  status: approved
+                  uploaded_at: "2026-09-04T15:00:00.000000Z"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe un documento con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No query results for model [App\\Models\\DriverDocument] 10
+        "422":
+          description: El documento no está `pending`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Solo se puede revisar un documento pendiente.
+                errors:
+                  document:
+                    - Solo se puede revisar un documento pendiente.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /admin/documents/{document}/reject:
+    post:
+      tags:
+        - Documents
+      operationId: rejectDriverDocument
+      summary: Rechazar un documento de verificación
+      description: >-
+        Rechaza un documento `pending` de un conductor con un motivo
+        obligatorio, para que sepa qué corregir (historia técnica #64). El
+        `verification_status` del conductor pasa a `rejected`.
+
+        Mismo criterio que aprobar: solo se puede rechazar un documento
+        `pending`. El conductor corrige y vuelve a subir el documento
+        (`POST /me/documents`), que vuelve a quedar `pending`.
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: document
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 10
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  maxLength: 255
+                  example: La foto está borrosa, no se alcanza a leer el nombre.
+            example:
+              reason: La foto está borrosa, no se alcanza a leer el nombre.
+      responses:
+        "200":
+          description: Documento rechazado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AdminDriverDocument"
+              example:
+                data:
+                  id: 10
+                  driver:
+                    id: 3
+                    name: Carlos Ramírez
+                  type: identidad
+                  status: rejected
+                  uploaded_at: "2026-09-04T15:00:00.000000Z"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe un documento con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No query results for model [App\\Models\\DriverDocument] 10
+        "422":
+          description: El documento no está `pending`, o falta el motivo.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The reason field is required.
+                errors:
+                  reason:
+                    - The reason field is required.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /me/availability:
     patch:
       tags:
@@ -2820,6 +3084,47 @@ components:
                 format: date-time
                 nullable: true
                 example: "2026-09-04T15:00:00.000000Z"
+    AdminDriverDocument:
+      type: object
+      description: >-
+        Un documento de verificación tal como lo ve un administrador: a
+        diferencia de `DriverDocument`, sí lleva `id` (es por lo que se lo
+        referencia en `/admin/documents/{document}/approve|reject`) y a qué
+        conductor pertenece.
+      required:
+        - id
+        - driver
+        - type
+        - status
+        - uploaded_at
+      properties:
+        id:
+          type: integer
+          example: 10
+        driver:
+          type: object
+          required:
+            - id
+            - name
+          properties:
+            id:
+              type: integer
+              example: 3
+            name:
+              type: string
+              example: Carlos Ramírez
+        type:
+          type: string
+          enum: [identidad, tarjeta_propiedad]
+          example: identidad
+        status:
+          type: string
+          enum: [pending, approved, rejected]
+          example: pending
+        uploaded_at:
+          type: string
+          format: date-time
+          example: "2026-09-04T15:00:00.000000Z"
     LoginRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\Api\V1\Admin\ApproveDriverDocumentController;
+use App\Http\Controllers\Api\V1\Admin\ListDriverDocumentsController;
+use App\Http\Controllers\Api\V1\Admin\RejectDriverDocumentController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
@@ -136,6 +139,25 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->get('me/documents', ShowDriverDocumentsController::class)
         ->name('documents.show');
+
+    // Revisión de documentos por un administrador (historia técnica #64).
+    // No cuelgan de `me`: el administrador no es dueño de los documentos que
+    // revisa, es staff operando sobre los de terceros. La autorización (solo
+    // `admin`) vive en `DriverDocumentPolicy::reviewAny()`/`review()`, no acá
+    // — mismo criterio que el resto de la API.
+    Route::prefix('admin')->name('admin.')->group(function () {
+        Route::middleware('auth:api')
+            ->get('documents', ListDriverDocumentsController::class)
+            ->name('documents.index');
+
+        Route::middleware('auth:api')
+            ->post('documents/{document}/approve', ApproveDriverDocumentController::class)
+            ->name('documents.approve');
+
+        Route::middleware('auth:api')
+            ->post('documents/{document}/reject', RejectDriverDocumentController::class)
+            ->name('documents.reject');
+    });
 
     // Historial de viajes de la cuenta autenticada: los que pidió, si es
     // pasajero (historia #29), o los que le asignaron, si es conductor

--- a/tests/Feature/Admin/ApproveDriverDocumentTest.php
+++ b/tests/Feature/Admin/ApproveDriverDocumentTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/admin/documents/{document}/approve — ver openapi.yaml.
+ */
+class ApproveDriverDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function uri(DriverDocument $document): string
+    {
+        return "/api/v1/admin/documents/{$document->id}/approve";
+    }
+
+    public function test_aprueba_un_documento_pendiente(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'identidad',
+            'status' => 'pending',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($documento))
+            ->assertOk()
+            ->assertJsonPath('data.status', 'approved');
+
+        $this->assertDatabaseHas('driver_documents', ['id' => $documento->id, 'status' => 'approved']);
+    }
+
+    public function test_no_verifica_al_conductor_si_todavia_falta_otro_documento_obligatorio(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $identidad = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'identidad',
+            'status' => 'pending',
+        ]);
+        // La tarjeta de propiedad ni siquiera se subió todavía.
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($identidad))
+            ->assertOk();
+
+        $this->assertSame('pending', $perfil->fresh()->verification_status->value);
+    }
+
+    public function test_verifica_al_conductor_cuando_se_aprueba_el_ultimo_documento_obligatorio(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        DriverDocument::factory()->approved()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'identidad',
+        ]);
+        $tarjeta = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'tarjeta_propiedad',
+            'status' => 'pending',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($tarjeta))
+            ->assertOk();
+
+        $this->assertSame('verified', $perfil->fresh()->verification_status->value);
+    }
+
+    public function test_rechaza_aprobar_un_documento_que_no_esta_pendiente(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->approved()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($documento))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('document');
+    }
+
+    public function test_responde_404_si_el_documento_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson('/api/v1/admin/documents/999999/approve')
+            ->assertNotFound();
+    }
+
+    public function test_un_conductor_no_puede_aprobar_documentos(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->postJson($this->uri($documento))
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_aprobacion_sin_token(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->postJson($this->uri($documento))->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Admin/ListAdminDriverDocumentsTest.php
+++ b/tests/Feature/Admin/ListAdminDriverDocumentsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/admin/documents — ver openapi.yaml.
+ */
+class ListAdminDriverDocumentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/admin/documents';
+
+    private function conductorConDocumento(string $status = 'pending', string $type = 'identidad'): DriverDocument
+    {
+        $conductor = User::factory()->driver()->create(['name' => 'Carlos Ramírez']);
+        $perfil = DriverProfile::factory()->create(['user_id' => $conductor->id]);
+
+        return DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => $type,
+            'status' => $status,
+        ]);
+    }
+
+    public function test_lista_los_documentos_pendientes_por_defecto(): void
+    {
+        $documento = $this->conductorConDocumento('pending');
+        $this->conductorConDocumento('approved');
+
+        $admin = User::factory()->admin()->create();
+
+        $this->withToken(JWTAuth::fromUser($admin))
+            ->getJson(self::URI)
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $documento->id)
+            ->assertJsonPath('data.0.status', 'pending')
+            ->assertJsonPath('data.0.driver.name', 'Carlos Ramírez');
+    }
+
+    public function test_filtra_por_status(): void
+    {
+        $this->conductorConDocumento('pending');
+        $rechazado = $this->conductorConDocumento('rejected');
+
+        $admin = User::factory()->admin()->create();
+
+        $this->withToken(JWTAuth::fromUser($admin))
+            ->getJson(self::URI.'?status=rejected')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $rechazado->id);
+    }
+
+    public function test_un_conductor_no_puede_listar_documentos_de_otros(): void
+    {
+        $this->conductorConDocumento('pending');
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->getJson(self::URI)
+            ->assertForbidden();
+    }
+
+    public function test_un_pasajero_no_puede_listar_documentos(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson(self::URI)
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_consulta_sin_token(): void
+    {
+        $this->getJson(self::URI)->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Admin/RejectDriverDocumentTest.php
+++ b/tests/Feature/Admin/RejectDriverDocumentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/admin/documents/{document}/reject — ver openapi.yaml.
+ */
+class RejectDriverDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function uri(DriverDocument $document): string
+    {
+        return "/api/v1/admin/documents/{$document->id}/reject";
+    }
+
+    public function test_rechaza_un_documento_pendiente_con_motivo(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'status' => 'pending',
+        ]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($documento), ['reason' => 'La foto está borrosa'])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'rejected');
+
+        $this->assertDatabaseHas('driver_documents', [
+            'id' => $documento->id,
+            'status' => 'rejected',
+            'rejection_reason' => 'La foto está borrosa',
+        ]);
+        $this->assertSame('rejected', $perfil->fresh()->verification_status->value);
+    }
+
+    public function test_rechaza_sin_motivo_responde_422(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id, 'status' => 'pending']);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($documento), [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('reason');
+
+        $this->assertDatabaseHas('driver_documents', ['id' => $documento->id, 'status' => 'pending']);
+    }
+
+    public function test_rechaza_rechazar_un_documento_que_no_esta_pendiente(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->approved()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson($this->uri($documento), ['reason' => 'motivo'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('document');
+    }
+
+    public function test_un_pasajero_no_puede_rechazar_documentos(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson($this->uri($documento), ['reason' => 'motivo'])
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->postJson($this->uri($documento), ['reason' => 'motivo'])->assertUnauthorized();
+    }
+}

--- a/tests/Feature/UserRoleSchemaTest.php
+++ b/tests/Feature/UserRoleSchemaTest.php
@@ -47,6 +47,21 @@ class UserRoleSchemaTest extends TestCase
         $this->assertSame('LIC-001', $user->driverProfile->license_number);
     }
 
+    public function test_admin_user_can_be_created(): void
+    {
+        $user = User::create([
+            'name' => 'Staff MotoYa',
+            'email' => 'admin@example.com',
+            'phone' => '+573001112233',
+            'password' => 'secret',
+            'role' => UserRole::Admin,
+        ]);
+
+        $this->assertTrue($user->isAdmin());
+        $this->assertFalse($user->isDriver());
+        $this->assertFalse($user->isPassenger());
+    }
+
     public function test_license_number_is_unique_across_drivers(): void
     {
         $this->expectException(QueryException::class);

--- a/tests/Unit/Actions/Documents/ApproveDriverDocumentActionTest.php
+++ b/tests/Unit/Actions/Documents/ApproveDriverDocumentActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Documents;
+
+use App\Actions\Documents\ApproveDriverDocumentAction;
+use App\Enums\DocumentStatus;
+use App\Enums\DriverVerificationStatus;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApproveDriverDocumentActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_marca_el_documento_como_aprobado(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'identidad',
+            'status' => 'pending',
+        ]);
+
+        $resultado = (new ApproveDriverDocumentAction)->handle($documento);
+
+        $this->assertSame(DocumentStatus::Approved, $resultado->status);
+        $this->assertNotNull($resultado->reviewed_at);
+    }
+
+    public function test_no_cambia_la_verificacion_del_conductor_si_falta_otro_documento_obligatorio(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $identidad = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'identidad',
+            'status' => 'pending',
+        ]);
+
+        (new ApproveDriverDocumentAction)->handle($identidad);
+
+        $this->assertSame(DriverVerificationStatus::Pending, $perfil->fresh()->verification_status);
+    }
+
+    public function test_verifica_al_conductor_cuando_se_aprueban_todos_los_documentos_obligatorios(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        DriverDocument::factory()->approved()->create(['driver_profile_id' => $perfil->id, 'type' => 'identidad']);
+        $tarjeta = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'tarjeta_propiedad',
+            'status' => 'pending',
+        ]);
+
+        (new ApproveDriverDocumentAction)->handle($tarjeta);
+
+        $this->assertSame(DriverVerificationStatus::Verified, $perfil->fresh()->verification_status);
+    }
+}

--- a/tests/Unit/Actions/Documents/RejectDriverDocumentActionTest.php
+++ b/tests/Unit/Actions/Documents/RejectDriverDocumentActionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Documents;
+
+use App\Actions\Documents\RejectDriverDocumentAction;
+use App\Enums\DocumentStatus;
+use App\Enums\DriverVerificationStatus;
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RejectDriverDocumentActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_marca_el_documento_como_rechazado_con_el_motivo(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'status' => 'pending',
+        ]);
+
+        $resultado = (new RejectDriverDocumentAction)->handle($documento, 'Foto borrosa');
+
+        $this->assertSame(DocumentStatus::Rejected, $resultado->status);
+        $this->assertSame('Foto borrosa', $resultado->rejection_reason);
+        $this->assertNotNull($resultado->reviewed_at);
+    }
+
+    public function test_pone_al_conductor_en_rechazado(): void
+    {
+        $perfil = DriverProfile::factory()->create();
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id, 'status' => 'pending']);
+
+        (new RejectDriverDocumentAction)->handle($documento, 'Foto borrosa');
+
+        $this->assertSame(DriverVerificationStatus::Rejected, $perfil->fresh()->verification_status);
+    }
+}

--- a/tests/Unit/Policies/DriverDocumentPolicyTest.php
+++ b/tests/Unit/Policies/DriverDocumentPolicyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Policies;
 
+use App\Models\DriverDocument;
 use App\Models\User;
 use App\Policies\DriverDocumentPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -29,5 +30,26 @@ class DriverDocumentPolicyTest extends TestCase
 
         $this->assertFalse($policy->upload($pasajero));
         $this->assertFalse($policy->viewAny($pasajero));
+    }
+
+    public function test_un_administrador_puede_revisar_documentos(): void
+    {
+        $policy = new DriverDocumentPolicy;
+        $admin = User::factory()->admin()->create();
+        $documento = DriverDocument::factory()->create();
+
+        $this->assertTrue($policy->reviewAny($admin));
+        $this->assertTrue($policy->review($admin, $documento));
+    }
+
+    public function test_un_conductor_no_puede_revisar_documentos_aunque_sean_los_propios(): void
+    {
+        $policy = new DriverDocumentPolicy;
+        $conductor = User::factory()->driver()->create();
+        $perfil = $conductor->driverProfile()->create(['license_number' => 'LIC-999999']);
+        $documento = DriverDocument::factory()->create(['driver_profile_id' => $perfil->id]);
+
+        $this->assertFalse($policy->reviewAny($conductor));
+        $this->assertFalse($policy->review($conductor, $documento));
     }
 }

--- a/tests/Unit/UserRoleTest.php
+++ b/tests/Unit/UserRoleTest.php
@@ -19,9 +19,15 @@ class UserRoleTest extends TestCase
         $this->assertSame('driver', UserRole::Driver->value);
     }
 
+    public function test_enum_has_admin_case(): void
+    {
+        $this->assertSame('admin', UserRole::Admin->value);
+    }
+
     public function test_can_be_created_from_value(): void
     {
         $this->assertSame(UserRole::Passenger, UserRole::from('passenger'));
         $this->assertSame(UserRole::Driver, UserRole::from('driver'));
+        $this->assertSame(UserRole::Admin, UserRole::from('admin'));
     }
 }


### PR DESCRIPTION
## Resumen
- Nuevo rol `admin` (`UserRole::Admin`, `User::isAdmin()`). Sin endpoint de registro público: se crea manualmente.
- `GET /api/v1/admin/documents?status=pending` — cola de documentos por revisar.
- `POST /api/v1/admin/documents/{document}/approve` — aprueba; si con eso el conductor tiene todos los documentos obligatorios aprobados, queda `verified`.
- `POST /api/v1/admin/documents/{document}/reject` — rechaza con motivo obligatorio; el conductor queda `rejected`.
- Revisar un documento que no está `pending` responde 422.

Depende de la historia #62 (PR #63) — por eso esta rama parte de `agent/feat-documentos-verificacion-conductor` y no de `main`; se re-apunta a `main` cuando el #63 se mergee.

Closes #64

## Plan de pruebas
- [x] `php artisan test` — 673 tests en verde.
- [x] `vendor/bin/pint --test` sin errores.
- [x] `vendor/bin/phpstan analyse` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)