### PR TITLE
feat(#78): agregar foto del vehiculo como tercer documento obligatorio

### DIFF
--- a/app/Enums/DocumentType.php
+++ b/app/Enums/DocumentType.php
@@ -12,10 +12,20 @@ namespace App\Enums;
  * lo único que importa es que la persona pueda identificarse, no el tipo de
  * documento con el que lo hace.
  *
+ * `FotoVehiculo` existe por antifraude, no por identidad (decisión de
+ * negocio, historia técnica #75): una tarjeta de propiedad por sí sola no
+ * prueba que corresponda al vehículo físico que el conductor realmente
+ * opera — una tarjeta de un vehículo dado de baja o en patios puede
+ * reutilizarse para registrar uno distinto. Comparar la foto contra la
+ * tarjeta es un paso manual del admin al revisar (`AdminDriverDocumentResource`),
+ * no algo que este enum ni el backend verifiquen automáticamente. Es también
+ * la base del censo real de vehículos y conductores que la app busca
+ * sostener con el tiempo.
+ *
  * Licencia de conducción y SOAT quedan fuera del alcance actual a propósito
- * (decisión de negocio): hoy solo cédula/tarjeta de propiedad son
- * obligatorias para operar. Si el negocio decide exigirlas más adelante, se
- * agregan acá y a `required()`.
+ * (decisión de negocio): hoy solo cédula, tarjeta de propiedad y foto del
+ * vehículo son obligatorias para operar. Si el negocio decide exigirlas más
+ * adelante, se agregan acá y a `required()`.
  *
  * Los valores viajan tal cual a `driver_documents.type`, y junto con
  * `driver_profile_id` sostienen el índice único que garantiza un solo
@@ -26,6 +36,7 @@ enum DocumentType: string
 {
     case Identidad = 'identidad';
     case TarjetaPropiedad = 'tarjeta_propiedad';
+    case FotoVehiculo = 'foto_vehiculo';
 
     /**
      * Los documentos exigidos hoy para quedar verificado. Un conductor queda
@@ -36,6 +47,6 @@ enum DocumentType: string
      */
     public static function required(): array
     {
-        return [self::Identidad, self::TarjetaPropiedad];
+        return [self::Identidad, self::TarjetaPropiedad, self::FotoVehiculo];
     }
 }

--- a/app/Http/Controllers/Api/V1/Documents/UploadDriverDocumentController.php
+++ b/app/Http/Controllers/Api/V1/Documents/UploadDriverDocumentController.php
@@ -14,8 +14,8 @@ use Illuminate\Http\JsonResponse;
  * POST /api/v1/me/documents
  *
  * Sube (o reemplaza) uno de los documentos de verificación del conductor
- * autenticado: documento de identidad o tarjeta de propiedad del motocarro
- * (ver `DocumentType`).
+ * autenticado: documento de identidad, tarjeta de propiedad o foto del
+ * vehículo (ver `DocumentType`).
  */
 class UploadDriverDocumentController extends Controller
 {

--- a/app/Models/DriverDocument.php
+++ b/app/Models/DriverDocument.php
@@ -16,10 +16,10 @@ use Illuminate\Support\Carbon;
 
 /**
  * Un documento subido por un conductor para su verificación (documento de
- * identidad o tarjeta de propiedad del motocarro; ver `DocumentType`).
+ * identidad, tarjeta de propiedad o foto del vehículo; ver `DocumentType`).
  *
  * `path` apunta al disco `local` —privado, nunca servido por una URL
- * pública como el disco `public`— porque son documentos de identidad.
+ * pública como el disco `public`— porque son documentos sensibles.
  *
  * @property DocumentType $type
  * @property string $path

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1090,10 +1090,10 @@ paths:
         `rejected`), y el estado general de la cuenta.
 
         Siempre lista los documentos exigidos hoy (`identidad`,
-        `tarjeta_propiedad`) aunque el conductor todavía no haya subido
-        alguno — ese documento aparece con `status: null`. Licencia de
-        conducción y SOAT no son obligatorios en esta etapa (decisión de
-        negocio) y por eso no aparecen en la lista.
+        `tarjeta_propiedad`, `foto_vehiculo`) aunque el conductor todavía no
+        haya subido alguno — ese documento aparece con `status: null`.
+        Licencia de conducción y SOAT no son obligatorios en esta etapa
+        (decisión de negocio) y por eso no aparecen en la lista.
 
         Cuelga de `/me` como el vehículo: se llega por el token, nunca por un
         id propio. Requiere un token vigente y rol `driver`.
@@ -1120,6 +1120,10 @@ paths:
                       rejection_reason: null
                       uploaded_at: "2026-09-04T15:00:00.000000Z"
                     - type: tarjeta_propiedad
+                      status: null
+                      rejection_reason: null
+                      uploaded_at: null
+                    - type: foto_vehiculo
                       status: null
                       rejection_reason: null
                       uploaded_at: null
@@ -1154,8 +1158,11 @@ paths:
       summary: Subir (o reemplazar) un documento de verificación
       description: >-
         Sube uno de los documentos de verificación del conductor autenticado:
-        `identidad` (cédula, cédula de extranjería o PTP, indistintamente) o
-        `tarjeta_propiedad` del motocarro.
+        `identidad` (cédula, cédula de extranjería o PTP, indistintamente),
+        `tarjeta_propiedad` del vehículo, o `foto_vehiculo` (foto del
+        vehículo físico, historia técnica #75 — antifraude: una tarjeta de
+        propiedad por sí sola no prueba que corresponda al vehículo que el
+        conductor realmente opera).
 
         Volver a subir el mismo `type` **reemplaza** el archivo y la fila
         existentes, no los duplica: no es un alta-o-reemplazo condicional
@@ -1165,7 +1172,8 @@ paths:
         nuevo (ver historia técnica #64, revisión por un administrador).
 
         El archivo se guarda en almacenamiento privado, nunca en una URL
-        servida públicamente: son documentos de identidad.
+        servida públicamente: son documentos sensibles (identidad y datos del
+        vehículo).
 
         Requiere un token vigente y rol `driver`.
       security:
@@ -1182,7 +1190,7 @@ paths:
               properties:
                 type:
                   type: string
-                  enum: [identidad, tarjeta_propiedad]
+                  enum: [identidad, tarjeta_propiedad, foto_vehiculo]
                   example: identidad
                 file:
                   type: string
@@ -1322,8 +1330,9 @@ paths:
       description: >-
         Aprueba un documento `pending` de un conductor (historia técnica
         #64). Si con esta aprobación el conductor queda con **todos** los
-        documentos exigidos (`identidad`, `tarjeta_propiedad`) en
-        `approved`, su `verification_status` pasa a `verified`.
+        documentos exigidos (`identidad`, `tarjeta_propiedad`,
+        `foto_vehiculo`) en `approved`, su `verification_status` pasa a
+        `verified`.
 
         Solo se puede aprobar un documento `pending`: uno ya `approved` o
         `rejected` responde 422, porque revisar dos veces la misma fila no es
@@ -3278,7 +3287,7 @@ components:
       properties:
         type:
           type: string
-          enum: [identidad, tarjeta_propiedad]
+          enum: [identidad, tarjeta_propiedad, foto_vehiculo]
           example: identidad
         status:
           type: string
@@ -3293,7 +3302,7 @@ components:
       description: >-
         Estado de verificación de un conductor: el general de la cuenta y el
         detalle de cada documento exigido hoy (`identidad`,
-        `tarjeta_propiedad`), lo haya subido o no.
+        `tarjeta_propiedad`, `foto_vehiculo`), lo haya subido o no.
       required:
         - verification_status
         - documents
@@ -3318,7 +3327,7 @@ components:
             properties:
               type:
                 type: string
-                enum: [identidad, tarjeta_propiedad]
+                enum: [identidad, tarjeta_propiedad, foto_vehiculo]
                 example: identidad
               status:
                 type: string
@@ -3366,7 +3375,7 @@ components:
               example: Carlos Ramírez
         type:
           type: string
-          enum: [identidad, tarjeta_propiedad]
+          enum: [identidad, tarjeta_propiedad, foto_vehiculo]
           example: identidad
         status:
           type: string

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -158,6 +158,7 @@
   var documentTypeLabels = {
     identidad: "Documento de identidad",
     tarjeta_propiedad: "Tarjeta de propiedad",
+    foto_vehiculo: "Foto del vehículo",
   };
 
   function getToken() {

--- a/tests/Feature/Admin/ApproveDriverDocumentTest.php
+++ b/tests/Feature/Admin/ApproveDriverDocumentTest.php
@@ -64,6 +64,10 @@ class ApproveDriverDocumentTest extends TestCase
             'driver_profile_id' => $perfil->id,
             'type' => 'identidad',
         ]);
+        DriverDocument::factory()->approved()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'foto_vehiculo',
+        ]);
         $tarjeta = DriverDocument::factory()->create([
             'driver_profile_id' => $perfil->id,
             'type' => 'tarjeta_propiedad',

--- a/tests/Feature/Documents/ShowDriverDocumentsTest.php
+++ b/tests/Feature/Documents/ShowDriverDocumentsTest.php
@@ -36,10 +36,10 @@ class ShowDriverDocumentsTest extends TestCase
             ->getJson(self::URI)
             ->assertOk()
             ->assertJsonPath('data.verification_status', 'pending')
-            ->assertJsonCount(2, 'data.documents');
+            ->assertJsonCount(3, 'data.documents');
 
         $tipos = collect($respuesta->json('data.documents'))->pluck('type')->all();
-        $this->assertSame(['identidad', 'tarjeta_propiedad'], $tipos);
+        $this->assertSame(['identidad', 'tarjeta_propiedad', 'foto_vehiculo'], $tipos);
 
         foreach ($respuesta->json('data.documents') as $documento) {
             $this->assertNull($documento['status']);

--- a/tests/Unit/Actions/Documents/ApproveDriverDocumentActionTest.php
+++ b/tests/Unit/Actions/Documents/ApproveDriverDocumentActionTest.php
@@ -49,6 +49,10 @@ class ApproveDriverDocumentActionTest extends TestCase
     {
         $perfil = DriverProfile::factory()->create();
         DriverDocument::factory()->approved()->create(['driver_profile_id' => $perfil->id, 'type' => 'identidad']);
+        DriverDocument::factory()->approved()->create([
+            'driver_profile_id' => $perfil->id,
+            'type' => 'foto_vehiculo',
+        ]);
         $tarjeta = DriverDocument::factory()->create([
             'driver_profile_id' => $perfil->id,
             'type' => 'tarjeta_propiedad',


### PR DESCRIPTION
## Resumen
Extiende `App\Enums\DocumentType` con `FotoVehiculo` (`foto_vehiculo`), incluido en `required()`. Un conductor ahora necesita los tres documentos aprobados (`identidad`, `tarjeta_propiedad`, `foto_vehiculo`) para quedar `verified`.

Motivación (idea del dueño del producto, por conocimiento real del terreno): una tarjeta de propiedad por sí sola no prueba que corresponda al vehículo físico que el conductor realmente opera — una tarjeta de un vehículo dado de baja o en patios puede reutilizarse para registrar de forma ilegal un vehículo distinto. Es también la base del censo real de vehículos y conductores que la app busca sostener con el tiempo.

`DriverVerificationResource`, `ApproveDriverDocumentAction` y `DriverDocumentFactory` ya iteraban `DocumentType::required()`/`DocumentType::cases()` dinámicamente, así que no necesitaron cambios de lógica — solo el enum. No requiere migración: `driver_documents.type` ya es una columna `string` libre.

- `public/admin/index.html`: etiqueta "Foto del vehículo" para el panel de aprobación.
- `openapi.yaml`: tercer valor reflejado en todos los enums/ejemplos de documentos.
- Tests actualizados: `ShowDriverDocumentsTest` (ahora lista 3 documentos), `ApproveDriverDocumentActionTest`/`ApproveDriverDocumentTest` (el conductor solo queda verificado con los 3 aprobados).

## Plan de pruebas
- [x] `php artisan test` — 704/704 verdes
- [x] `vendor/bin/pint --test` — verde
- [x] `vendor/bin/phpstan analyse` — 0 errores

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)