### PR TITLE
feat(#67): registrar token de push y avisar por push al conductor de un viaje cercano

### DIFF
--- a/app/Actions/Realtime/RegisterDeviceTokenAction.php
+++ b/app/Actions/Realtime/RegisterDeviceTokenAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Realtime;
+
+use App\DTOs\DeviceTokenRegistration;
+use App\Models\DeviceToken;
+use App\Models\User;
+
+/**
+ * Registra el token de notificaciones push de un dispositivo (historia #67).
+ *
+ * El token es único sin importar la cuenta (ver la migración): si ya estaba
+ * registrado —por esta misma cuenta o por otra, porque el dispositivo cambió
+ * de usuario— esto lo actualiza en vez de duplicarlo. `updateOrCreate` filtra
+ * por `token`, la única columna que identifica de verdad al dispositivo.
+ */
+final class RegisterDeviceTokenAction
+{
+    public function handle(User $user, DeviceTokenRegistration $registration): DeviceToken
+    {
+        return DeviceToken::query()->updateOrCreate(
+            ['token' => $registration->token],
+            ['user_id' => $user->getKey(), 'platform' => $registration->platform],
+        );
+    }
+}

--- a/app/Actions/Rides/CreateRideAction.php
+++ b/app/Actions/Rides/CreateRideAction.php
@@ -6,14 +6,17 @@ namespace App\Actions\Rides;
 
 use App\Actions\Payments\CalculateFareAction;
 use App\DTOs\Coordinates;
+use App\DTOs\PushNotification;
 use App\DTOs\RideRequest;
 use App\Enums\RideStatus;
 use App\Events\Realtime\RideRequested;
 use App\Exceptions\RouteEstimationFailed;
+use App\Models\DeviceToken;
 use App\Models\Ride;
 use App\Models\User;
 use App\Services\Maps\RouteEstimator;
 use App\Services\Realtime\NearbyDriverFinder;
+use App\Services\Realtime\PushNotificationGateway;
 
 /**
  * Crea la solicitud de viaje de un pasajero.
@@ -37,6 +40,12 @@ use App\Services\Realtime\NearbyDriverFinder;
  * es "cercano" lo resuelve `NearbyDriverFinder`, y si no hay ninguno no se
  * dispara ningún evento —un `RideRequested` sin conductores a quién llegarle
  * no le sirve a nadie.
+ *
+ * Además de avisarles por el canal `driver.{id}` (que solo llega con la app
+ * abierta), les manda una notificación push por cada dispositivo que tengan
+ * registrado (historia #67): es el aviso que sí llega con la app cerrada. Un
+ * conductor cercano sin ningún `DeviceToken` no genera ningún error, solo se
+ * queda sin ese aviso adicional.
  */
 final readonly class CreateRideAction
 {
@@ -44,6 +53,7 @@ final readonly class CreateRideAction
         private RouteEstimator $routeEstimator,
         private CalculateFareAction $calculateFare,
         private NearbyDriverFinder $nearbyDrivers,
+        private PushNotificationGateway $pushGateway,
     ) {}
 
     /**
@@ -91,5 +101,23 @@ final readonly class CreateRideAction
             estimatedFare: $ride->estimated_fare,
             nearbyDriverIds: $driverIds,
         );
+
+        $this->sendPushToNearbyDrivers($driverIds);
+    }
+
+    /**
+     * @param  list<int>  $driverIds
+     */
+    private function sendPushToNearbyDrivers(array $driverIds): void
+    {
+        $notification = new PushNotification(
+            title: 'Nuevo viaje cerca de ti',
+            body: 'Hay un pasajero esperando cerca. Abre la app para ver el detalle.',
+        );
+
+        DeviceToken::query()
+            ->whereIn('user_id', $driverIds)
+            ->get()
+            ->each(fn (DeviceToken $token) => $this->pushGateway->send($token, $notification));
     }
 }

