### PR TITLE
feat(#82): recuperar contrasena por SMS

### DIFF
--- a/app/Actions/Auth/ConfirmPasswordResetAction.php
+++ b/app/Actions/Auth/ConfirmPasswordResetAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\DTOs\AuthenticatedUser;
+use App\Models\User;
+use App\Services\Auth\AccessTokenFactory;
+use Tymon\JWTAuth\JWTAuth;
+
+/**
+ * Confirma la recuperación de contraseña de una cuenta y la deja autenticada
+ * en el mismo paso.
+ *
+ * Que el código enviado sea correcto, no haya vencido, y no se hayan agotado
+ * los intentos lo comprueba `ConfirmPasswordResetRequest` antes de llegar
+ * acá, mismo criterio que `ConfirmPhoneVerificationAction` con el suyo: esta
+ * Action asume una confirmación válida y no vuelve a validarla.
+ *
+ * Devuelve un `AuthenticatedUser` (mismo DTO que login y los registros) en
+ * vez de solo confirmar el cambio: quien acaba de recuperar el acceso no
+ * debería tener que volver a escribir la contraseña que recién eligió para
+ * poder entrar.
+ */
+final class ConfirmPasswordResetAction
+{
+    public function __construct(
+        private readonly JWTAuth $jwt,
+        private readonly AccessTokenFactory $tokens,
+    ) {}
+
+    public function handle(User $user, #[\SensitiveParameter] string $newPassword): AuthenticatedUser
+    {
+        $user->password = $newPassword;
+        $user->save();
+
+        $user->passwordResetCode?->delete();
+
+        return new AuthenticatedUser(
+            user: $user,
+            token: $this->tokens->fromJwt($this->jwt->fromUser($user)),
+        );
+    }
+}

--- a/app/Actions/Auth/RequestPasswordResetAction.php
+++ b/app/Actions/Auth/RequestPasswordResetAction.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Genera y envía por SMS el código de recuperación de contraseña de la cuenta
+ * con el celular dado, si existe.
+ *
+ * Este endpoint es anónimo por diseño (quien lo llama todavía no puede
+ * iniciar sesión), así que un celular sin cuenta tiene que responder
+ * exactamente igual que uno con cuenta: si no, el propio endpoint sería un
+ * oráculo para saber qué números de celular están registrados en MotoYa,
+ * mismo problema que `LoginAction` resuelve para el email. Por eso este
+ * método nunca lanza ni informa si encontró la cuenta — `handle()` siempre
+ * "tiene éxito" desde afuera, y el controller responde 204 sin importar el
+ * resultado.
+ *
+ * Un código vigente por cuenta: `password_reset_codes.user_id` es único (ver
+ * la migración), así que pedir uno nuevo reemplaza el anterior en vez de
+ * acumularlo.
+ */
+final readonly class RequestPasswordResetAction
+{
+    public function __construct(private SmsGateway $sms) {}
+
+    public function handle(string $phone): void
+    {
+        $user = User::firstWhere('phone', $phone);
+
+        if ($user === null) {
+            // Se gasta un hash contra nada, mismo motivo que `LoginAction`
+            // con un email sin cuenta: sin esto, un celular sin cuenta
+            // respondería más rápido que uno real (que además hashea el
+            // código y escribe en la base), y esa diferencia de tiempo
+            // reconstruye el mismo oráculo que evitar el mensaje ya evita.
+            Hash::make($this->generateCode());
+
+            return;
+        }
+
+        $code = $this->generateCode();
+
+        $user->passwordResetCode()->updateOrCreate(
+            [],
+            [
+                'code_hash' => Hash::make($code),
+                'attempts' => 0,
+                'expires_at' => Date::now()->addMinutes(Config::integer('password_reset.expires_in_minutes')),
+            ],
+        );
+
+        $minutos = Config::integer('password_reset.expires_in_minutes');
+
+        $this->sms->send(
+            $user->phone,
+            "Tu código para recuperar tu contraseña en MotoYa es {$code}. Vence en {$minutos} minutos.",
+        );
+    }
+
+    private function generateCode(): string
+    {
+        $digitos = Config::integer('password_reset.code_length');
+        $maximo = (10 ** $digitos) - 1;
+
+        return str_pad((string) random_int(0, $maximo), $digitos, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/ConfirmPasswordResetController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ConfirmPasswordResetController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\ConfirmPasswordResetAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ConfirmPasswordResetRequest;
+use App\Http\Resources\AuthenticatedUserResource;
+use App\Models\User;
+use RuntimeException;
+
+/**
+ * POST /api/v1/auth/password/reset
+ *
+ * Confirma la recuperación de contraseña con el código enviado por SMS y deja
+ * la cuenta autenticada, mismo criterio que el login y los registros. Que el
+ * código sea correcto, no haya vencido, y no se hayan agotado los intentos lo
+ * resuelve `ConfirmPasswordResetRequest`.
+ */
+class ConfirmPasswordResetController extends Controller
+{
+    public function __invoke(
+        ConfirmPasswordResetRequest $request,
+        ConfirmPasswordResetAction $confirmReset,
+    ): AuthenticatedUserResource {
+        $account = $request->account();
+
+        // La validación ya exige una recuperación pendiente para llegar
+        // acá, y eso implica una cuenta encontrada por `account()`: esta
+        // comprobación es para PHPStan, que no puede inferirlo desde
+        // `after()`, no un caso real. Mismo criterio que
+        // `ApproveDriverDocumentAction`.
+        if (! $account instanceof User) {
+            throw new RuntimeException('ConfirmPasswordResetRequest sin cuenta resuelta.');
+        }
+
+        return new AuthenticatedUserResource($confirmReset->handle($account, $request->newPassword()));
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/RequestPasswordResetController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RequestPasswordResetController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\RequestPasswordResetAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RequestPasswordResetRequest;
+use Illuminate\Http\Response;
+
+/**
+ * POST /api/v1/auth/password/forgot
+ *
+ * Genera un código de recuperación de contraseña y lo envía por SMS al
+ * celular dado, si tiene cuenta (recuperación de contraseña).
+ *
+ * Responde 204 sin importar si el celular tiene cuenta o no —igual que
+ * `RequestPasswordResetAction` nunca informa el resultado—, para que este
+ * endpoint no sea un oráculo de qué números están registrados en MotoYa.
+ */
+class RequestPasswordResetController extends Controller
+{
+    public function __invoke(RequestPasswordResetRequest $request, RequestPasswordResetAction $requestReset): Response
+    {
+        $requestReset->handle($request->phone());
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Auth/ConfirmPasswordResetRequest.php
+++ b/app/Http/Requests/Auth/ConfirmPasswordResetRequest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Http\Requests\Concerns\NormalizesAccountInput;
+use App\Models\PasswordResetCode;
+use App\Models\User;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Entrada de POST /api/v1/auth/password/reset — ver openapi.yaml.
+ *
+ * No define `authorize()`: el endpoint es anónimo por diseño, mismo criterio
+ * que `LoginRequest` y `RequestPasswordResetRequest`.
+ */
+class ConfirmPasswordResetRequest extends FormRequest
+{
+    use NormalizesAccountInput;
+
+    private ?User $account = null;
+
+    /**
+     * Lleva `phone` a su forma canónica, mismo motivo que
+     * `RequestPasswordResetRequest`.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge($this->canonicalAccountInput());
+    }
+
+    /**
+     * La contraseña nueva pasa por la misma política que el registro
+     * (`Password::defaults()`): recuperar el acceso no puede ser una vía para
+     * terminar con una contraseña más débil que la que el alta habría
+     * aceptado.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'phone' => ['required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/'],
+            'code' => ['required', 'string'],
+            'password' => ['required', 'string', Password::defaults()],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio; se guarda siempre con el +.',
+        ];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            $this->validateCode(...),
+        ];
+    }
+
+    /**
+     * Todas las razones por las que un código no se acepta viajan bajo la
+     * misma clave `code` —celular sin cuenta, sin recuperación pendiente,
+     * vencido, intentos agotados, o el valor no coincide—, mismo criterio que
+     * `ConfirmPhoneVerificationRequest`: acá además evita que un celular sin
+     * cuenta se distinga de uno con cuenta pero sin código pendiente, que
+     * sería el mismo oráculo que `RequestPasswordResetAction` ya evita del
+     * otro lado.
+     */
+    private function validateCode(Validator $validator): void
+    {
+        $reset = $this->pendingReset();
+
+        if ($reset === null) {
+            $validator->errors()->add('code', 'No tienes una recuperación de contraseña pendiente; solicita un código nuevo.');
+
+            return;
+        }
+
+        if ($reset->expires_at->isPast()) {
+            $validator->errors()->add('code', 'El código venció; solicita uno nuevo.');
+
+            return;
+        }
+
+        if ($reset->attempts >= Config::integer('password_reset.max_attempts')) {
+            $validator->errors()->add('code', 'Superaste el número de intentos permitidos; solicita un código nuevo.');
+
+            return;
+        }
+
+        if (! Hash::check($this->string('code')->toString(), $reset->code_hash)) {
+            $reset->increment('attempts');
+            $validator->errors()->add('code', 'El código no es correcto.');
+        }
+    }
+
+    private function pendingReset(): ?PasswordResetCode
+    {
+        return $this->account()?->passwordResetCode;
+    }
+
+    /**
+     * La cuenta dueña del celular de la entrada, o `null` si no existe.
+     *
+     * Memoizada porque la usan la validación y el controller, y las dos
+     * tienen que ver la misma fila. No se llama `user()` a propósito: ese
+     * nombre en un `FormRequest` es el de la cuenta *autenticada* del guard
+     * (ver `Illuminate\Http\Request::user()`), y este endpoint es anónimo —
+     * llamarlo igual invitaría a confundir "quién hizo la request" con
+     * "de qué cuenta es el celular que mandó".
+     */
+    public function account(): ?User
+    {
+        if ($this->account instanceof User) {
+            return $this->account;
+        }
+
+        if (! $this->filled('phone')) {
+            return null;
+        }
+
+        return $this->account = User::firstWhere('phone', $this->string('phone')->toString());
+    }
+
+    public function newPassword(): string
+    {
+        return $this->string('password')->toString();
+    }
+}

--- a/app/Http/Requests/Auth/RequestPasswordResetRequest.php
+++ b/app/Http/Requests/Auth/RequestPasswordResetRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Http\Requests\Concerns\NormalizesAccountInput;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/auth/password/forgot — ver openapi.yaml.
+ *
+ * No define `authorize()`: el endpoint es anónimo por diseño, mismo criterio
+ * que `LoginRequest`. Tampoco valida que el celular tenga cuenta —`exists:`
+ * sería el oráculo que `RequestPasswordResetAction` existe para evitar—: la
+ * regla solo comprueba la forma, igual que el email en el login.
+ */
+class RequestPasswordResetRequest extends FormRequest
+{
+    use NormalizesAccountInput;
+
+    /**
+     * Lleva `phone` a su forma canónica ANTES de validar, mismo motivo que en
+     * el login: si esta entrada normalizara distinto que el registro, un
+     * celular guardado como `+57...` no coincidiría con uno tecleado sin el
+     * `+`, y la cuenta "no encontrada" quedaría indistinguible de una
+     * realmente inexistente por el motivo equivocado.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge($this->canonicalAccountInput());
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'phone' => ['required', 'string', 'max:20', 'regex:/^\+[0-9]{7,15}$/'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'phone.regex' => 'El campo phone debe tener entre 7 y 15 dígitos, con un + opcional al inicio; se guarda siempre con el +.',
+        ];
+    }
+
+    public function phone(): string
+    {
+        return $this->string('phone')->toString();
+    }
+}

--- a/app/Models/PasswordResetCode.php
+++ b/app/Models/PasswordResetCode.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * El código de recuperación de contraseña vigente de una cuenta (historia
+ * técnica de recuperación de contraseña).
+ *
+ * Uno por cuenta (`user_id` único): pedir un código nuevo reemplaza este,
+ * nunca lo duplica — misma estructura que `PhoneVerificationCode`, con la que
+ * comparte el canal de envío (SMS) pero no la tabla: son dos flujos distintos
+ * (probar que el celular es propio vs. recuperar el acceso a la cuenta) y
+ * mezclarlos en la misma fila haría que pedir uno cancelara el otro sin que
+ * eso tenga sentido de negocio.
+ *
+ * @property int $attempts
+ * @property Carbon $expires_at
+ */
+#[Fillable(['user_id', 'code_hash', 'attempts', 'expires_at'])]
+class PasswordResetCode extends Model
+{
+    use HasFactory;
+
+    /**
+     * El hash nunca debe salir en una respuesta de la API, mismo criterio que
+     * `password` en `User` y `code_hash` en `PhoneVerificationCode`.
+     */
+    protected $hidden = ['code_hash'];
+
+    protected function casts(): array
+    {
+        return [
+            'attempts' => 'integer',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -116,6 +116,19 @@ class User extends Authenticatable implements JWTSubject
     }
 
     /**
+     * El código de recuperación de contraseña vigente de esta cuenta, si hay
+     * uno. Uno a uno: `password_reset_codes.user_id` es único, y pedir un
+     * código nuevo reemplaza el que hubiera — mismo criterio que
+     * `phoneVerificationCode()`.
+     *
+     * @return HasOne<PasswordResetCode, $this>
+     */
+    public function passwordResetCode(): HasOne
+    {
+        return $this->hasOne(PasswordResetCode::class);
+    }
+
+    /**
      * Identificador que viaja en el claim `sub` del JWT.
      */
     public function getJWTIdentifier(): mixed

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -192,6 +192,12 @@ class AppServiceProvider extends ServiceProvider
      * el endpoint exige `auth:api`): cada acierto le cuesta un SMS real a
      * MotoYa apenas haya un proveedor conectado (historia #69), así que el
      * límite general de 60/min dejaría pedir 60 códigos en un minuto.
+     *
+     * `password-reset` es el mismo caso que `phone-verification` —cada
+     * acierto cuesta un SMS real— pero por IP en vez de por usuario: pedir
+     * un código de recuperación es, por diseño, anónimo (`auth/password/forgot`
+     * no exige `auth:api`, porque quien lo llama todavía no puede iniciar
+     * sesión), así que no hay un usuario autenticado del que colgar el límite.
      */
     private function configureRateLimiting(): void
     {
@@ -209,6 +215,11 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for(
             'phone-verification',
             fn (Request $request) => Limit::perMinutes(10, 3)->by((string) $request->user()?->getAuthIdentifier()),
+        );
+
+        RateLimiter::for(
+            'password-reset',
+            fn (Request $request) => Limit::perMinutes(10, 3)->by((string) $request->ip()),
         );
     }
 }

--- a/config/password_reset.php
+++ b/config/password_reset.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Recuperación de contraseña por SMS
+    |--------------------------------------------------------------------------
+    |
+    | Parámetros del código que se envía a `POST /auth/password/forgot`. Ver
+    | App\Actions\Auth\RequestPasswordResetAction. Mismos valores por defecto
+    | que `config/phone_verification.php` porque es la misma UX (código de
+    | un solo uso por SMS), aunque son flujos y configuraciones separadas.
+    |
+    */
+
+    // Cantidad de dígitos del código, p. ej. 6 -> códigos entre 000000 y 999999.
+    'code_length' => (int) env('PASSWORD_RESET_CODE_LENGTH', 6),
+
+    // Minutos que el código sigue siendo válido después de generado.
+    'expires_in_minutes' => (int) env('PASSWORD_RESET_EXPIRES_IN_MINUTES', 10),
+
+    // Intentos fallidos permitidos antes de exigir pedir un código nuevo.
+    'max_attempts' => (int) env('PASSWORD_RESET_MAX_ATTEMPTS', 5),
+
+];

--- a/database/factories/PasswordResetCodeFactory.php
+++ b/database/factories/PasswordResetCodeFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\PasswordResetCode;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * @extends Factory<PasswordResetCode>
+ */
+class PasswordResetCodeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'code_hash' => Hash::make('123456'),
+            'attempts' => 0,
+            'expires_at' => now()->addMinutes(10),
+        ];
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => now()->subMinute(),
+        ]);
+    }
+
+    public function exhausted(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'attempts' => 5,
+        ]);
+    }
+}

--- a/database/migrations/2026_09_06_000001_create_password_reset_codes_table.php
+++ b/database/migrations/2026_09_06_000001_create_password_reset_codes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('password_reset_codes', function (Blueprint $table) {
+            $table->id();
+            // Único: un código vigente por cuenta. Pedir uno nuevo reemplaza
+            // el anterior (ver RequestPasswordResetAction), no acumula —
+            // misma estructura que `phone_verification_codes`.
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('code_hash');
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('expires_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('password_reset_codes');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -214,6 +214,166 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /auth/password/forgot:
+    post:
+      tags:
+        - Auth
+      operationId: requestPasswordReset
+      summary: Pedir un código para recuperar mi contraseña
+      description: >-
+        Genera un código de recuperación de contraseña y lo envía por SMS al
+        celular dado, si tiene cuenta. Pedir uno nuevo reemplaza el anterior:
+        nunca hay dos códigos vigentes a la vez para la misma cuenta, mismo
+        criterio que `POST /me/phone/verification`.
+
+        No requiere autenticación —quien lo llama no puede iniciar sesión,
+        por eso está pidiendo recuperar el acceso—, y por eso responde
+        **204 sin importar si el celular tiene cuenta o no**: distinguir
+        ambos casos convertiría al endpoint en un oráculo para averiguar qué
+        números de celular están registrados en MotoYa.
+
+        Límite de tasa más estricto que el general de auth (3 cada 10
+        minutos, por IP): cada acierto le va a costar un SMS real apenas
+        haya un proveedor conectado.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - phone
+              properties:
+                phone:
+                  type: string
+                  example: "+573001234567"
+            example:
+              phone: "+573001234567"
+      responses:
+        "204":
+          description: >-
+            Solicitud procesada. No indica si el celular tiene cuenta: si la
+            tiene, el código ya se envió por SMS.
+        "422":
+          description: El celular no tiene forma de celular.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The phone field is required.
+                errors:
+                  phone:
+                    - The phone field is required.
+        "429":
+          description: >-
+            Se superó el límite de 3 solicitudes cada 10 minutos para esta IP.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /auth/password/reset:
+    post:
+      tags:
+        - Auth
+      operationId: confirmPasswordReset
+      summary: Confirmar la recuperación de mi contraseña
+      description: >-
+        Confirma el código pedido en `POST /auth/password/forgot` y cambia la
+        contraseña de la cuenta. Si el código es correcto, no venció, y no se
+        agotaron los intentos, la respuesta deja la cuenta autenticada —misma
+        forma que el login— para no obligar a volver a escribir la
+        contraseña recién elegida.
+
+        Todas las razones por las que un código no se acepta —celular sin
+        cuenta, sin recuperación pendiente, venció, se agotaron los
+        intentos, o el valor no coincide— responden 422 bajo la misma clave
+        `code`, mismo criterio que `POST /me/phone/verification/confirm` y
+        por el mismo motivo que el 204 de `POST /auth/password/forgot`: un
+        celular sin cuenta no puede distinguirse de uno con cuenta pero sin
+        código pendiente.
+
+        La contraseña nueva pasa por la misma política que el registro (al
+        menos 8 caracteres, con letras y números).
+
+        No requiere autenticación, y por eso comparte con el resto de
+        endpoints anónimos de auth el límite de 10 requests por minuto e IP.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - phone
+                - code
+                - password
+              properties:
+                phone:
+                  type: string
+                  example: "+573001234567"
+                code:
+                  type: string
+                  example: "482913"
+                password:
+                  type: string
+                  example: nuevaClave2026
+            example:
+              phone: "+573001234567"
+              code: "482913"
+              password: nuevaClave2026
+      responses:
+        "200":
+          description: Contraseña cambiada; sesión iniciada.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AuthenticatedUser"
+              example:
+                data:
+                  user:
+                    id: 1
+                    name: Ana García
+                    email: ana@example.com
+                    phone: "+573001234567"
+                    phone_verified: true
+                    role: passenger
+                  token:
+                    access_token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsInJvbGUiOiJwYXNzZW5nZXIifQ.4pcPyMD09olPSyXnrXCjTwXyr4BsezdI1AVTmud2fU4
+                    token_type: bearer
+                    expires_in: 900
+        "422":
+          description: >-
+            El código no es correcto, venció, se agotaron los intentos, no
+            hay ninguna recuperación pendiente, el celular no tiene forma de
+            celular, o la contraseña no cumple la política mínima.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: El código no es correcto.
+                errors:
+                  code:
+                    - El código no es correcto.
+        "429":
+          description: >-
+            Se superó el límite de intentos por minuto para esta IP.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /auth/register/driver:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,12 +4,14 @@ use App\Http\Controllers\Api\V1\Admin\ApproveDriverDocumentController;
 use App\Http\Controllers\Api\V1\Admin\ListDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Admin\RejectDriverDocumentController;
 use App\Http\Controllers\Api\V1\Admin\ShowDriverDocumentFileController;
+use App\Http\Controllers\Api\V1\Auth\ConfirmPasswordResetController;
 use App\Http\Controllers\Api\V1\Auth\ConfirmPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RefreshTokenController;
 use App\Http\Controllers\Api\V1\Auth\RegisterDriverController;
 use App\Http\Controllers\Api\V1\Auth\RegisterPassengerController;
+use App\Http\Controllers\Api\V1\Auth\RequestPasswordResetController;
 use App\Http\Controllers\Api\V1\Auth\RequestPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Documents\ShowDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Documents\UploadDriverDocumentController;
@@ -61,7 +63,22 @@ Route::prefix('v1')->group(function () {
             Route::post('refresh', RefreshTokenController::class)->name('refresh');
             Route::post('register/driver', RegisterDriverController::class)->name('register.driver');
             Route::post('register/passenger', RegisterPassengerController::class)->name('register.passenger');
+            // Confirmar el código no cuesta un SMS por intento —a diferencia
+            // de pedirlo—, así que le alcanza con el mismo limitador anónimo
+            // que el resto de este grupo; adivinar el código además está
+            // acotado aparte por `max_attempts` en `ConfirmPasswordResetRequest`.
+            Route::post('password/reset', ConfirmPasswordResetController::class)->name('password.reset');
         });
+
+        // Pedir un código sí cuesta un SMS real apenas haya un proveedor
+        // conectado, mismo motivo por el que `me/phone/verification` lleva
+        // `throttle:phone-verification` en vez del límite general de la API.
+        // Ese limitador no sirve acá porque clasifica por usuario autenticado
+        // y este endpoint es anónimo — `password-reset` es su equivalente
+        // por IP (ver AppServiceProvider::configureRateLimiting()).
+        Route::middleware('throttle:password-reset')
+            ->post('password/forgot', RequestPasswordResetController::class)
+            ->name('password.forgot');
 
         // El cierre de sesión, en cambio, exige un token vigente, así que se
         // queda con el limitador general de la API (60/min por usuario). Bajo

--- a/tests/Feature/Auth/ConfirmPasswordResetTest.php
+++ b/tests/Feature/Auth/ConfirmPasswordResetTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\PasswordResetCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/auth/password/reset — ver openapi.yaml.
+ */
+class ConfirmPasswordResetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/auth/password/reset';
+
+    public function test_cambia_la_contrasena_con_el_codigo_correcto_y_deja_la_cuenta_autenticada(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        PasswordResetCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $respuesta = $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.user.id', $usuario->id);
+
+        $this->assertTrue(Hash::check('nuevaClave2026', $usuario->fresh()->password));
+        $this->assertDatabaseCount('password_reset_codes', 0);
+
+        $token = $respuesta->json('data.token.access_token');
+        $identificado = JWTAuth::setToken($token)->authenticate();
+        $this->assertSame($usuario->id, $identificado?->id);
+    }
+
+    public function test_normaliza_el_celular_sin_el_signo_mas_antes_de_buscar_la_cuenta(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        PasswordResetCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->postJson(self::URI, [
+            'phone' => '573001234567',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])->assertOk();
+
+        $this->assertTrue(Hash::check('nuevaClave2026', $usuario->fresh()->password));
+    }
+
+    public function test_rechaza_un_codigo_incorrecto_y_cuenta_el_intento(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        $reset = PasswordResetCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '000000',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+
+        $this->assertSame(1, $reset->fresh()->attempts);
+        $this->assertTrue(Hash::check('password', $usuario->fresh()->password));
+    }
+
+    public function test_rechaza_un_codigo_vencido(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        PasswordResetCode::factory()->expired()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_cuando_se_agotaron_los_intentos(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        PasswordResetCode::factory()->exhausted()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_sin_ninguna_recuperacion_pendiente(): void
+    {
+        User::factory()->create(['phone' => '+573001234567']);
+
+        $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    /**
+     * Mismo mensaje genérico que "sin ninguna recuperación pendiente", para
+     * que un celular sin cuenta no se distinga de uno con cuenta pero sin
+     * código pendiente — es la misma protección de
+     * `RequestPasswordResetAction` vista desde este lado del flujo.
+     */
+    public function test_rechaza_un_celular_sin_cuenta_con_el_mismo_mensaje_generico(): void
+    {
+        $this->postJson(self::URI, [
+            'phone' => '+573009999999',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('code');
+    }
+
+    public function test_rechaza_una_contrasena_que_no_cumple_la_politica(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        PasswordResetCode::factory()->create([
+            'user_id' => $usuario->id,
+            'code_hash' => Hash::make('123456'),
+        ]);
+
+        $this->postJson(self::URI, [
+            'phone' => '+573001234567',
+            'code' => '123456',
+            'password' => 'corta1',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_rechaza_un_celular_mal_formado(): void
+    {
+        $this->postJson(self::URI, [
+            'phone' => 'no-es-un-celular',
+            'code' => '123456',
+            'password' => 'nuevaClave2026',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+}

--- a/tests/Feature/Auth/RequestPasswordResetTest.php
+++ b/tests/Feature/Auth/RequestPasswordResetTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Contrato de POST /api/v1/auth/password/forgot — ver openapi.yaml.
+ *
+ * Lo que fija esta suite, además del flujo feliz, es que un celular sin
+ * cuenta responda exactamente igual (204, sin SMS) que uno con cuenta: es lo
+ * que evita que el endpoint sea un oráculo de qué números están registrados.
+ */
+class RequestPasswordResetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const URI = '/api/v1/auth/password/forgot';
+
+    private function gatewayFalso(): SmsGateway
+    {
+        return new class implements SmsGateway
+        {
+            public function send(string $phone, string $message): void {}
+        };
+    }
+
+    public function test_genera_un_codigo_y_lo_envia_por_sms_a_una_cuenta_existente(): void
+    {
+        User::factory()->create(['phone' => '+573001234567']);
+
+        $gateway = new class implements SmsGateway
+        {
+            public ?string $phone = null;
+
+            public ?string $message = null;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->phone = $phone;
+                $this->message = $message;
+            }
+        };
+        $this->app->instance(SmsGateway::class, $gateway);
+
+        $this->postJson(self::URI, ['phone' => '+573001234567'])->assertNoContent();
+
+        $this->assertDatabaseCount('password_reset_codes', 1);
+        $this->assertSame('+573001234567', $gateway->phone);
+        $this->assertNotNull($gateway->message);
+    }
+
+    public function test_un_celular_sin_cuenta_responde_igual_que_uno_con_cuenta(): void
+    {
+        $this->app->instance(SmsGateway::class, $this->gatewayFalso());
+
+        $this->postJson(self::URI, ['phone' => '+573009999999'])->assertNoContent();
+
+        $this->assertDatabaseCount('password_reset_codes', 0);
+    }
+
+    public function test_normaliza_el_celular_sin_el_signo_mas_antes_de_buscar_la_cuenta(): void
+    {
+        User::factory()->create(['phone' => '+573001234567']);
+
+        $gateway = new class implements SmsGateway
+        {
+            public ?string $phone = null;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->phone = $phone;
+            }
+        };
+        $this->app->instance(SmsGateway::class, $gateway);
+
+        $this->postJson(self::URI, ['phone' => '573001234567'])->assertNoContent();
+
+        $this->assertSame('+573001234567', $gateway->phone);
+    }
+
+    public function test_pedir_un_codigo_nuevo_reemplaza_el_anterior(): void
+    {
+        User::factory()->create(['phone' => '+573001234567']);
+        $this->app->instance(SmsGateway::class, $this->gatewayFalso());
+
+        $this->postJson(self::URI, ['phone' => '+573001234567'])->assertNoContent();
+        $this->postJson(self::URI, ['phone' => '+573001234567'])->assertNoContent();
+
+        $this->assertDatabaseCount('password_reset_codes', 1);
+    }
+
+    public function test_rechaza_un_celular_mal_formado(): void
+    {
+        $this->postJson(self::URI, ['phone' => 'no-es-un-celular'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+
+        $this->assertDatabaseCount('password_reset_codes', 0);
+    }
+
+    public function test_rechaza_sin_celular_en_el_body(): void
+    {
+        $this->postJson(self::URI, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('phone');
+    }
+
+    public function test_respeta_el_limite_de_tres_solicitudes_cada_diez_minutos_por_ip(): void
+    {
+        $this->app->instance(SmsGateway::class, $this->gatewayFalso());
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->postJson(self::URI, ['phone' => '+573009999999'])->assertNoContent();
+        }
+
+        $this->postJson(self::URI, ['phone' => '+573009999999'])->assertStatus(429);
+    }
+}

--- a/tests/Unit/Actions/Auth/ConfirmPasswordResetActionTest.php
+++ b/tests/Unit/Actions/Auth/ConfirmPasswordResetActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\ConfirmPasswordResetAction;
+use App\Models\PasswordResetCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ConfirmPasswordResetActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cambia_la_contrasena_y_borra_el_codigo(): void
+    {
+        $usuario = User::factory()->create();
+        PasswordResetCode::factory()->create(['user_id' => $usuario->id]);
+
+        $this->action()->handle($usuario, 'nuevaClave2026');
+
+        $this->assertTrue(Hash::check('nuevaClave2026', $usuario->fresh()->password));
+        $this->assertSame(0, PasswordResetCode::query()->count());
+    }
+
+    public function test_devuelve_un_token_que_identifica_a_la_cuenta(): void
+    {
+        $usuario = User::factory()->create();
+        PasswordResetCode::factory()->create(['user_id' => $usuario->id]);
+
+        $resultado = $this->action()->handle($usuario, 'nuevaClave2026');
+
+        $identificado = JWTAuth::setToken($resultado->token->accessToken)->authenticate();
+
+        $this->assertInstanceOf(User::class, $identificado);
+        $this->assertSame($usuario->id, $identificado->id);
+    }
+
+    private function action(): ConfirmPasswordResetAction
+    {
+        return $this->app->make(ConfirmPasswordResetAction::class);
+    }
+}

--- a/tests/Unit/Actions/Auth/RequestPasswordResetActionTest.php
+++ b/tests/Unit/Actions/Auth/RequestPasswordResetActionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions\Auth;
+
+use App\Actions\Auth\RequestPasswordResetAction;
+use App\Models\PasswordResetCode;
+use App\Models\User;
+use App\Services\Sms\SmsGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RequestPasswordResetActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_el_codigo_asociado_a_la_cuenta_y_lo_envia(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+
+        $gateway = new class implements SmsGateway
+        {
+            public ?string $phone = null;
+
+            public ?string $message = null;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->phone = $phone;
+                $this->message = $message;
+            }
+        };
+
+        (new RequestPasswordResetAction($gateway))->handle('+573001234567');
+
+        $codigo = PasswordResetCode::query()->where('user_id', $usuario->id)->firstOrFail();
+        $this->assertSame(0, $codigo->attempts);
+        $this->assertTrue($codigo->expires_at->isFuture());
+        $this->assertSame('+573001234567', $gateway->phone);
+        $this->assertNotNull($gateway->message);
+    }
+
+    public function test_pedir_un_codigo_nuevo_reemplaza_el_hash_anterior(): void
+    {
+        $usuario = User::factory()->create(['phone' => '+573001234567']);
+        $gateway = new class implements SmsGateway
+        {
+            public function send(string $phone, string $message): void {}
+        };
+        $action = new RequestPasswordResetAction($gateway);
+
+        $action->handle('+573001234567');
+        $primerHash = PasswordResetCode::query()->where('user_id', $usuario->id)->firstOrFail()->code_hash;
+
+        $action->handle('+573001234567');
+        $segundoHash = PasswordResetCode::query()->where('user_id', $usuario->id)->firstOrFail()->code_hash;
+
+        $this->assertSame(1, PasswordResetCode::query()->count());
+        $this->assertNotSame($primerHash, $segundoHash);
+    }
+
+    /**
+     * El caso real que motiva esta suite: un celular sin cuenta no puede
+     * distinguirse desde afuera de uno con cuenta, así que no debe escribir
+     * ninguna fila ni intentar mandar nada.
+     */
+    public function test_un_celular_sin_cuenta_no_escribe_nada_ni_envia_nada(): void
+    {
+        $gateway = new class implements SmsGateway
+        {
+            public int $envios = 0;
+
+            public function send(string $phone, string $message): void
+            {
+                $this->envios++;
+            }
+        };
+
+        (new RequestPasswordResetAction($gateway))->handle('+573009999999');
+
+        $this->assertSame(0, PasswordResetCode::query()->count());
+        $this->assertSame(0, $gateway->envios);
+    }
+}


### PR DESCRIPTION
## Resumen
Agrega `POST /auth/password/forgot` y `POST /auth/password/reset` (ambos anónimos — quien los llama todavía no puede iniciar sesión).

- `POST /auth/password/forgot`: genera un código y lo manda por SMS al celular dado si tiene cuenta, pero **siempre responde 204** sin importar el resultado — distinguir los dos casos convertiría al endpoint en un oráculo de qué números están registrados, mismo problema que `LoginAction` ya resuelve para el email (incluido el hash de descarte contra un celular sin cuenta, para que la diferencia de tiempo tampoco delate cuál es cuál).
- `POST /auth/password/reset`: confirma el código (mismas reglas que la confirmación de celular de la historia #69: no vencido, intentos no agotados, hash coincide) y deja la cuenta autenticada de una vez, mismo formato que el login, para no obligar a volver a escribir la contraseña recién elegida. La contraseña nueva pasa por la misma política que el registro (`Password::defaults()`).

Se implementa por SMS y no por email: para la población a la que apunta la app —mayoritariamente indígena, con alfabetización limitada en español— revisar un correo es menos natural que recibir un código por SMS (decisión del dueño del producto).

Tabla propia (`password_reset_codes`) en vez de reusar `phone_verification_codes`: son dos flujos de negocio distintos (probar que el celular es propio vs. recuperar el acceso a la cuenta) aunque compartan estructura y el mismo `SmsGateway`/`NullSmsGateway`. Límite de tasa propio (`password-reset`, 3 cada 10 min por IP) para pedir el código, ya que cada acierto cuesta un SMS real apenas haya un proveedor conectado; `password-reset` no puede reusar `phone-verification` porque ese clasifica por usuario autenticado y este endpoint es anónimo.

## Plan de pruebas
- [x] `php artisan test` — 730/730 verdes
- [x] `vendor/bin/pint --test` — verde
- [x] `vendor/bin/phpstan analyse` — 0 errores
- [x] Verificado manualmente contra el servidor local corriendo de verdad: pedir el código, confirmarlo, y volver a iniciar sesión con la contraseña nueva

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)