### PR TITLE
feat(#75): cambiar el campo model del vehiculo por type (Motocarro/Motocarga)

### DIFF
--- a/app/Actions/Vehicles/RegisterVehicleAction.php
+++ b/app/Actions/Vehicles/RegisterVehicleAction.php
@@ -29,7 +29,7 @@ final class RegisterVehicleAction
     {
         return $driver->vehicle()->create([
             'plate' => $registration->plate,
-            'model' => $registration->model,
+            'type' => $registration->type,
             'year' => $registration->year,
         ]);
     }

--- a/app/Actions/Vehicles/UpdateVehicleAction.php
+++ b/app/Actions/Vehicles/UpdateVehicleAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Vehicles;
 
 use App\DTOs\VehicleUpdate;
+use App\Enums\VehicleType;
 use App\Models\Vehicle;
 
 /**
@@ -26,7 +27,7 @@ final class UpdateVehicleAction
     public function handle(Vehicle $vehicle, VehicleUpdate $update): Vehicle
     {
         // Descarta también la cadena vacía, y no solo `null`: las tres columnas
-        // son NOT NULL y una moto sin placa ni modelo no le sirve al pasajero
+        // son NOT NULL y una moto sin placa ni tipo no le sirve al pasajero
         // que tiene que reconocerla. `UpdateVehicleRequest` ya lo ataja con
         // `sometimes|required`, pero esta Action es invocable desde un job o un
         // comando que no pasa por el Form Request, y su invariante propia es
@@ -34,10 +35,10 @@ final class UpdateVehicleAction
         $datos = array_filter(
             [
                 'plate' => $update->plate,
-                'model' => $update->model,
+                'type' => $update->type,
                 'year' => $update->year,
             ],
-            static fn (string|int|null $valor): bool => is_string($valor)
+            static fn (string|int|VehicleType|null $valor): bool => is_string($valor)
                 ? trim($valor) !== ''
                 : $valor !== null,
         );

--- a/app/DTOs/VehicleRegistration.php
+++ b/app/DTOs/VehicleRegistration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\DTOs;
 
+use App\Enums\VehicleType;
+
 /**
  * Datos con los que un conductor da de alta su moto, ya validados.
  *
@@ -17,7 +19,7 @@ final readonly class VehicleRegistration
 {
     public function __construct(
         public string $plate,
-        public string $model,
+        public VehicleType $type,
         public int $year,
     ) {}
 }

--- a/app/DTOs/VehicleUpdate.php
+++ b/app/DTOs/VehicleUpdate.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\DTOs;
 
+use App\Enums\VehicleType;
+
 /**
  * Datos a corregir en la moto ya registrada de un conductor, ya validados.
  *
@@ -20,7 +22,7 @@ final readonly class VehicleUpdate
 {
     public function __construct(
         public ?string $plate = null,
-        public ?string $model = null,
+        public ?VehicleType $type = null,
         public ?int $year = null,
     ) {}
 }

--- a/app/Enums/VehicleType.php
+++ b/app/Enums/VehicleType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Las dos categorías de vehículo que opera la app (historia técnica #75).
+ *
+ * Reemplaza el antiguo campo `model` (texto libre): el año ya identifica el
+ * modelo puntual, y lo que importa operativamente —para el servicio y para
+ * el censo de vehículos y conductores que la app busca sostener con el
+ * tiempo— es si el vehículo es un motocarro o una motocarga.
+ */
+enum VehicleType: string
+{
+    case Motocarro = 'motocarro';
+    case Motocarga = 'motocarga';
+}

--- a/app/Http/Requests/Vehicles/RegisterVehicleRequest.php
+++ b/app/Http/Requests/Vehicles/RegisterVehicleRequest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Requests\Vehicles;
 
 use App\DTOs\VehicleRegistration;
+use App\Enums\VehicleType;
 use App\Models\User;
 use App\Models\Vehicle;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Enum;
 
 /**
  * Entrada de POST /api/v1/me/vehicle — ver openapi.yaml.
@@ -70,7 +72,7 @@ class RegisterVehicleRequest extends FormRequest
                 'regex:/^[A-Z0-9-]{5,10}$/',
                 'unique:vehicles,plate',
             ],
-            'model' => ['required', 'string', 'max:100'],
+            'type' => ['required', new Enum(VehicleType::class)],
             // El tope es el año que viene porque los modelos se venden
             // adelantados al calendario. Los dos límites atajan el dedazo
             // (`2205`, `19999`), no declaran una antigüedad máxima de la flota:
@@ -130,7 +132,7 @@ class RegisterVehicleRequest extends FormRequest
     {
         return new VehicleRegistration(
             plate: $this->string('plate')->toString(),
-            model: $this->string('model')->toString(),
+            type: VehicleType::from($this->string('type')->toString()),
             year: $this->integer('year'),
         );
     }

--- a/app/Http/Requests/Vehicles/UpdateVehicleRequest.php
+++ b/app/Http/Requests/Vehicles/UpdateVehicleRequest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Requests\Vehicles;
 
 use App\DTOs\VehicleUpdate;
+use App\Enums\VehicleType;
 use App\Models\User;
 use App\Models\Vehicle;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -128,7 +130,7 @@ class UpdateVehicleRequest extends FormRequest
                 'regex:/^[A-Z0-9-]{5,10}$/',
                 Rule::unique('vehicles', 'plate')->ignore($this->vehicle()->getKey()),
             ],
-            'model' => ['sometimes', 'required', 'string', 'max:100'],
+            'type' => ['sometimes', 'required', new Enum(VehicleType::class)],
             // El tope es el año que viene porque los modelos se venden
             // adelantados al calendario, igual que en el alta.
             'year' => ['sometimes', 'required', 'integer', 'digits:4', 'min:1970', 'max:'.((int) date('Y') + 1)],
@@ -160,7 +162,7 @@ class UpdateVehicleRequest extends FormRequest
     {
         return new VehicleUpdate(
             plate: $this->has('plate') ? $this->string('plate')->toString() : null,
-            model: $this->has('model') ? $this->string('model')->toString() : null,
+            type: $this->has('type') ? VehicleType::from($this->string('type')->toString()) : null,
             year: $this->has('year') ? $this->integer('year') : null,
         );
     }

--- a/app/Http/Resources/RideDriverResource.php
+++ b/app/Http/Resources/RideDriverResource.php
@@ -15,7 +15,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * Es deliberadamente más chico que {@see UserResource}: ahí el que mira es el
  * dueño de la cuenta, acá es la contraparte del viaje. Va lo mínimo para saber
  * a quién se está esperando; el `email`, el `phone` y el `role` no tienen nada
- * que hacer del otro lado, y los datos de la moto (placa, modelo) no entran
+ * que hacer del otro lado, y los datos de la moto (placa, tipo) no entran
  * todavía porque ninguna historia los pidió.
  *
  * Sí publica el `id`, al revés que `DriverProfileResource`: es el id de `User`

--- a/app/Http/Resources/VehicleResource.php
+++ b/app/Http/Resources/VehicleResource.php
@@ -27,7 +27,7 @@ class VehicleResource extends JsonResource
     {
         return [
             'plate' => $this->resource->plate,
-            'model' => $this->resource->model,
+            'type' => $this->resource->type->value,
             'year' => $this->resource->year,
         ];
     }

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\VehicleType;
 use App\Policies\VehiclePolicy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
@@ -21,9 +22,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * más frágil de lo que conviene.
  *
  * @property int $user_id
+ * @property VehicleType $type
  * @property int $year
  */
-#[Fillable(['user_id', 'plate', 'model', 'year'])]
+#[Fillable(['user_id', 'plate', 'type', 'year'])]
 #[UsePolicy(VehiclePolicy::class)]
 class Vehicle extends Model
 {
@@ -32,6 +34,7 @@ class Vehicle extends Model
     protected function casts(): array
     {
         return [
+            'type' => VehicleType::class,
             'year' => 'integer',
         ];
     }

--- a/database/factories/VehicleFactory.php
+++ b/database/factories/VehicleFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\VehicleType;
 use App\Models\User;
 use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -25,12 +26,7 @@ class VehicleFactory extends Factory
             // más laxo a propósito, ver openapi.yaml— pero para los datos de
             // prueba conviene que se parezcan a los reales.
             'plate' => fake()->unique()->bothify('???##?', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
-            'model' => fake()->randomElement([
-                'Bajaj Boxer CT 100',
-                'Yamaha YBR 125',
-                'Honda CB 110',
-                'Suzuki GN 125',
-            ]),
+            'type' => fake()->randomElement(VehicleType::cases()),
             'year' => fake()->numberBetween(2010, (int) date('Y')),
         ];
     }

--- a/database/migrations/2026_09_10_000001_replace_vehicles_model_with_type.php
+++ b/database/migrations/2026_09_10_000001_replace_vehicles_model_with_type.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Reemplaza `vehicles.model` (texto libre) por `vehicles.type`, respaldado
+ * por `App\Enums\VehicleType` (historia técnica #75). El proyecto todavía no
+ * está en producción, así que no hace falta un paso de backfill: se elimina
+ * la columna vieja y se crea la nueva en la misma migración.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            $table->dropColumn('model');
+        });
+
+        Schema::table('vehicles', function (Blueprint $table) {
+            $table->string('type')->after('plate');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+
+        Schema::table('vehicles', function (Blueprint $table) {
+            $table->string('model', 100)->after('plate');
+        });
+    }
+};