--- a/app/DTOs/DeviceTokenRegistration.php
+++ b/app/DTOs/DeviceTokenRegistration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Enums\DevicePlatform;
+
+/**
+ * El token de push que un dispositivo registra, ya validado.
+ *
+ * No lleva la cuenta dueña, mismo criterio que `VehicleRegistration`: de
+ * quién es el token lo decide quien invoca la Action —el guard, en el caso
+ * del endpoint— y nunca la entrada.
+ */
+final readonly class DeviceTokenRegistration
+{
+    public function __construct(
+        public string $token,
+        public DevicePlatform $platform,
+    ) {}
+}

--- a/app/DTOs/PushNotification.php
+++ b/app/DTOs/PushNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+/**
+ * El contenido de una notificación push, independiente de a quién se le
+ * envía o por qué proveedor (historia #67).
+ */
+final readonly class PushNotification
+{
+    public function __construct(
+        public string $title,
+        public string $body,
+    ) {}
+}

--- a/app/Enums/DevicePlatform.php
+++ b/app/Enums/DevicePlatform.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Sistema operativo del dispositivo que registra un token de notificaciones
+ * push (historia #67).
+ *
+ * Los valores viajan tal cual a `device_tokens.platform`. Hoy nada distingue
+ * el envío según la plataforma —`NullPushNotificationGateway` no envía nada
+ * de verdad—, pero un proveedor real (FCM/APNs) sí necesita saber cuál es
+ * para elegir el canal de entrega.
+ */
+enum DevicePlatform: string
+{
+    case Android = 'android';
+    case Ios = 'ios';
+}

--- a/app/Http/Controllers/Api/V1/Realtime/RegisterDeviceTokenController.php
+++ b/app/Http/Controllers/Api/V1/Realtime/RegisterDeviceTokenController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Realtime;
+
+use App\Actions\Realtime\RegisterDeviceTokenAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Realtime\RegisterDeviceTokenRequest;
+use App\Http\Resources\DeviceTokenResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/me/device-token
+ *
+ * Registra (o actualiza) el token de notificaciones push del dispositivo de
+ * la cuenta autenticada (historia #67).
+ */
+class RegisterDeviceTokenController extends Controller
+{
+    public function __invoke(
+        RegisterDeviceTokenRequest $request,
+        RegisterDeviceTokenAction $registerDeviceToken,
+    ): JsonResponse {
+        $token = $registerDeviceToken->handle($request->user(), $request->toRegistration());
+
+        return (new DeviceTokenResource($token))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Requests/Realtime/RegisterDeviceTokenRequest.php
+++ b/app/Http/Requests/Realtime/RegisterDeviceTokenRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Realtime;
+
+use App\DTOs\DeviceTokenRegistration;
+use App\Enums\DevicePlatform;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Entrada de POST /api/v1/me/device-token — ver openapi.yaml.
+ *
+ * No define `authorize()`: el recurso *es* la cuenta autenticada (el token se
+ * asocia a quien lo registra, no a un id de la ruta), así que no hay una
+ * pregunta de autorización distinta de "¿tiene un token válido?", que ya
+ * resuelve el middleware `auth:api`. No es una operación de un rol en
+ * particular: pasajero y conductor pueden tener un dispositivo (mismo
+ * criterio que `UpdateProfileRequest`).
+ */
+class RegisterDeviceTokenRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string', 'max:255'],
+            'platform' => ['required', new Enum(DevicePlatform::class)],
+        ];
+    }
+
+    public function toRegistration(): DeviceTokenRegistration
+    {
+        return new DeviceTokenRegistration(
+            token: $this->string('token')->toString(),
+            platform: DevicePlatform::from($this->string('platform')->toString()),
+        );
+    }
+}

--- a/app/Http/Resources/DeviceTokenResource.php
+++ b/app/Http/Resources/DeviceTokenResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DeviceToken;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa el token de dispositivo recién registrado.
+ *
+ * No lleva el `token` en sí ni el `id` de la fila: el cliente ya sabe cuál es
+ * su propio token (lo mandó), y el `id` no sirve para nada en esta respuesta
+ * —no hay ningún endpoint que direccione por él—, mismo criterio que
+ * `VehicleResource`.
+ *
+ * @property-read DeviceToken $resource
+ */
+class DeviceTokenResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'platform' => $this->resource->platform->value,
+            'registered_at' => $this->resource->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Models/DeviceToken.php
+++ b/app/Models/DeviceToken.php
@@ -25,6 +25,14 @@ class DeviceToken extends Model
 {
     use HasFactory;
 
+    /**
+     * El token identifica al dispositivo ante el proveedor de push: no debe
+     * salir en ninguna respuesta de la API, mismo criterio que `password` en
+     * `User`. `DeviceTokenResource` ya no lo incluye, pero esto lo protege
+     * también si algún día se serializa el modelo directamente.
+     */
+    protected $hidden = ['token'];
+
     protected function casts(): array
     {
         return [

--- a/app/Models/DeviceToken.php
+++ b/app/Models/DeviceToken.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\DevicePlatform;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * El token de notificaciones push de un dispositivo (historia #67).
+ *
+ * `token` es único sin importar la cuenta: es el mismo dispositivo físico el
+ * que se identifica, y `RegisterDeviceTokenAction` lo muda de dueño en vez de
+ * duplicarlo si otra cuenta lo registra después.
+ *
+ * @property string $token
+ * @property DevicePlatform $platform
+ */
+#[Fillable(['user_id', 'token', 'platform'])]
+class DeviceToken extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'platform' => DevicePlatform::class,
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,8 @@ use App\Services\Payments\PaymentGateway;
 use App\Services\Realtime\EloquentNearbyDriverFinder;
 use App\Services\Realtime\EloquentRideParticipants;
 use App\Services\Realtime\NearbyDriverFinder;
+use App\Services\Realtime\NullPushNotificationGateway;
+use App\Services\Realtime\PushNotificationGateway;
 use App\Services\Realtime\RideParticipants;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -31,6 +33,20 @@ class AppServiceProvider extends ServiceProvider
         $this->registerFareSchedule();
         $this->registerRideParticipants();
         $this->registerNearbyDriverFinder();
+        $this->registerPushNotificationGateway();
+    }
+
+    /**
+     * Proveedor de notificaciones push que avisa a los conductores cercanos
+     * de un viaje nuevo (historia #67). Todavía no hay cuenta de Firebase/APNs
+     * configurada —ver "Fuera de alcance" en el issue—, así que apunta a
+     * `NullPushNotificationGateway`, que solo deja un registro en el log.
+     * Cambiar a un proveedor real es reemplazar este binding, mismo criterio
+     * que `registerPaymentGateway()`.
+     */
+    private function registerPushNotificationGateway(): void
+    {
+        $this->app->singleton(PushNotificationGateway::class, NullPushNotificationGateway::class);
     }
 
     /**

--- a/app/Services/Realtime/NullPushNotificationGateway.php
+++ b/app/Services/Realtime/NullPushNotificationGateway.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+use App\DTOs\PushNotification;
+use App\Models\DeviceToken;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Implementación de `PushNotificationGateway` mientras no hay un proveedor
+ * real integrado (historia #67: no hay cuenta de Firebase/APNs configurada
+ * todavía, decisión de negocio explícita).
+ *
+ * En vez de enviar de verdad, deja un registro en el log: es lo que permite
+ * conectar el resto del flujo (registrar el token, avisar a los conductores
+ * cercanos) y verificarlo en desarrollo y en tests sin depender de una red ni
+ * de credenciales de un proveedor externo. El día que se decida un proveedor
+ * real, se reemplaza el binding en `AppServiceProvider` sin tocar
+ * `CreateRideAction`, mismo criterio que `NullPaymentGateway`.
+ */
+final class NullPushNotificationGateway implements PushNotificationGateway
+{
+    public function send(DeviceToken $token, PushNotification $notification): void
+    {
+        Log::info('Notificación push (sin proveedor real configurado)', [
+            'device_token_id' => $token->id,
+            'platform' => $token->platform->value,
+            'title' => $notification->title,
+            'body' => $notification->body,
+        ]);
+    }
+}

--- a/app/Services/Realtime/PushNotificationGateway.php
+++ b/app/Services/Realtime/PushNotificationGateway.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Realtime;
+
+use App\DTOs\PushNotification;
+use App\Models\DeviceToken;
+
+/**
+ * Contrato con el proveedor de notificaciones push (historia #67).
+ *
+ * `CreateRideAction` depende de esta interfaz y nunca de una implementación
+ * concreta, mismo criterio que `PaymentGateway`: qué proveedor se usa
+ * (Firebase Cloud Messaging, APNs directo) no está decidido todavía —no hay
+ * cuenta de Firebase configurada—, y el punto de integración tiene que poder
+ * cambiar sin tocar `CreateRideAction`.
+ */
+interface PushNotificationGateway
+{
+    /**
+     * Envía `$notification` al dispositivo de `$token`. No devuelve nada: el
+     * éxito es que el método retorne sin lanzar, mismo criterio que
+     * `PaymentGateway::charge()`.
+     */
+    public function send(DeviceToken $token, PushNotification $notification): void;
+}

--- a/database/factories/DeviceTokenFactory.php
+++ b/database/factories/DeviceTokenFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\DevicePlatform;
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DeviceToken>
+ */
+class DeviceTokenFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'token' => fake()->unique()->uuid(),
+            'platform' => fake()->randomElement(DevicePlatform::cases()),
+        ];
+    }
+}

--- a/database/migrations/2026_09_05_000002_create_device_tokens_table.php
+++ b/database/migrations/2026_09_05_000002_create_device_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('device_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // Único sin importar la cuenta: el mismo dispositivo físico puede
+            // volver a registrarse bajo otra cuenta (se cerró sesión y entró
+            // otra persona), y ahí el token tiene que mudarse de dueño, no
+            // duplicarse (ver RegisterDeviceTokenAction).
+            $table->string('token')->unique();
+            $table->string('platform');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('device_tokens');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -587,6 +587,80 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /me/device-token:
+    post:
+      tags:
+        - Realtime
+      operationId: registerDeviceToken
+      summary: Registrar el token de notificaciones push de mi dispositivo
+      description: >-
+        Registra (o actualiza) el token de notificaciones push del
+        dispositivo de la cuenta autenticada (historia #67). No es una
+        operación de un rol en particular: cualquier cuenta autenticada
+        —pasajero o conductor— puede tener un dispositivo.
+
+        El token es único sin importar la cuenta: si el mismo dispositivo ya
+        estaba registrado —por esta cuenta o por otra, porque cambió de
+        usuario— esto lo actualiza en vez de duplicarlo.
+
+        Hoy esto solo dispara notificaciones para el conductor cuando hay un
+        viaje cercano nuevo (historia #17). El envío real a través de un
+        proveedor (Firebase/APNs) todavía no está conectado: mientras tanto,
+        cada notificación queda solo en el log del servidor.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceTokenRegistrationRequest"
+            example:
+              token: fcm-a1b2c3d4e5f6
+              platform: android
+      responses:
+        "201":
+          description: Token registrado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/DeviceToken"
+              example:
+                data:
+                  platform: android
+                  registered_at: "2026-09-05T15:00:00.000000Z"
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "422":
+          description: Falta `token` o `platform`, o `platform` no es `android`/`ios`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The selected platform is invalid.
+                errors:
+                  platform:
+                    - The selected platform is invalid.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /me/vehicle:
     get:
       tags:
@@ -3014,6 +3088,42 @@ components:
           type: integer
           description: Año del modelo.
           example: 2022
+    DeviceToken:
+      type: object
+      description: >-
+        El token de notificaciones push recién registrado (historia #67). No
+        lleva el `token` en sí ni el `id` de la fila: el cliente ya sabe cuál
+        es su propio token, y el `id` no sirve para nada en esta respuesta.
+      required:
+        - platform
+        - registered_at
+      properties:
+        platform:
+          type: string
+          enum: [android, ios]
+          example: android
+        registered_at:
+          type: string
+          format: date-time
+          example: "2026-09-05T15:00:00.000000Z"
+    DeviceTokenRegistrationRequest:
+      type: object
+      description: >-
+        El token de push de un dispositivo. No lleva a quién pertenece: el
+        dueño es siempre la cuenta que envía el token de acceso.
+      required:
+        - token
+        - platform
+      properties:
+        token:
+          type: string
+          maxLength: 255
+          description: Token que entrega el SDK de notificaciones push del dispositivo.
+          example: fcm-a1b2c3d4e5f6
+        platform:
+          type: string
+          enum: [android, ios]
+          example: android
     DriverDocument:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\V1\Drivers\ShowDriverEarningsController;
 use App\Http\Controllers\Api\V1\Drivers\UpdateDriverAvailabilityController;
 use App\Http\Controllers\Api\V1\Profile\ShowProfileController;
 use App\Http\Controllers\Api\V1\Profile\UpdateProfileController;
+use App\Http\Controllers\Api\V1\Realtime\RegisterDeviceTokenController;
 use App\Http\Controllers\Api\V1\Rides\AcceptRideController;
 use App\Http\Controllers\Api\V1\Rides\CancelRideController;
 use App\Http\Controllers\Api\V1\Rides\CompleteRideController;
@@ -87,6 +88,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->patch('me', UpdateProfileController::class)
         ->name('profile.update');
+
+    // Token de notificaciones push del dispositivo (historia #67). No es una
+    // operación de un rol en particular —pasajero o conductor pueden tener un
+    // dispositivo—, por eso cuelga de `me` junto al perfil y no de un
+    // sub-recurso de conductor como el vehículo.
+    Route::middleware('auth:api')
+        ->post('me/device-token', RegisterDeviceTokenController::class)
+        ->name('device-tokens.store');
 
     // El vehículo del conductor cuelga de `me` porque es un sub-recurso de la
     // cuenta: se llega a él por el token, nunca por un id propio. Que solo los

--- a/tests/Feature/Realtime/RegisterDeviceTokenTest.php
+++ b/tests/Feature/Realtime/RegisterDeviceTokenTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Realtime;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/me/device-token — ver openapi.yaml.
+ */
+class RegisterDeviceTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/device-token';
+
+    public function test_registra_el_token_y_lo_asocia_a_la_cuenta(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $respuesta = $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, ['token' => 'fcm-abc123', 'platform' => 'android'])
+            ->assertCreated()
+            ->assertJsonPath('data.platform', 'android');
+
+        $respuesta->assertJsonMissingPath('data.token');
+        $this->assertNotNull($respuesta->json('data.registered_at'));
+
+        $this->assertDatabaseHas('device_tokens', [
+            'user_id' => $conductor->id,
+            'token' => 'fcm-abc123',
+            'platform' => 'android',
+        ]);
+    }
+
+    public function test_un_pasajero_tambien_puede_registrar_su_token(): void
+    {
+        $pasajero = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($pasajero))
+            ->postJson(self::URI, ['token' => 'fcm-pasajero-1', 'platform' => 'ios'])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('device_tokens', ['user_id' => $pasajero->id, 'platform' => 'ios']);
+    }
+
+    public function test_volver_a_registrar_el_mismo_token_lo_actualiza_en_vez_de_duplicarlo(): void
+    {
+        $conductor = User::factory()->driver()->create();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, ['token' => 'fcm-mismo', 'platform' => 'android'])
+            ->assertCreated();
+
+        $this->withToken(JWTAuth::fromUser($conductor))
+            ->postJson(self::URI, ['token' => 'fcm-mismo', 'platform' => 'ios'])
+            ->assertCreated();
+
+        $this->assertDatabaseCount('device_tokens', 1);
+        $this->assertDatabaseHas('device_tokens', ['token' => 'fcm-mismo', 'platform' => 'ios']);
+    }
+
+    public function test_el_mismo_dispositivo_puede_mudarse_a_otra_cuenta(): void
+    {
+        // El token ya registrado por otra cuenta se siembra directamente en
+        // la base (no con una segunda request autenticada): dos requests
+        // como cuentas distintas en un mismo test chocan con el caché interno
+        // del parser de JWT sobre la request ya resuelta, algo que no ocurre
+        // en producción —cada request real arranca su propio parser— pero sí
+        // dentro de un mismo método de test. Mismo criterio que el resto de
+        // la suite (ver `RegisterVehicleTest`), que nunca autentica dos
+        // cuentas distintas dentro de un mismo test.
+        $primeraCuenta = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $primeraCuenta->id, 'token' => 'fcm-compartido']);
+
+        $segundaCuenta = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($segundaCuenta))
+            ->postJson(self::URI, ['token' => 'fcm-compartido', 'platform' => 'android'])
+            ->assertCreated();
+
+        $this->assertDatabaseCount('device_tokens', 1);
+        $this->assertDatabaseHas('device_tokens', ['token' => 'fcm-compartido', 'user_id' => $segundaCuenta->id]);
+    }
+
+    public function test_rechaza_una_plataforma_invalida(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, ['token' => 'fcm-x', 'platform' => 'windows'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('platform');
+
+        $this->assertDatabaseCount('device_tokens', 0);
+    }
+
+    public function test_rechaza_sin_token(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, ['platform' => 'android'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('token');
+    }
+
+    public function test_rechaza_la_solicitud_sin_autenticar(): void
+    {
+        $this->postJson(self::URI, ['token' => 'fcm-x', 'platform' => 'android'])
+            ->assertUnauthorized();
+
+        $this->assertDatabaseCount('device_tokens', 0);
+    }
+}

--- a/tests/Unit/Actions/Realtime/RegisterDeviceTokenActionTest.php
+++ b/tests/Unit/Actions/Realtime/RegisterDeviceTokenActionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Realtime;
+
+use App\Actions\Realtime\RegisterDeviceTokenAction;
+use App\DTOs\DeviceTokenRegistration;
+use App\Enums\DevicePlatform;
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterDeviceTokenActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_el_token_asociado_al_usuario(): void
+    {
+        $usuario = User::factory()->create();
+
+        $token = (new RegisterDeviceTokenAction)->handle(
+            $usuario,
+            new DeviceTokenRegistration(token: 'abc', platform: DevicePlatform::Android),
+        );
+
+        $this->assertSame($usuario->id, $token->user_id);
+        $this->assertSame(DevicePlatform::Android, $token->platform);
+    }
+
+    public function test_registrar_el_mismo_token_dos_veces_no_lo_duplica(): void
+    {
+        $usuario = User::factory()->create();
+        $action = new RegisterDeviceTokenAction;
+
+        $action->handle($usuario, new DeviceTokenRegistration('abc', DevicePlatform::Android));
+        $action->handle($usuario, new DeviceTokenRegistration('abc', DevicePlatform::Ios));
+
+        $this->assertSame(1, DeviceToken::query()->count());
+        $this->assertSame(DevicePlatform::Ios, DeviceToken::query()->firstOrFail()->platform);
+    }
+
+    public function test_el_mismo_token_puede_mudarse_de_una_cuenta_a_otra(): void
+    {
+        $primero = User::factory()->create();
+        $segundo = User::factory()->create();
+        $action = new RegisterDeviceTokenAction;
+
+        $action->handle($primero, new DeviceTokenRegistration('compartido', DevicePlatform::Android));
+        $action->handle($segundo, new DeviceTokenRegistration('compartido', DevicePlatform::Android));
+
+        $this->assertSame(1, DeviceToken::query()->count());
+        $this->assertSame($segundo->id, DeviceToken::query()->firstOrFail()->user_id);
+    }
+}

