### PR TITLE
fix(#75): agregar default transitorio a la migracion de vehicles.type

### DIFF
--- a/database/migrations/2026_09_10_000001_replace_vehicles_model_with_type.php
+++ b/database/migrations/2026_09_10_000001_replace_vehicles_model_with_type.php
@@ -7,8 +7,17 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Reemplaza `vehicles.model` (texto libre) por `vehicles.type`, respaldado
  * por `App\Enums\VehicleType` (historia técnica #75). El proyecto todavía no
- * está en producción, así que no hace falta un paso de backfill: se elimina
- * la columna vieja y se crea la nueva en la misma migración.
+ * está en producción, así que no hace falta un paso de backfill real: se
+ * elimina la columna vieja y se crea la nueva en la misma migración.
+ *
+ * `type` lleva un `default()` transitorio (`motocarro`) únicamente porque
+ * SQLite no permite agregar una columna NOT NULL sin valor por defecto
+ * cuando la tabla ya tiene filas — ni siquiera dentro de una migración que
+ * nunca corrió antes contra datos reales, cualquier entorno de desarrollo
+ * con vehículos de prueba ya cargados choca con esto. Ninguna fila nueva
+ * depende de ese valor: el Form Request exige `type` como campo requerido,
+ * así que el default nunca lo pone un cliente real, solo lo necesita el
+ * ALTER TABLE para poder ejecutarse.
  */
 return new class extends Migration
 {
@@ -19,7 +28,7 @@ return new class extends Migration
         });
 
         Schema::table('vehicles', function (Blueprint $table) {
-            $table->string('type')->after('plate');
+            $table->string('type')->default('motocarro')->after('plate');
         });
     }
 


### PR DESCRIPTION
## Resumen
SQLite rechaza agregar una columna `NOT NULL` sin valor por defecto cuando la tabla ya tiene filas. La migración de #75 (`replace_vehicles_model_with_type`) pasó CI porque la suite de tests usa una base `:memory:` que siempre arranca vacía, pero falló al correr `php artisan migrate` contra una base de datos local con datos de prueba ya cargados (dejó la tabla en un estado intermedio: sin `model` y sin `type`).

El fix agrega `->default('motocarro')` a la definición de la columna — puramente técnico para que el `ALTER TABLE` pueda ejecutarse; ninguna fila nueva depende de él porque `type` sigue siendo un campo requerido en los Form Requests.

## Plan de pruebas
- [x] `php artisan migrate:fresh` contra la base de datos local — verde
- [x] `php artisan test` — 704/704 verdes
- [x] `vendor/bin/pint --test` — verde
- [x] `vendor/bin/phpstan analyse` — 0 errores

Relacionado con #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)