--- a/lang/es/validation.php
+++ b/lang/es/validation.php
@@ -182,7 +182,6 @@ return [
         'latitude' => 'latitud',
         'license_number' => 'número de licencia',
         'longitude' => 'longitud',
-        'model' => 'modelo',
         'name' => 'nombre',
         'origin' => 'origen',
         'page' => 'página',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -825,7 +825,7 @@ paths:
               example:
                 data:
                   plate: ABC12D
-                  model: Bajaj Boxer CT 100
+                  type: motocarro
                   year: 2022
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -903,7 +903,7 @@ paths:
               $ref: "#/components/schemas/VehicleRegistrationRequest"
             example:
               plate: ABC12D
-              model: Bajaj Boxer CT 100
+              type: motocarro
               year: 2022
       responses:
         "201":
@@ -920,7 +920,7 @@ paths:
               example:
                 data:
                   plate: ABC12D
-                  model: Bajaj Boxer CT 100
+                  type: motocarro
                   year: 2022
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -976,7 +976,7 @@ paths:
 
         Es un PATCH parcial, igual que `PATCH /me`: solo los campos presentes
         en el body se cambian, el resto conserva su valor. Un campo presente no
-        puede venir vacío — `{"model": ""}` responde 422, no borra el modelo;
+        puede venir vacío — `{"type": ""}` responde 422, no borra el tipo;
         las tres columnas son NOT NULL. La forma de no tocar un dato es no
         mandarlo.
 
@@ -1006,7 +1006,7 @@ paths:
             schema:
               $ref: "#/components/schemas/VehicleUpdateRequest"
             example:
-              model: Bajaj Boxer CT 100 ES
+              type: motocarga
               year: 2023
       responses:
         "200":
@@ -1023,7 +1023,7 @@ paths:
               example:
                 data:
                   plate: ABC12D
-                  model: Bajaj Boxer CT 100 ES
+                  type: motocarga
                   year: 2023
         "401":
           description: Falta el access token, es ilegible o ya venció.
@@ -3208,7 +3208,7 @@ components:
         ahí.
       required:
         - plate
-        - model
+        - type
         - year
       properties:
         plate:
@@ -3217,13 +3217,17 @@ components:
             Placa tal como quedó guardada, en su forma canónica (mayúsculas,
             sin espacios al borde).
           example: ABC12D
-        model:
+        type:
           type: string
-          description: Modelo declarado por el conductor, texto libre.
-          example: Bajaj Boxer CT 100
+          enum: [motocarro, motocarga]
+          description: >-
+            Categoría del vehículo. El año ya identifica el modelo puntual;
+            esto es lo que importa operativamente para el servicio y para el
+            censo de vehículos y conductores.
+          example: motocarro
         year:
           type: integer
-          description: Año del modelo.
+          description: Año del vehículo.
           example: 2022
     DeviceToken:
       type: object
@@ -3520,7 +3524,7 @@ components:
         pertenece: el dueño es siempre la cuenta que envía el token.
       required:
         - plate
-        - model
+        - type
         - year
       properties:
         plate:
@@ -3542,14 +3546,14 @@ components:
             licencia.
           pattern: "^[A-Z0-9-]{5,10}$"
           example: ABC12D
-        model:
+        type:
           type: string
-          maxLength: 100
+          enum: [motocarro, motocarga]
           description: >-
-            Modelo de la moto, texto libre: no hay catálogo de marcas ni
-            modelos, y fabricar uno para un dato que hoy solo sirve para que el
-            pasajero reconozca la moto que lo recoge sería inventar un problema.
-          example: Bajaj Boxer CT 100
+            Categoría del vehículo. El año ya identifica el modelo puntual;
+            esto es lo que importa operativamente para el servicio y para el
+            censo de vehículos y conductores.
+          example: motocarro
         year:
           type: integer
           minimum: 1970
@@ -3572,14 +3576,14 @@ components:
         pueda elegir.
 
         **Opcional no es vaciable.** Un campo que viene tiene que traer un
-        valor: las tres columnas son NOT NULL, y una moto sin placa ni modelo
+        valor: las tres columnas son NOT NULL, y una moto sin placa ni tipo
         no le sirve al pasajero que tiene que reconocerla. La forma de no
         cambiar un dato es no mandarlo.
 
         Las reglas de cada campo son las mismas del alta (`plate` normalizada y
-        única, `model` texto libre, `year` de cuatro dígitos hasta el que viene)
-        — un dato corregido no puede quedar en un estado que el alta habría
-        rechazado.
+        única, `type` uno de los dos valores fijos, `year` de cuatro dígitos
+        hasta el que viene) — un dato corregido no puede quedar en un estado
+        que el alta habría rechazado.
       properties:
         plate:
           type: string