--- a/tests/Unit/Actions/Rides/CreateRideActionTest.php
+++ b/tests/Unit/Actions/Rides/CreateRideActionTest.php
@@ -6,15 +6,18 @@ namespace Tests\Unit\Actions\Rides;
 
 use App\Actions\Rides\CreateRideAction;
 use App\DTOs\Coordinates;
+use App\DTOs\PushNotification;
 use App\DTOs\RideRequest;
 use App\DTOs\RouteEstimate;
 use App\Enums\RideStatus;
 use App\Events\Realtime\RideRequested;
 use App\Exceptions\RouteEstimationFailed;
+use App\Models\DeviceToken;
 use App\Models\DriverProfile;
 use App\Models\Ride;
 use App\Models\User;
 use App\Services\Maps\RouteEstimator;
+use App\Services\Realtime\PushNotificationGateway;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -179,6 +182,58 @@ class CreateRideActionTest extends TestCase
         $this->action()->handle(User::factory()->create(), $this->solicitud());
 
         Event::assertNotDispatched(RideRequested::class);
+    }
+
+    /**
+     * Historia #67: además del websocket, avisa por push a cada dispositivo
+     * registrado de los conductores cercanos.
+     */
+    public function test_envia_notificacion_push_a_cada_dispositivo_del_conductor_cercano(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->available(latitude: 4.710989, longitude: -74.072092)
+            ->create(['user_id' => $conductor->id]);
+        DeviceToken::factory()->create(['user_id' => $conductor->id, 'token' => 'device-1']);
+        DeviceToken::factory()->create(['user_id' => $conductor->id, 'token' => 'device-2']);
+
+        $gateway = new class implements PushNotificationGateway
+        {
+            /** @var list<string> */
+            public array $enviados = [];
+
+            public function send(DeviceToken $token, PushNotification $notification): void
+            {
+                $this->enviados[] = $token->token;
+            }
+        };
+        $this->app->instance(PushNotificationGateway::class, $gateway);
+
+        $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        $this->assertEqualsCanonicalizing(['device-1', 'device-2'], $gateway->enviados);
+    }
+
+    public function test_no_falla_si_el_conductor_cercano_no_tiene_ningun_dispositivo_registrado(): void
+    {
+        $conductor = User::factory()->driver()->create();
+        DriverProfile::factory()->available(latitude: 4.710989, longitude: -74.072092)
+            ->create(['user_id' => $conductor->id]);
+
+        $gateway = new class implements PushNotificationGateway
+        {
+            public int $llamadas = 0;
+
+            public function send(DeviceToken $token, PushNotification $notification): void
+            {
+                $this->llamadas++;
+            }
+        };
+        $this->app->instance(PushNotificationGateway::class, $gateway);
+
+        $viaje = $this->action()->handle(User::factory()->create(), $this->solicitud());
+
+        $this->assertTrue($viaje->exists);
+        $this->assertSame(0, $gateway->llamadas);
     }
 
     private function action(?RouteEstimate $trayecto = null): CreateRideAction


### PR DESCRIPTION
## Resumen
- `POST /api/v1/me/device-token` — cualquier cuenta autenticada registra el token de notificaciones push de su dispositivo. El mismo token puede mudarse a otra cuenta (dispositivo compartido/reinstalado).
- `PushNotificationGateway` (interfaz) + `NullPushNotificationGateway` — mismo patrón que `PaymentGateway`/`NullPaymentGateway`: hoy solo deja un registro en el log, el envío real vía Firebase/APNs queda para cuando exista esa cuenta.
- `CreateRideAction` ahora también envía una notificación push a cada dispositivo registrado de los conductores cercanos, además del aviso por websockets (que solo llega con la app abierta).

Closes #67

## Plan de pruebas
- [x] `php artisan test` — 685 tests en verde.
- [x] `vendor/bin/pint --test` sin errores.
- [x] `vendor/bin/phpstan analyse` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)