### PR TITLE
feat(#69): confirmar el número de celular con un código por SMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,13 @@ REVERB_SERVER_PORT=8080
 # aviso por el canal driver.{id}.
 RIDES_NEARBY_RADIUS_METERS=3000
 
+# Confirmación del número de celular por SMS (historia #69). Sin proveedor de
+# SMS configurado todavía: el envío real queda para cuando exista esa cuenta,
+# mientras tanto el código solo se registra en el log del servidor.
+PHONE_VERIFICATION_CODE_LENGTH=6
+PHONE_VERIFICATION_EXPIRES_IN_MINUTES=10
+PHONE_VERIFICATION_MAX_ATTEMPTS=5
+
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 

--- a/app/Actions/Auth/ConfirmPhoneVerificationAction.php
+++ b/app/Actions/Auth/ConfirmPhoneVerificationAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * Marca el celular de la cuenta como verificado (historia #69).
+ *
+ * Que el código enviado sea correcto, no haya vencido, y no se hayan agotado
+ * los intentos lo comprueba `ConfirmPhoneVerificationRequest` antes de llegar
+ * acá (422 si no), mismo criterio que `ApproveDriverDocumentAction` con el
+ * estado del documento: esta Action asume una confirmación válida y no
+ * vuelve a validarla.
+ *
+ * `phone_verified_at` no es fillable a propósito (ver `User`): se asigna
+ * directo y se guarda, mismo criterio que `verification_status` en
+ * `DriverProfile`.
+ */
+final class ConfirmPhoneVerificationAction
+{
+    public function handle(User $user): User
+    {
+        $user->phone_verified_at = Date::now();
+        $user->save();
+
+        $user->phoneVerificationCode?->delete();
+
+        return $user;
+    }
+}

--- a/app/Actions/Auth/RequestPhoneVerificationAction.php
+++ b/app/Actions/Auth/RequestPhoneVerificationAction.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Genera y envía el código de verificación de celular de una cuenta (historia
+ * #69).
+ *
+ * Un código vigente por cuenta: `phone_verification_codes.user_id` es único
+ * (ver la migración), así que pedir uno nuevo reemplaza el anterior en vez de
+ * acumularlo —`updateOrCreate()` a través de la relación resuelve esto solo.
+ *
+ * Se guarda el hash del código, nunca el valor en claro: nadie con acceso a
+ * la base debería poder leerlo, mismo criterio que la contraseña.
+ */
+final readonly class RequestPhoneVerificationAction
+{
+    public function __construct(private SmsGateway $sms) {}
+
+    public function handle(User $user): void
+    {
+        $code = $this->generateCode();
+
+        $user->phoneVerificationCode()->updateOrCreate(
+            [],
+            [
+                'code_hash' => Hash::make($code),
+                'attempts' => 0,
+                'expires_at' => Date::now()->addMinutes(Config::integer('phone_verification.expires_in_minutes')),
+            ],
+        );
+
+        $minutos = Config::integer('phone_verification.expires_in_minutes');
+
+        $this->sms->send(
+            $user->phone,
+            "Tu código de verificación MotoYa es {$code}. Vence en {$minutos} minutos.",
+        );
+    }
+
+    private function generateCode(): string
+    {
+        $digitos = Config::integer('phone_verification.code_length');
+        $maximo = (10 ** $digitos) - 1;
+
+        return str_pad((string) random_int(0, $maximo), $digitos, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/ConfirmPhoneVerificationController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ConfirmPhoneVerificationController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\ConfirmPhoneVerificationAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ConfirmPhoneVerificationRequest;
+use App\Http\Resources\ProfileResource;
+
+/**
+ * POST /api/v1/me/phone/verification/confirm
+ *
+ * Confirma el código de verificación de celular de la cuenta autenticada
+ * (historia #69). Que el código sea correcto, no haya vencido, y no se hayan
+ * agotado los intentos lo resuelve `ConfirmPhoneVerificationRequest`.
+ */
+class ConfirmPhoneVerificationController extends Controller
+{
+    public function __invoke(
+        ConfirmPhoneVerificationRequest $request,
+        ConfirmPhoneVerificationAction $confirmVerification,
+    ): ProfileResource {
+        $user = $confirmVerification->handle($request->user());
+
+        return new ProfileResource($user);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/RequestPhoneVerificationController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RequestPhoneVerificationController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\RequestPhoneVerificationAction;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * POST /api/v1/me/phone/verification
+ *
+ * Genera un código de verificación de celular y lo envía por SMS a la cuenta
+ * autenticada (historia #69).
+ *
+ * No lleva Form Request propio: no hay nada que validar en el cuerpo, mismo
+ * criterio que `LogoutController`. Responde 204 y no un API Resource porque
+ * no hay ningún recurso que devolver — el cliente solo necesita saber que el
+ * envío se disparó.
+ */
+class RequestPhoneVerificationController extends Controller
+{
+    public function __invoke(Request $request, RequestPhoneVerificationAction $requestVerification): Response
+    {
+        $requestVerification->handle($request->user());
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Auth/ConfirmPhoneVerificationRequest.php
+++ b/app/Http/Requests/Auth/ConfirmPhoneVerificationRequest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\PhoneVerificationCode;
+use App\Models\User;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Entrada de POST /api/v1/me/phone/verification/confirm — ver openapi.yaml.
+ *
+ * No define `authorize()`: el recurso *es* la cuenta autenticada, mismo
+ * criterio que `UpdateProfileRequest`. No es una operación de un rol en
+ * particular.
+ */
+class ConfirmPhoneVerificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'code' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->validateCode(...),
+        ];
+    }
+
+    /**
+     * Todas las razones por las que un código no se acepta viajan bajo la
+     * misma clave `code` —no hay verificación pendiente, venció, se agotaron
+     * los intentos, o el valor no coincide—: para el cliente móvil todas
+     * piden lo mismo, pedir un código nuevo (`POST /me/phone/verification`).
+     *
+     * Un intento incorrecto incrementa `attempts` como parte de esta misma
+     * validación: es la comprobación que necesita el valor de `code`, así
+     * que no tiene sentido repetirla en la Action solo para poder llevar la
+     * cuenta ahí.
+     */
+    private function validateCode(Validator $validator): void
+    {
+        $verification = $this->pendingVerification();
+
+        if ($verification === null) {
+            $validator->errors()->add('code', 'No tienes una verificación pendiente; solicita un código nuevo.');
+
+            return;
+        }
+
+        if ($verification->expires_at->isPast()) {
+            $validator->errors()->add('code', 'El código venció; solicita uno nuevo.');
+
+            return;
+        }
+
+        if ($verification->attempts >= Config::integer('phone_verification.max_attempts')) {
+            $validator->errors()->add('code', 'Superaste el número de intentos permitidos; solicita un código nuevo.');
+
+            return;
+        }
+
+        if (! Hash::check($this->string('code')->toString(), $verification->code_hash)) {
+            $verification->increment('attempts');
+            $validator->errors()->add('code', 'El código no es correcto.');
+        }
+    }
+
+    public function pendingVerification(): ?PhoneVerificationCode
+    {
+        $user = $this->user();
+
+        return $user instanceof User ? $user->phoneVerificationCode : null;
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -29,6 +29,7 @@ class UserResource extends JsonResource
             'name' => $this->resource->name,
             'email' => $this->resource->email,
             'phone' => $this->resource->phone,
+            'phone_verified' => $this->resource->isPhoneVerified(),
             'role' => $this->resource->role->value,
         ];
     }

--- a/app/Models/PhoneVerificationCode.php
+++ b/app/Models/PhoneVerificationCode.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * El código de verificación de celular vigente de una cuenta (historia #69).
+ *
+ * Uno por cuenta (`user_id` único): pedir un código nuevo reemplaza este,
+ * nunca lo duplica.
+ *
+ * @property int $attempts
+ * @property Carbon $expires_at
+ */
+#[Fillable(['user_id', 'code_hash', 'attempts', 'expires_at'])]
+class PhoneVerificationCode extends Model
+{
+    use HasFactory;
+
+    /**
+     * El hash nunca debe salir en una respuesta de la API, mismo criterio que
+     * `password` en `User` y `token` en `DeviceToken`.
+     */
+    protected $hidden = ['code_hash'];
+
+    protected function casts(): array
+    {
+        return [
+            'attempts' => 'integer',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,10 +12,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 
 /**
  * @property UserRole $role
+ * @property Carbon|null $phone_verified_at
  */
 #[Fillable(['name', 'email', 'phone', 'password', 'role'])]
 class User extends Authenticatable implements JWTSubject
@@ -30,6 +32,7 @@ class User extends Authenticatable implements JWTSubject
         return [
             'password' => 'hashed',
             'role' => UserRole::class,
+            'phone_verified_at' => 'datetime',
         ];
     }
 
@@ -93,6 +96,23 @@ class User extends Authenticatable implements JWTSubject
     public function isAdmin(): bool
     {
         return $this->role === UserRole::Admin;
+    }
+
+    public function isPhoneVerified(): bool
+    {
+        return $this->phone_verified_at !== null;
+    }
+
+    /**
+     * El código de verificación de celular vigente de esta cuenta (historia
+     * #69), si hay uno. Uno a uno: `phone_verification_codes.user_id` es
+     * único, y pedir un código nuevo reemplaza el que hubiera.
+     *
+     * @return HasOne<PhoneVerificationCode, $this>
+     */
+    public function phoneVerificationCode(): HasOne
+    {
+        return $this->hasOne(PhoneVerificationCode::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,8 @@ use App\Services\Realtime\NearbyDriverFinder;
 use App\Services\Realtime\NullPushNotificationGateway;
 use App\Services\Realtime\PushNotificationGateway;
 use App\Services\Realtime\RideParticipants;
+use App\Services\Sms\NullSmsGateway;
+use App\Services\Sms\SmsGateway;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
@@ -34,6 +36,20 @@ class AppServiceProvider extends ServiceProvider
         $this->registerRideParticipants();
         $this->registerNearbyDriverFinder();
         $this->registerPushNotificationGateway();
+        $this->registerSmsGateway();
+    }
+
+    /**
+     * Proveedor de SMS que envía el código de verificación de celular
+     * (historia #69). Todavía no hay cuenta de Twilio u otro proveedor
+     * configurada —ver "Fuera de alcance" en el issue—, así que apunta a
+     * `NullSmsGateway`, que solo deja un registro en el log. Cambiar a un
+     * proveedor real es reemplazar este binding, mismo criterio que
+     * `registerPaymentGateway()`.
+     */
+    private function registerSmsGateway(): void
+    {
+        $this->app->singleton(SmsGateway::class, NullSmsGateway::class);
     }
 
     /**
@@ -171,6 +187,11 @@ class AppServiceProvider extends ServiceProvider
      * sin `auth:api` — hoy solo el refresh, mañana login y registro. Son los
      * que se pueden golpear por fuerza bruta sin credenciales, y en el caso del
      * refresh cada acierto escribe además una entrada de blacklist en el cache.
+     *
+     * `phone-verification` es más estricto todavía y por usuario (no por IP:
+     * el endpoint exige `auth:api`): cada acierto le cuesta un SMS real a
+     * MotoYa apenas haya un proveedor conectado (historia #69), así que el
+     * límite general de 60/min dejaría pedir 60 códigos en un minuto.
      */
     private function configureRateLimiting(): void
     {
@@ -183,6 +204,11 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for(
             'auth',
             fn (Request $request) => Limit::perMinute(10)->by((string) $request->ip()),
+        );
+
+        RateLimiter::for(
+            'phone-verification',
+            fn (Request $request) => Limit::perMinutes(10, 3)->by((string) $request->user()?->getAuthIdentifier()),
         );
     }
 }

--- a/app/Services/Sms/NullSmsGateway.php
+++ b/app/Services/Sms/NullSmsGateway.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sms;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Implementación de `SmsGateway` mientras no hay un proveedor real integrado
+ * (historia #69: no hay cuenta de Twilio u otro proveedor configurada
+ * todavía, decisión de negocio explícita).
+ *
+ * En vez de enviar de verdad, deja un registro en el log: es lo que permite
+ * verificar el resto del flujo (generar el código, confirmarlo) en
+ * desarrollo y en tests sin depender de una red ni de credenciales de un
+ * proveedor externo. El día que se decida un proveedor real, se reemplaza el
+ * binding en `AppServiceProvider` sin tocar
+ * `RequestPhoneVerificationAction`, mismo criterio que `NullPaymentGateway`.
+ */
+final class NullSmsGateway implements SmsGateway
+{
+    public function send(string $phone, string $message): void
+    {
+        Log::info('SMS (sin proveedor real configurado)', [
+            'phone' => $phone,
+            'message' => $message,
+        ]);
+    }
+}

--- a/app/Services/Sms/SmsGateway.php
+++ b/app/Services/Sms/SmsGateway.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sms;
+
+/**
+ * Contrato con el proveedor de SMS (historia #69).
+ *
+ * `RequestPhoneVerificationAction` depende de esta interfaz y nunca de una
+ * implementación concreta, mismo criterio que `PaymentGateway` y
+ * `PushNotificationGateway`: qué proveedor se usa (Twilio u otro) no está
+ * decidido todavía, y el punto de integración tiene que poder cambiar sin
+ * tocar la Action.
+ */
+interface SmsGateway
+{
+    /**
+     * Envía `$message` al número `$phone`. No devuelve nada: el éxito es que
+     * el método retorne sin lanzar, mismo criterio que
+     * `PaymentGateway::charge()`.
+     */
+    public function send(string $phone, string $message): void;
+}

--- a/config/phone_verification.php
+++ b/config/phone_verification.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Confirmación del número de celular por SMS
+    |--------------------------------------------------------------------------
+    |
+    | Parámetros del código que se envía a `POST /me/phone/verification`
+    | (historia #69). Ver App\Actions\Auth\RequestPhoneVerificationAction.
+    |
+    */
+
+    // Cantidad de dígitos del código, p. ej. 6 -> códigos entre 000000 y 999999.
+    'code_length' => (int) env('PHONE_VERIFICATION_CODE_LENGTH', 6),
+
+    // Minutos que el código sigue siendo válido después de generado.
+    'expires_in_minutes' => (int) env('PHONE_VERIFICATION_EXPIRES_IN_MINUTES', 10),
+
+    // Intentos fallidos permitidos antes de exigir pedir un código nuevo.
+    'max_attempts' => (int) env('PHONE_VERIFICATION_MAX_ATTEMPTS', 5),
+
+];

--- a/database/factories/PhoneVerificationCodeFactory.php
+++ b/database/factories/PhoneVerificationCodeFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\PhoneVerificationCode;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * @extends Factory<PhoneVerificationCode>
+ */
+class PhoneVerificationCodeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'code_hash' => Hash::make('123456'),
+            'attempts' => 0,
+            'expires_at' => now()->addMinutes(10),
+        ];
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => now()->subMinute(),
+        ]);
+    }
+
+    public function exhausted(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'attempts' => 5,
+        ]);
+    }
+}

--- a/database/migrations/2026_09_05_000003_add_phone_verified_at_to_users_table.php
+++ b/database/migrations/2026_09_05_000003_add_phone_verified_at_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('phone_verified_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('phone_verified_at');
+        });
+    }
+};

--- a/database/migrations/2026_09_05_000004_create_phone_verification_codes_table.php
+++ b/database/migrations/2026_09_05_000004_create_phone_verification_codes_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('phone_verification_codes', function (Blueprint $table) {
+            $table->id();
+            // Único: un código vigente por cuenta. Pedir uno nuevo reemplaza
+            // el anterior (ver RequestPhoneVerificationAction), no acumula.
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('code_hash');
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('expires_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('phone_verification_codes');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66,6 +66,7 @@ paths:
                     name: Ana García
                     email: ana@example.com
                     phone: "+573001234567"
+                    phone_verified: false
                     role: passenger
                   token:
                     access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJwYXNzZW5nZXIifQ.4pcPyMD09olPSyXnrXCjTwXyr4BsezdI1AVTmud2fU4
@@ -274,6 +275,7 @@ paths:
                     name: Carlos Ramírez
                     email: carlos@example.com
                     phone: "+573009876543"
+                    phone_verified: false
                     role: driver
                   token:
                     access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJkcml2ZXIifQ.HCJUJDXBM6BAvUcTGF6ZiHR2Wr3ubuRxKh7uBB4Umt4
@@ -350,6 +352,7 @@ paths:
                     name: Ana García
                     email: ana@example.com
                     phone: "+573001234567"
+                    phone_verified: false
                     role: passenger
                   token:
                     access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJwYXNzZW5nZXIifQ.4pcPyMD09olPSyXnrXCjTwXyr4BsezdI1AVTmud2fU4
@@ -491,6 +494,7 @@ paths:
                   name: Ana García
                   email: ana@example.com
                   phone: "+573001234567"
+                  phone_verified: false
                   role: passenger
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -556,6 +560,7 @@ paths:
                   name: Ana García Pérez
                   email: ana@example.com
                   phone: "+573007654321"
+                  phone_verified: false
                   role: passenger
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -653,6 +658,127 @@ paths:
                 errors:
                   platform:
                     - The selected platform is invalid.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /me/phone/verification:
+    post:
+      tags:
+        - Auth
+      operationId: requestPhoneVerification
+      summary: Pedir un código de verificación de mi celular
+      description: >-
+        Genera un código de verificación y lo envía por SMS al celular de la
+        cuenta autenticada (historia #69). Pedir uno nuevo reemplaza el
+        anterior: nunca hay dos códigos vigentes a la vez para la misma
+        cuenta.
+
+        No hay proveedor de SMS configurado todavía: mientras tanto, el
+        código solo queda registrado en el log del servidor.
+
+        Límite de tasa más estricto que el general de la API (3 cada 10
+        minutos, por cuenta): cada acierto le va a costar un SMS real apenas
+        haya un proveedor conectado.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Código generado y enviado. No hay contenido que devolver.
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "429":
+          description: >-
+            Se superó el límite de 3 solicitudes cada 10 minutos para esta
+            cuenta.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /me/phone/verification/confirm:
+    post:
+      tags:
+        - Auth
+      operationId: confirmPhoneVerification
+      summary: Confirmar el código de verificación de mi celular
+      description: >-
+        Confirma el código pedido en `POST /me/phone/verification` (historia
+        #69). Si es correcto, no venció, y no se agotaron los intentos, la
+        cuenta queda con `phone_verified: true`.
+
+        Todas las razones por las que un código no se acepta —no hay
+        verificación pendiente, venció, se agotaron los intentos, o el valor
+        no coincide— responden 422 bajo la misma clave `code`: para el
+        cliente móvil todas piden lo mismo, pedir un código nuevo.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - code
+              properties:
+                code:
+                  type: string
+                  example: "482913"
+            example:
+              code: "482913"
+      responses:
+        "200":
+          description: Celular confirmado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Profile"
+              example:
+                data:
+                  id: 1
+                  name: Ana García
+                  email: ana@example.com
+                  phone: "+573001234567"
+                  phone_verified: true
+                  role: passenger
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "422":
+          description: >-
+            El código no es correcto, venció, se agotaron los intentos, o no
+            hay ninguna verificación pendiente.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: El código no es correcto.
+                errors:
+                  code:
+                    - El código no es correcto.
         "429":
           description: Se superó el límite general de la API para este usuario.
           content:
@@ -2882,6 +3008,7 @@ components:
         - name
         - email
         - phone
+        - phone_verified
         - role
       properties:
         id:
@@ -2897,16 +3024,26 @@ components:
         phone:
           type: string
           example: "+573001234567"
+        phone_verified:
+          type: boolean
+          description: >-
+            Si el celular ya se confirmó con un código por SMS (historia
+            #69). No exige nada todavía: hoy ninguna acción de la cuenta
+            depende de este valor.
+          example: false
         role:
           type: string
           description: >-
             Rol de autenticación de la cuenta (ver la decisión de modelo de
             datos en .claude/STANDARDS.md). Sirve para que el cliente sepa qué
             UI mostrar; la autorización de negocio se resuelve con Policies en
-            el servidor, no con este campo.
+            el servidor, no con este campo. `admin` no tiene endpoint de
+            registro público (historia técnica #64): la cuenta se crea
+            manualmente.
           enum:
             - passenger
             - driver
+            - admin
           example: passenger
     AuthenticatedUser:
       type: object

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,11 +3,13 @@
 use App\Http\Controllers\Api\V1\Admin\ApproveDriverDocumentController;
 use App\Http\Controllers\Api\V1\Admin\ListDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Admin\RejectDriverDocumentController;
+use App\Http\Controllers\Api\V1\Auth\ConfirmPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Auth\RequestPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Documents\ShowDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Documents\UploadDriverDocumentController;
 use App\Http\Controllers\Api\V1\Drivers\ShowDriverEarningsController;
@@ -96,6 +98,22 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')
         ->post('me/device-token', RegisterDeviceTokenController::class)
         ->name('device-tokens.store');
+
+    // Confirmación del número de celular por SMS (historia #69). Cuelga de
+    // `me` como el token de push: no es una operación de un rol en
+    // particular. `phone-verification` es más estricto que el límite general
+    // de la API porque cada acierto le cuesta un SMS real apenas haya un
+    // proveedor conectado (ver AppServiceProvider::configureRateLimiting()).
+    Route::middleware(['auth:api', 'throttle:phone-verification'])
+        ->post('me/phone/verification', RequestPhoneVerificationController::class)
+        ->name('phone-verification.request');
+
+    // Confirmar sí se queda con el límite general: a diferencia de pedir el
+    // código, no dispara ningún SMS, y el propio código ya agota sus
+    // intentos (ver ConfirmPhoneVerificationRequest).
+    Route::middleware('auth:api')
+        ->post('me/phone/verification/confirm', ConfirmPhoneVerificationController::class)
+        ->name('phone-verification.confirm');
 
     // El vehículo del conductor cuelga de `me` porque es un sub-recurso de la
     // cuenta: se llega a él por el token, nunca por un id propio. Que solo los

--- a/tests/Feature/Auth/ConfirmPhoneVerificationTest.php
+++ b/tests/Feature/Auth/ConfirmPhoneVerificationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\PhoneVerificationCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/me/phone/verification/confirm — ver openapi.yaml.
+ */
+class ConfirmPhoneVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/phone/verification/confirm';
+
+    public function test_confirma_el_celular_con_el_codigo_correcto(): void
+    {
+        $usuario = User::factory()->create();
+        PhoneVerificationCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI, ['code' => '123456'])
+            ->assertOk()
+            ->assertJsonPath('data.phone_verified', true);
+
+        $this->assertNotNull($usuario->fresh()->phone_verified_at);
+        $this->assertDatabaseCount('phone_verification_codes', 0);
+    }
+
+    public function test_rechaza_un_codigo_incorrecto_y_cuenta_el_intento(): void
+    {
+        $usuario = User::factory()->create();
+        $verificacion = PhoneVerificationCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI, ['code' => '000000'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+
+        $this->assertSame(1, $verificacion->fresh()->attempts);
+        $this->assertNull($usuario->fresh()->phone_verified_at);
+    }
+
+    public function test_rechaza_un_codigo_vencido(): void
+    {
+        $usuario = User::factory()->create();
+        PhoneVerificationCode::factory()->expired()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI, ['code' => '123456'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_cuando_se_agotaron_los_intentos(): void
+    {
+        $usuario = User::factory()->create();
+        PhoneVerificationCode::factory()->exhausted()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI, ['code' => '123456'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_sin_ninguna_verificacion_pendiente(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI, ['code' => '123456'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_sin_codigo_en_el_body(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson(self::URI, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $this->postJson(self::URI, ['code' => '123456'])->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Auth/RequestPhoneVerificationTest.php
+++ b/tests/Feature/Auth/RequestPhoneVerificationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/me/phone/verification — ver openapi.yaml.
+ */
+class RequestPhoneVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/me/phone/verification';
+
+    private function gatewayFalso(): SmsGateway
+    {
+        return new class implements SmsGateway
+        {
+            public function send(string $phone, string $message): void {}
+        };
+    }
+
+    public function test_genera_un_codigo_y_lo_envia_por_sms(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+
+        $gateway = new class implements SmsGateway
+        {
+            public ?string $phone = null;
+
+            public ?string $message = null;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->phone = $phone;
+                $this->message = $message;
+            }
+        };
+        $this->app->instance(SmsGateway::class, $gateway);
+
+        $this->withToken(JWTAuth::fromUser($usuario))
+            ->postJson(self::URI)
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('phone_verification_codes', ['user_id' => $usuario->id]);
+        $this->assertSame('+573001234567', $gateway->phone);
+        $this->assertNotNull($gateway->message);
+    }
+
+    public function test_pedir_un_codigo_nuevo_reemplaza_el_anterior(): void
+    {
+        $usuario = User::factory()->create();
+        $this->app->instance(SmsGateway::class, $this->gatewayFalso());
+        $token = JWTAuth::fromUser($usuario);
+
+        $this->withToken($token)->postJson(self::URI)->assertNoContent();
+        $this->withToken($token)->postJson(self::URI)->assertNoContent();
+
+        $this->assertDatabaseCount('phone_verification_codes', 1);
+    }
+
+    public function test_respeta_el_limite_de_tres_solicitudes_cada_diez_minutos(): void
+    {
+        $usuario = User::factory()->create();
+        $this->app->instance(SmsGateway::class, $this->gatewayFalso());
+        $token = JWTAuth::fromUser($usuario);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->withToken($token)->postJson(self::URI)->assertNoContent();
+        }
+
+        $this->withToken($token)->postJson(self::URI)->assertStatus(429);
+    }
+
+    public function test_rechaza_la_solicitud_sin_token(): void
+    {
+        $this->postJson(self::URI)->assertUnauthorized();
+
+        $this->assertDatabaseCount('phone_verification_codes', 0);
+    }
+}

--- a/tests/Feature/Profile/ShowProfileTest.php
+++ b/tests/Feature/Profile/ShowProfileTest.php
@@ -42,6 +42,7 @@ class ShowProfileTest extends TestCase
                     'name' => 'Ana García',
                     'email' => 'ana@example.com',
                     'phone' => '+573001234567',
+                    'phone_verified' => false,
                     'role' => 'passenger',
                 ],
             ]);
@@ -89,6 +90,7 @@ class ShowProfileTest extends TestCase
                     'name' => 'Carlos Ramírez',
                     'email' => 'carlos@example.com',
                     'phone' => '+573009876543',
+                    'phone_verified' => false,
                     'role' => 'driver',
                     'driver_profile' => [
                         'license_number' => 'LIC-445566',

--- a/tests/Unit/Actions/Auth/ConfirmPhoneVerificationActionTest.php
+++ b/tests/Unit/Actions/Auth/ConfirmPhoneVerificationActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\ConfirmPhoneVerificationAction;
+use App\Models\PhoneVerificationCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConfirmPhoneVerificationActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_marca_el_celular_como_verificado_y_borra_el_codigo(): void
+    {
+        $usuario = User::factory()->create();
+        PhoneVerificationCode::factory()->create(['user_id' => $usuario->id]);
+
+        $resultado = (new ConfirmPhoneVerificationAction)->handle($usuario);
+
+        $this->assertNotNull($resultado->phone_verified_at);
+        $this->assertSame(0, PhoneVerificationCode::query()->count());
+    }
+}

--- a/tests/Unit/Actions/Auth/RequestPhoneVerificationActionTest.php
+++ b/tests/Unit/Actions/Auth/RequestPhoneVerificationActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\RequestPhoneVerificationAction;
+use App\Models\PhoneVerificationCode;
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RequestPhoneVerificationActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_el_codigo_asociado_a_la_cuenta_y_lo_envia(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+
+        $gateway = new class implements SmsGateway
+        {
+            public ?string $phone = null;
+
+            public ?string $message = null;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->phone = $phone;
+                $this->message = $message;
+            }
+        };
+
+        (new RequestPhoneVerificationAction($gateway))->handle($usuario);
+
+        $codigo = PhoneVerificationCode::query()->where('user_id', $usuario->id)->firstOrFail();
+        $this->assertSame(0, $codigo->attempts);
+        $this->assertTrue($codigo->expires_at->isFuture());
+        $this->assertSame('+573001234567', $gateway->phone);
+        $this->assertNotNull($gateway->message);
+    }
+
+    public function test_pedir_un_codigo_nuevo_reemplaza_el_hash_anterior(): void
+    {
+        $usuario = User::factory()->create();
+        $gateway = new class implements SmsGateway
+        {
+            public function send(string $phone, string $message): void {}
+        };
+        $action = new RequestPhoneVerificationAction($gateway);
+
+        $action->handle($usuario);
+        $primerHash = PhoneVerificationCode::query()->where('user_id', $usuario->id)->firstOrFail()->code_hash;
+
+        $action->handle($usuario);
+        $segundoHash = PhoneVerificationCode::query()->where('user_id', $usuario->id)->firstOrFail()->code_hash;
+
+        $this->assertSame(1, PhoneVerificationCode::query()->count());
+        $this->assertNotSame($primerHash, $segundoHash);
+    }
+}


### PR DESCRIPTION
## Resumen
- `POST /api/v1/me/phone/verification` — genera un código (uno vigente por cuenta) y lo envía por `SmsGateway`. Límite de 3 cada 10 minutos por cuenta.
- `POST /api/v1/me/phone/verification/confirm` — valida el código (correcto, sin vencer, sin agotar intentos) y deja `phone_verified_at`.
- `SmsGateway`/`NullSmsGateway` — mismo patrón que `PaymentGateway`/`PushNotificationGateway`: sin proveedor real (Twilio u otro), solo deja un registro en el log.
- `UserResource` ahora expone `phone_verified`, que se propaga a login, registro y `GET /me`.
- Corrección adicional: el schema `User` de `openapi.yaml` no incluía `admin` en el enum de `role` desde la historia #64 (los administradores también inician sesión).

Closes #69

## Plan de pruebas
- [x] `php artisan test` — 699 tests en verde.
- [x] `vendor/bin/pint --test` sin errores.
- [x] `vendor/bin/phpstan analyse` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)