@@ -3594,12 +3598,11 @@ components:
             mismo.
           pattern: "^[A-Z0-9-]{5,10}$"
           example: ABC12D
-        model:
+        type:
           type: string
-          minLength: 1
-          maxLength: 100
-          description: Modelo de la moto, texto libre. Mismo criterio que el alta.
-          example: Bajaj Boxer CT 100 ES
+          enum: [motocarro, motocarga]
+          description: Categoría del vehículo. Mismo criterio que el alta.
+          example: motocarga
         year:
           type: integer
           minimum: 1970
@@ -3872,7 +3875,7 @@ components:
         Es deliberadamente más chico que `User`: acá el que mira es la
         contraparte del viaje, no el dueño de la cuenta. Va lo mínimo para
         saber a quién se está esperando; el teléfono y los datos de la moto
-        (placa, modelo) no entran todavía porque ninguna historia los pidió, y
+        (placa, tipo) no entran todavía porque ninguna historia los pidió, y
         publicar el contacto de una persona a la otra es una decisión de
         producto, no un detalle de serialización.
       required:

--- a/tests/Feature/Vehicles/RegisterVehicleTest.php
+++ b/tests/Feature/Vehicles/RegisterVehicleTest.php
@@ -36,7 +36,7 @@ class RegisterVehicleTest extends TestCase
             ->assertExactJson([
                 'data' => [
                     'plate' => 'ABC12D',
-                    'model' => 'Bajaj Boxer CT 100',
+                    'type' => 'motocarro',
                     'year' => 2022,
                 ],
             ]);
