### PR TITLE
feat(#80): vista previa del archivo del documento en el panel de admin

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/ShowDriverDocumentFileController.php
+++ b/app/Http/Controllers/Api/V1/Admin/ShowDriverDocumentFileController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ShowDriverDocumentFileRequest;
+use App\Models\DriverDocument;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * GET /api/v1/admin/documents/{document}/file
+ *
+ * Sirve el archivo (imagen o PDF) de un documento de verificación para que
+ * un administrador lo vea antes de aprobar o rechazar (historia técnica
+ * #78 — vista previa). El archivo vive en el disco `local` (privado); este
+ * es el único punto por el que se puede leer, siempre detrás de `auth:api`
+ * y la misma autorización de `review()` que aprobar/rechazar.
+ *
+ * `Storage::response()` arma la respuesta con el `Content-Type` real del
+ * archivo y `Content-Disposition: inline`, que es lo que permite embeberlo
+ * en un `<img>` o abrirlo en la pestaña en vez de forzar una descarga.
+ */
+class ShowDriverDocumentFileController extends Controller
+{
+    public function __invoke(ShowDriverDocumentFileRequest $request, DriverDocument $document): StreamedResponse
+    {
+        return Storage::disk('local')->response($document->path);
+    }
+}

--- a/app/Http/Requests/Admin/ShowDriverDocumentFileRequest.php
+++ b/app/Http/Requests/Admin/ShowDriverDocumentFileRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\DriverDocument;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de GET /api/v1/admin/documents/{document}/file — ver openapi.yaml.
+ */
+class ShowDriverDocumentFileRequest extends FormRequest
+{
+    /**
+     * `{document}` resuelve por binding implícito de la ruta, igual que
+     * `ApproveDriverDocumentRequest`: un id inexistente sale como 404 antes
+     * de que se evalúe `authorize()`.
+     *
+     * Misma autorización que aprobar/rechazar (`review()`): ver el archivo
+     * es parte del mismo flujo de revisión, no una operación aparte con
+     * reglas propias.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('review', $this->document()) ?? false;
+    }
+
+    /**
+     * No hay campos en el cuerpo: todo lo que decide esta operación es el
+     * documento de la ruta.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function document(): DriverDocument
+    {
+        /** @var DriverDocument */
+        return $this->route('document');
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1321,6 +1321,84 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /admin/documents/{document}/file:
+    get:
+      tags:
+        - Documents
+      operationId: showDriverDocumentFile
+      summary: Ver el archivo de un documento de verificación
+      description: >-
+        Devuelve el archivo (imagen o PDF) de un documento de verificación,
+        para que un administrador lo vea antes de aprobar o rechazar
+        (historia técnica #78) — por ejemplo, comparar la foto del vehículo
+        contra la tarjeta de propiedad antes de decidir.
+
+        A diferencia del resto de la API, esta respuesta **no** es JSON: el
+        cuerpo es el archivo tal cual, con su `Content-Type` real
+        (`image/jpeg`, `image/png` o `application/pdf`) y
+        `Content-Disposition: inline`, para poder embeberlo directo en un
+        `<img>` o abrirlo en una pestaña sin forzar una descarga.
+
+        Misma autorización que aprobar/rechazar: requiere un token vigente y
+        rol `admin`. No depende de que el documento esté en un estado
+        particular — se puede ver el archivo de un documento ya revisado.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: document
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 10
+      responses:
+        "200":
+          description: El archivo del documento.
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe un documento con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No query results for model [App\\Models\\DriverDocument] 10
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /admin/documents/{document}/approve:
     post:
       tags:
@@ -3349,8 +3427,8 @@ components:
       description: >-
         Un documento de verificación tal como lo ve un administrador: a
         diferencia de `DriverDocument`, sí lleva `id` (es por lo que se lo
-        referencia en `/admin/documents/{document}/approve|reject`) y a qué
-        conductor pertenece.
+        referencia en `/admin/documents/{document}/file|approve|reject`) y a
+        qué conductor pertenece.
       required:
         - id
         - driver

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -102,6 +102,17 @@
   .doc-row .driver { font-weight: 600; }
   .doc-row .meta { color: var(--muted); font-size: 0.85rem; margin: 2px 0 10px; }
   .doc-row .actions { display: flex; gap: 8px; }
+  .doc-preview { margin-bottom: 10px; }
+  .doc-preview img {
+    max-width: 100%;
+    max-height: 280px;
+    display: block;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .doc-preview .preview-loading,
+  .doc-preview .preview-error { color: var(--muted); font-size: 0.85rem; }
+  .doc-preview a { color: var(--primary); font-size: 0.9rem; }
   .empty { color: var(--muted); text-align: center; padding: 24px 0; }
   .loading { color: var(--muted); text-align: center; padding: 24px 0; }
   [hidden] { display: none !important; }
@@ -325,6 +336,11 @@
     metaLine.textContent = typeLabel + " · subido " + uploadedAt;
     li.appendChild(metaLine);
 
+    var preview = document.createElement("div");
+    preview.className = "doc-preview";
+    li.appendChild(preview);
+    loadDocumentPreview(document_.id, preview);
+
     var rowError = document.createElement("p");
     rowError.className = "error";
     rowError.hidden = true;
@@ -406,6 +422,55 @@
     return li;
   }
 
+  // Trae el archivo con el mismo `apiFetch` autenticado que el resto del
+  // panel: un <img src="/api/v1/..."> plano no puede mandar el header
+  // Authorization, así que hay que pedirlo por JS y mostrarlo como blob URL.
+  // Si es PDF (o cualquier cosa que no sea imagen), un link a abrirlo en una
+  // pestaña nueva alcanza — no hace falta un visor embebido para eso.
+  function loadDocumentPreview(documentId, container) {
+    var loading = document.createElement("p");
+    loading.className = "preview-loading";
+    loading.textContent = "Cargando vista previa...";
+    container.appendChild(loading);
+
+    apiFetch("/admin/documents/" + documentId + "/file")
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error("No se pudo cargar la vista previa.");
+        }
+        var contentType = response.headers.get("Content-Type") || "";
+        return response.blob().then(function (blob) {
+          return { blob: blob, contentType: contentType };
+        });
+      })
+      .then(function (result) {
+        container.innerHTML = "";
+        var url = URL.createObjectURL(result.blob);
+        container.dataset.previewUrl = url;
+
+        if (result.contentType.indexOf("image/") === 0) {
+          var img = document.createElement("img");
+          img.src = url;
+          img.alt = "Vista previa del documento";
+          container.appendChild(img);
+        } else {
+          var link = document.createElement("a");
+          link.href = url;
+          link.target = "_blank";
+          link.rel = "noopener";
+          link.textContent = "Ver documento";
+          container.appendChild(link);
+        }
+      })
+      .catch(function () {
+        container.innerHTML = "";
+        var message = document.createElement("p");
+        message.className = "preview-error";
+        message.textContent = "No se pudo cargar la vista previa.";
+        container.appendChild(message);
+      });
+  }
+
   function reviewDocument(documentId, action, reason, row, rowError) {
     hideError(rowError);
     var buttons = row.querySelectorAll("button");
@@ -428,6 +493,10 @@
         });
       })
       .then(function () {
+        var preview = row.querySelector(".doc-preview");
+        if (preview && preview.dataset.previewUrl) {
+          URL.revokeObjectURL(preview.dataset.previewUrl);
+        }
         row.remove();
         if (documentsList.children.length === 0) {
           documentsEmpty.hidden = false;

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\Admin\ApproveDriverDocumentController;
 use App\Http\Controllers\Api\V1\Admin\ListDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Admin\RejectDriverDocumentController;
+use App\Http\Controllers\Api\V1\Admin\ShowDriverDocumentFileController;
 use App\Http\Controllers\Api\V1\Auth\ConfirmPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\LogoutController;
@@ -176,6 +177,14 @@ Route::prefix('v1')->group(function () {
         Route::middleware('auth:api')
             ->get('documents', ListDriverDocumentsController::class)
             ->name('documents.index');
+
+        // Vista previa del archivo antes de aprobar/rechazar (historia
+        // técnica #78). Va antes de `approve`/`reject` en el listado nada
+        // más por orden de lectura: las tres rutas no compiten entre sí, cada
+        // una tiene su propio sufijo estático.
+        Route::middleware('auth:api')
+            ->get('documents/{document}/file', ShowDriverDocumentFileController::class)
+            ->name('documents.file');
 
         Route::middleware('auth:api')
             ->post('documents/{document}/approve', ApproveDriverDocumentController::class)

--- a/tests/Feature/Admin/ShowDriverDocumentFileTest.php
+++ b/tests/Feature/Admin/ShowDriverDocumentFileTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\DriverDocument;
+use App\Models\DriverProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/admin/documents/{document}/file — ver openapi.yaml.
+ *
+ * Lo que fija esta suite es que solo un administrador pueda leer el archivo
+ * (mismo criterio de autorización que aprobar/rechazar), y que la respuesta
+ * lleve el contenido real del archivo con su `Content-Type`, no una URL ni
+ * un JSON — es lo que permite embeberlo directo en un `<img>` del panel.
+ */
+class ShowDriverDocumentFileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+    }
+
+    private function uri(DriverDocument $document): string
+    {
+        return "/api/v1/admin/documents/{$document->id}/file";
+    }
+
+    private function documentoConArchivo(string $contenido = 'contenido-de-prueba'): DriverDocument
+    {
+        $perfil = DriverProfile::factory()->create();
+        $archivo = UploadedFile::fake()->createWithContent('cedula.jpg', $contenido);
+        $path = $archivo->store("driver-documents/{$perfil->id}", 'local');
+
+        return DriverDocument::factory()->create([
+            'driver_profile_id' => $perfil->id,
+            'path' => $path,
+        ]);
+    }
+
+    public function test_un_administrador_puede_ver_el_archivo_del_documento(): void
+    {
+        $documento = $this->documentoConArchivo('contenido-de-la-cedula');
+
+        $respuesta = $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->get($this->uri($documento))
+            ->assertOk();
+
+        $respuesta->assertHeader('Content-Type', 'image/jpeg');
+        $this->assertSame('contenido-de-la-cedula', $respuesta->streamedContent());
+    }
+
+    public function test_responde_404_si_el_documento_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->get('/api/v1/admin/documents/999999/file')
+            ->assertNotFound();
+    }
+
+    public function test_un_conductor_no_puede_ver_el_archivo(): void
+    {
+        $documento = $this->documentoConArchivo();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->driver()->create()))
+            ->get($this->uri($documento))
+            ->assertForbidden();
+    }
+
+    public function test_un_pasajero_no_puede_ver_el_archivo(): void
+    {
+        $documento = $this->documentoConArchivo();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->get($this->uri($documento))
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_consulta_sin_token(): void
+    {
+        $documento = $this->documentoConArchivo();
+
+        $this->getJson($this->uri($documento))->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Resumen
Agrega `GET /api/v1/admin/documents/{document}/file`, que sirve el archivo real (imagen o PDF, no JSON) de un documento de verificación para que un administrador lo vea antes de aprobar o rechazar — por ejemplo, comparar la foto del vehículo contra la tarjeta de propiedad. Misma autorización que aprobar/rechazar (`DriverDocumentPolicy::review()`); el archivo vive en el disco privado, así que este endpoint es el único punto por el que se puede leer.

El panel (`public/admin/index.html`) pide el archivo por JS con el mismo `apiFetch` autenticado que el resto del panel — un `<img src>` plano no puede mandar el header `Authorization` — y lo muestra como blob URL: imagen embebida si el `Content-Type` es `image/*`, link a abrir en pestaña nueva si es PDF. El blob URL se libera cuando la fila se retira tras aprobar o rechazar, para no acumular memoria en una sesión larga del panel.

## Plan de pruebas
- [x] `php artisan test` — 709/709 verdes
- [x] `vendor/bin/pint --test` — verde
- [x] `vendor/bin/phpstan analyse` — 0 errores
- [x] Probado manualmente en el navegador: la vista previa carga, el aprobar/rechazar sigue funcionando y la fila se retira correctamente

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)