@@ -44,7 +44,7 @@ class RegisterVehicleTest extends TestCase
         $this->assertDatabaseHas('vehicles', [
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
     }
@@ -182,9 +182,9 @@ class RegisterVehicleTest extends TestCase
             // servidor adivine cómo debería haberse escrito.
             'placa con espacios interiores' => [['plate' => 'ABC 12D'], 'plate'],
             'placa con símbolos' => [['plate' => 'ABC*12D'], 'plate'],
-            'sin modelo' => [['model' => null], 'model'],
-            'modelo vacío' => [['model' => ''], 'model'],
-            'modelo demasiado largo' => [['model' => str_repeat('a', 101)], 'model'],
+            'sin tipo' => [['type' => null], 'type'],
+            'tipo vacío' => [['type' => ''], 'type'],
+            'tipo inválido' => [['type' => 'automovil'], 'type'],
             'sin año' => [['year' => null], 'year'],
             'año no numérico' => [['year' => 'dos mil veintidós'], 'year'],
             'año de dos dígitos' => [['year' => 22], 'year'],
@@ -257,7 +257,7 @@ class RegisterVehicleTest extends TestCase
     {
         return [
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ];
     }

--- a/tests/Feature/Vehicles/ShowVehicleTest.php
+++ b/tests/Feature/Vehicles/ShowVehicleTest.php
@@ -30,7 +30,7 @@ class ShowVehicleTest extends TestCase
         Vehicle::factory()->create([
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
 
@@ -40,7 +40,7 @@ class ShowVehicleTest extends TestCase
             ->assertExactJson([
                 'data' => [
                     'plate' => 'ABC12D',
-                    'model' => 'Bajaj Boxer CT 100',
+                    'type' => 'motocarro',
                     'year' => 2022,
                 ],
             ]);
@@ -67,7 +67,7 @@ class ShowVehicleTest extends TestCase
         Vehicle::factory()->create([
             'user_id' => $otro->id,
             'plate' => 'JJJ11J',
-            'model' => 'Honda CB 110',
+            'type' => 'motocarga',
             'year' => 2020,
         ]);
 

--- a/tests/Feature/Vehicles/UpdateVehicleTest.php
+++ b/tests/Feature/Vehicles/UpdateVehicleTest.php
@@ -33,21 +33,21 @@ class UpdateVehicleTest extends TestCase
         Vehicle::factory()->create([
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
 
         $this->withToken(JWTAuth::fromUser($conductor))
             ->patchJson(self::URI, [
                 'plate' => 'XYZ98W',
-                'model' => 'Bajaj Boxer CT 100 ES',
+                'type' => 'motocarga',
                 'year' => 2023,
             ])
             ->assertOk()
             ->assertExactJson([
                 'data' => [
                     'plate' => 'XYZ98W',
-                    'model' => 'Bajaj Boxer CT 100 ES',
+                    'type' => 'motocarga',
                     'year' => 2023,
                 ],
             ]);
@@ -55,7 +55,7 @@ class UpdateVehicleTest extends TestCase
         $this->assertDatabaseHas('vehicles', [
             'user_id' => $conductor->id,
             'plate' => 'XYZ98W',
-            'model' => 'Bajaj Boxer CT 100 ES',
+            'type' => 'motocarga',
             'year' => 2023,
         ]);
     }
@@ -67,7 +67,7 @@ class UpdateVehicleTest extends TestCase
         Vehicle::factory()->create([
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
 
@@ -77,7 +77,7 @@ class UpdateVehicleTest extends TestCase
             ->assertExactJson([
                 'data' => [
                     'plate' => 'ABC12D',
-                    'model' => 'Bajaj Boxer CT 100',
+                    'type' => 'motocarro',
                     'year' => 2023,
                 ],
             ]);
@@ -85,7 +85,7 @@ class UpdateVehicleTest extends TestCase
         $this->assertDatabaseHas('vehicles', [
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2023,
         ]);
     }
@@ -170,7 +170,7 @@ class UpdateVehicleTest extends TestCase
         $ajeno = Vehicle::factory()->create([
             'user_id' => $otro->id,
             'plate' => 'JJJ11J',
-            'model' => 'Honda CB 110',
+            'type' => 'motocarro',
             'year' => 2020,
         ]);
 
@@ -181,7 +181,7 @@ class UpdateVehicleTest extends TestCase
             ->patchJson(self::URI, [
                 'id' => $ajeno->id,
                 'user_id' => $otro->id,
-                'model' => 'Yamaha YBR 125',
+                'type' => 'motocarga',
             ])
             ->assertOk()
             ->assertJsonPath('data.plate', 'ABC12D');
@@ -189,11 +189,11 @@ class UpdateVehicleTest extends TestCase
         $this->assertDatabaseHas('vehicles', [
             'id' => $ajeno->id,
             'user_id' => $otro->id,
-            'model' => 'Honda CB 110',
+            'type' => 'motocarro',
         ]);
         $this->assertDatabaseHas('vehicles', [
             'user_id' => $conductor->id,
-            'model' => 'Yamaha YBR 125',
+            'type' => 'motocarga',
         ]);
     }
 
@@ -262,7 +262,7 @@ class UpdateVehicleTest extends TestCase
         Vehicle::factory()->create([
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
 
@@ -274,7 +274,7 @@ class UpdateVehicleTest extends TestCase
         $this->assertDatabaseHas('vehicles', [
             'user_id' => $conductor->id,
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
     }
@@ -282,7 +282,7 @@ class UpdateVehicleTest extends TestCase
     /**
      * Un campo ausente es "no lo toques", pero uno presente no puede venir
      * vacío ni en `null`: las tres columnas son NOT NULL y un vehículo sin
-     * placa ni modelo no le sirve al pasajero que tiene que reconocerlo.
+     * placa ni tipo no le sirve al pasajero que tiene que reconocerlo.
      *
      * @return array<string, array{array<string, mixed>, string}>
      */
@@ -296,9 +296,9 @@ class UpdateVehicleTest extends TestCase
             'placa demasiado larga' => [['plate' => 'ABCDE12345F'], 'plate'],
             'placa con espacios interiores' => [['plate' => 'ABC 12D'], 'plate'],
             'placa con símbolos' => [['plate' => 'ABC*12D'], 'plate'],
-            'modelo vacío' => [['model' => ''], 'model'],
-            'modelo en null' => [['model' => null], 'model'],
-            'modelo demasiado largo' => [['model' => str_repeat('a', 101)], 'model'],
+            'tipo vacío' => [['type' => ''], 'type'],
+            'tipo en null' => [['type' => null], 'type'],
+            'tipo inválido' => [['type' => 'automovil'], 'type'],
             'año en null' => [['year' => null], 'year'],
             'año no numérico' => [['year' => 'dos mil veintidós'], 'year'],
             'año de dos dígitos' => [['year' => 22], 'year'],

--- a/tests/Unit/Actions/Vehicles/RegisterVehicleActionTest.php
+++ b/tests/Unit/Actions/Vehicles/RegisterVehicleActionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions\Vehicles;
 
 use App\Actions\Vehicles\RegisterVehicleAction;
 use App\DTOs\VehicleRegistration;
+use App\Enums\VehicleType;
 use App\Models\User;
 use App\Models\Vehicle;
 use Illuminate\Database\QueryException;
@@ -28,7 +29,7 @@ class RegisterVehicleActionTest extends TestCase
 
         $this->assertTrue($vehiculo->exists);
         $this->assertSame('ABC12D', $vehiculo->plate);
-        $this->assertSame('Bajaj Boxer CT 100', $vehiculo->model);
+        $this->assertSame(VehicleType::Motocarro, $vehiculo->type);
         $this->assertSame(2022, $vehiculo->year);
         $this->assertDatabaseCount('vehicles', 1);
         $this->assertDatabaseHas('vehicles', [
@@ -93,7 +94,7 @@ class RegisterVehicleActionTest extends TestCase
     {
         return new VehicleRegistration(
             plate: 'ABC12D',
-            model: 'Bajaj Boxer CT 100',
+            type: VehicleType::Motocarro,
             year: 2022,
         );
     }

--- a/tests/Unit/Actions/Vehicles/UpdateVehicleActionTest.php
+++ b/tests/Unit/Actions/Vehicles/UpdateVehicleActionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions\Vehicles;
 
 use App\Actions\Vehicles\UpdateVehicleAction;
 use App\DTOs\VehicleUpdate;
+use App\Enums\VehicleType;
 use App\Models\User;
 use App\Models\Vehicle;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -26,7 +27,7 @@ class UpdateVehicleActionTest extends TestCase
         $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(year: 2023));
 
         $this->assertSame('ABC12D', $resultado->plate);
-        $this->assertSame('Bajaj Boxer CT 100', $resultado->model);
+        $this->assertSame(VehicleType::Motocarro, $resultado->type);
         $this->assertSame(2023, $resultado->year);
     }
 
@@ -45,6 +46,8 @@ class UpdateVehicleActionTest extends TestCase
     /**
      * La Action no depende de que la haya llamado el Form Request: un job o un
      * comando pueden armar el DTO a mano, y las tres columnas son NOT NULL.
+     * `type` ya no puede llegar como cadena vacía —es un `VehicleType` o
+     * `null`—, así que el caso a defender queda solo en `plate`.
      */
     public function test_ignora_los_campos_de_texto_que_vienen_vacios_en_el_dto(): void
     {
@@ -52,16 +55,14 @@ class UpdateVehicleActionTest extends TestCase
 
         $resultado = $this->action()->handle(
             $vehiculo,
-            new VehicleUpdate(plate: '   ', model: ''),
+            new VehicleUpdate(plate: '   '),
         );
 
         $this->assertSame('ABC12D', $resultado->plate);
-        $this->assertSame('Bajaj Boxer CT 100', $resultado->model);
 
         $recargado = $vehiculo->fresh();
 
         $this->assertSame('ABC12D', $recargado->plate);
-        $this->assertSame('Bajaj Boxer CT 100', $recargado->model);
     }
 
     public function test_el_dueno_no_cambia_porque_el_dto_no_lo_tiene(): void
@@ -72,10 +73,10 @@ class UpdateVehicleActionTest extends TestCase
         $vehiculo = $this->vehiculo();
         $dueno = $vehiculo->user_id;
 
-        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(model: 'Yamaha YBR 125'));
+        $resultado = $this->action()->handle($vehiculo, new VehicleUpdate(type: VehicleType::Motocarga));
 
         $this->assertSame($dueno, $resultado->user_id);
-        $this->assertDatabaseHas('vehicles', ['user_id' => $dueno, 'model' => 'Yamaha YBR 125']);
+        $this->assertDatabaseHas('vehicles', ['user_id' => $dueno, 'type' => 'motocarga']);
     }
 
     public function test_devuelve_la_instancia_con_los_datos_ya_actualizados(): void
@@ -91,11 +92,11 @@ class UpdateVehicleActionTest extends TestCase
 
     public function test_no_toca_ningun_otro_vehiculo(): void
     {
-        $ajeno = Vehicle::factory()->create(['plate' => 'JJJ11J', 'model' => 'Honda CB 110']);
+        $ajeno = Vehicle::factory()->create(['plate' => 'JJJ11J', 'type' => 'motocarro']);
 
-        $this->action()->handle($this->vehiculo(), new VehicleUpdate(model: 'Yamaha YBR 125'));
+        $this->action()->handle($this->vehiculo(), new VehicleUpdate(type: VehicleType::Motocarga));
 
-        $this->assertDatabaseHas('vehicles', ['id' => $ajeno->id, 'model' => 'Honda CB 110']);
+        $this->assertDatabaseHas('vehicles', ['id' => $ajeno->id, 'type' => 'motocarro']);
     }
 
     private function action(): UpdateVehicleAction
@@ -108,7 +109,7 @@ class UpdateVehicleActionTest extends TestCase
         return Vehicle::factory()->create([
             'user_id' => User::factory()->driver(),
             'plate' => 'ABC12D',
-            'model' => 'Bajaj Boxer CT 100',
+            'type' => 'motocarro',
             'year' => 2022,
         ]);
     }


### PR DESCRIPTION
## Resumen
- Reemplaza `vehicles.model` (texto libre) por `vehicles.type`, respaldado por el enum `App\Enums\VehicleType` con exactamente dos valores: `motocarro` y `motocarga`. El año ya identifica el modelo puntual; lo que importa operativamente para el servicio y para el censo de vehículos y conductores es la categoría.
- Migración nueva que reemplaza la columna (sin backfill: el proyecto todavía no está en producción, no hay datos reales que preservar).
- `RegisterVehicleRequest`/`UpdateVehicleRequest` validan `type` con `Illuminate\Validation\Rules\Enum` (mismo patrón que `DocumentType` en la subida de documentos).
- `VehicleResource`, `RegisterVehicleAction`, `UpdateVehicleAction`, `VehicleFactory` y `openapi.yaml` actualizados.
- Tests de `RegisterVehicleTest`, `UpdateVehicleTest`, `ShowVehicleTest` y los tests unitarios de las Actions actualizados a `type`.

Es un breaking change de la API (el campo se renombra y su valor pasa de texto libre a uno de dos valores fijos), aceptado porque el proyecto todavía no está en producción.

## Plan de pruebas
- [x] `php artisan test` — 704/704 verdes
- [x] `vendor/bin/pint --test` — verde
- [x] `vendor/bin/phpstan analyse` — 0 errores

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)