### PR TITLE
feat(#86): tipos de acarreo de Motocarga con precio fijo editable

### DIFF
--- a/app/Actions/Fares/CreateCargoJobTypeAction.php
+++ b/app/Actions/Fares/CreateCargoJobTypeAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fares;
+
+use App\Models\CargoJobType;
+
+/**
+ * Crea un tipo de acarreo con su precio fijo (historia técnica #86).
+ */
+final class CreateCargoJobTypeAction
+{
+    public function handle(string $name, int $price): CargoJobType
+    {
+        return CargoJobType::create(['name' => $name, 'price' => $price]);
+    }
+}

--- a/app/Actions/Fares/DeleteCargoJobTypeAction.php
+++ b/app/Actions/Fares/DeleteCargoJobTypeAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fares;
+
+use App\Models\CargoJobType;
+
+/**
+ * Borra un tipo de acarreo del catálogo (historia técnica #86). Nada lo usa
+ * todavía —eso es #87—, así que no hay ningún uso que impedir.
+ */
+final class DeleteCargoJobTypeAction
+{
+    public function handle(CargoJobType $cargoJobType): void
+    {
+        $cargoJobType->delete();
+    }
+}

--- a/app/Actions/Fares/UpdateCargoJobTypePriceAction.php
+++ b/app/Actions/Fares/UpdateCargoJobTypePriceAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fares;
+
+use App\Models\CargoJobType;
+
+/**
+ * Ajusta el precio de un tipo de acarreo ya creado (historia técnica #86).
+ * Solo el precio es editable — el nombre identifica el tipo de trabajo y no
+ * tiene sentido de negocio para renombrarlo una vez que el admin ya lo usó.
+ */
+final class UpdateCargoJobTypePriceAction
+{
+    public function handle(CargoJobType $cargoJobType, int $price): CargoJobType
+    {
+        $cargoJobType->update(['price' => $price]);
+
+        return $cargoJobType;
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/CreateCargoJobTypeController.php
+++ b/app/Http/Controllers/Api/V1/Admin/CreateCargoJobTypeController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Actions\Fares\CreateCargoJobTypeAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\CreateCargoJobTypeRequest;
+use App\Http\Resources\CargoJobTypeResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * POST /api/v1/admin/cargo-job-types
+ *
+ * Crea un tipo de acarreo con su precio fijo (historia técnica #86).
+ */
+class CreateCargoJobTypeController extends Controller
+{
+    public function __invoke(
+        CreateCargoJobTypeRequest $request,
+        CreateCargoJobTypeAction $createCargoJobType,
+    ): JsonResponse {
+        $tipo = $createCargoJobType->handle($request->toName(), $request->toPrice());
+
+        return (new CargoJobTypeResource($tipo))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/DeleteCargoJobTypeController.php
+++ b/app/Http/Controllers/Api/V1/Admin/DeleteCargoJobTypeController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Actions\Fares\DeleteCargoJobTypeAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\DeleteCargoJobTypeRequest;
+use App\Models\CargoJobType;
+use Illuminate\Http\Response;
+
+/**
+ * DELETE /api/v1/admin/cargo-job-types/{cargoJobType}
+ *
+ * Borra un tipo de acarreo del catálogo (historia técnica #86). Responde
+ * 204 sin cuerpo, mismo criterio que borrar un sitio (#85).
+ */
+class DeleteCargoJobTypeController extends Controller
+{
+    public function __invoke(
+        DeleteCargoJobTypeRequest $request,
+        DeleteCargoJobTypeAction $deleteCargoJobType,
+        CargoJobType $cargoJobType,
+    ): Response {
+        $deleteCargoJobType->handle($cargoJobType);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/ListCargoJobTypesController.php
+++ b/app/Http/Controllers/Api/V1/Admin/ListCargoJobTypesController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ListCargoJobTypesRequest;
+use App\Http\Resources\CargoJobTypeResource;
+use App\Models\CargoJobType;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * GET /api/v1/admin/cargo-job-types
+ *
+ * Lista el catálogo de tipos de acarreo de Motocarga con su precio, para
+ * que el admin lo gestione desde el panel (historia técnica #86).
+ */
+class ListCargoJobTypesController extends Controller
+{
+    public function __invoke(ListCargoJobTypesRequest $request): AnonymousResourceCollection
+    {
+        $tipos = CargoJobType::query()->orderBy('name')->get();
+
+        return CargoJobTypeResource::collection($tipos);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/UpdateCargoJobTypeController.php
+++ b/app/Http/Controllers/Api/V1/Admin/UpdateCargoJobTypeController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Actions\Fares\UpdateCargoJobTypePriceAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UpdateCargoJobTypeRequest;
+use App\Http\Resources\CargoJobTypeResource;
+use App\Models\CargoJobType;
+
+/**
+ * PATCH /api/v1/admin/cargo-job-types/{cargoJobType}
+ *
+ * Ajusta el precio de un tipo de acarreo ya creado (historia técnica #86).
+ */
+class UpdateCargoJobTypeController extends Controller
+{
+    public function __invoke(
+        UpdateCargoJobTypeRequest $request,
+        UpdateCargoJobTypePriceAction $updatePrice,
+        CargoJobType $cargoJobType,
+    ): CargoJobTypeResource {
+        $tipo = $updatePrice->handle($cargoJobType, $request->toPrice());
+
+        return new CargoJobTypeResource($tipo);
+    }
+}

--- a/app/Http/Requests/Admin/CreateCargoJobTypeRequest.php
+++ b/app/Http/Requests/Admin/CreateCargoJobTypeRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\CargoJobType;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de POST /api/v1/admin/cargo-job-types — ver openapi.yaml.
+ */
+class CreateCargoJobTypeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create', CargoJobType::class) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            // `unique` acá y no solo el índice de la tabla: sin la regla, un
+            // nombre repetido escalaría a un 500 por violación de constraint
+            // en vez del 422 que el admin puede entender y corregir.
+            'name' => ['required', 'string', 'max:100', 'unique:cargo_job_types,name'],
+            // Entero en COP, nunca float — ver .claude/STANDARDS.md.
+            'price' => ['required', 'integer', 'min:0'],
+        ];
+    }
+
+    public function toName(): string
+    {
+        return $this->string('name')->toString();
+    }
+
+    public function toPrice(): int
+    {
+        return $this->integer('price');
+    }
+}

--- a/app/Http/Requests/Admin/DeleteCargoJobTypeRequest.php
+++ b/app/Http/Requests/Admin/DeleteCargoJobTypeRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\CargoJobType;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de DELETE /api/v1/admin/cargo-job-types/{cargoJobType} — ver
+ * openapi.yaml.
+ */
+class DeleteCargoJobTypeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('delete', $this->cargoJobType()) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function cargoJobType(): CargoJobType
+    {
+        /** @var CargoJobType */
+        return $this->route('cargoJobType');
+    }
+}

--- a/app/Http/Requests/Admin/ListCargoJobTypesRequest.php
+++ b/app/Http/Requests/Admin/ListCargoJobTypesRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\CargoJobType;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de GET /api/v1/admin/cargo-job-types — ver openapi.yaml.
+ */
+class ListCargoJobTypesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewAny', CargoJobType::class) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateCargoJobTypeRequest.php
+++ b/app/Http/Requests/Admin/UpdateCargoJobTypeRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\CargoJobType;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Entrada de PATCH /api/v1/admin/cargo-job-types/{cargoJobType} — ver
+ * openapi.yaml.
+ */
+class UpdateCargoJobTypeRequest extends FormRequest
+{
+    /**
+     * `{cargoJobType}` resuelve por binding implícito de la ruta: un id
+     * inexistente sale como 404 antes de que se evalúe `authorize()`.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('update', $this->cargoJobType()) ?? false;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'price' => ['required', 'integer', 'min:0'],
+        ];
+    }
+
+    public function cargoJobType(): CargoJobType
+    {
+        /** @var CargoJobType */
+        return $this->route('cargoJobType');
+    }
+
+    public function toPrice(): int
+    {
+        return $this->integer('price');
+    }
+}

--- a/app/Http/Resources/CargoJobTypeResource.php
+++ b/app/Http/Resources/CargoJobTypeResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\CargoJobType;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Serializa un tipo de acarreo (historia técnica #86). Lleva `id` — es por
+ * lo que se lo referencia en `/admin/cargo-job-types/{cargoJobType}`.
+ *
+ * @property-read CargoJobType $resource
+ */
+class CargoJobTypeResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'price' => $this->resource->price,
+        ];
+    }
+}

--- a/app/Models/CargoJobType.php
+++ b/app/Models/CargoJobType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Policies\CargoJobTypePolicy;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Un tipo de trabajo de Motocarga con precio fijo (historia técnica #86),
+ * ej. "Acarreo" ($20.000), "Escombro" ($40.000). A diferencia del precio de
+ * pasajero por sitio (`SiteFare`, #85), el precio de carga depende de qué se
+ * transporta y no de a dónde va — así lo describió el dueño del producto: el
+ * precio de un trasteo dentro del pueblo no depende del sitio de destino.
+ *
+ * @property string $name
+ * @property int $price
+ */
+#[Fillable(['name', 'price'])]
+#[UsePolicy(CargoJobTypePolicy::class)]
+class CargoJobType extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'price' => 'integer',
+        ];
+    }
+}

--- a/app/Policies/CargoJobTypePolicy.php
+++ b/app/Policies/CargoJobTypePolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\CargoJobType;
+use App\Models\User;
+
+/**
+ * Quién administra el catálogo de tipos de acarreo (historia técnica #86).
+ * Solo el rol `admin`, mismo criterio que `SitePolicy`.
+ */
+class CargoJobTypePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function update(User $user, CargoJobType $cargoJobType): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function delete(User $user, CargoJobType $cargoJobType): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/database/factories/CargoJobTypeFactory.php
+++ b/database/factories/CargoJobTypeFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\CargoJobType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CargoJobType>
+ */
+class CargoJobTypeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'price' => fake()->numberBetween(10, 40) * 1000,
+        ];
+    }
+}

--- a/database/migrations/2026_09_06_185903_create_cargo_job_types_table.php
+++ b/database/migrations/2026_09_06_185903_create_cargo_job_types_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cargo_job_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100)->unique();
+            // Entero en COP (sin subunidad), nunca float — ver
+            // .claude/STANDARDS.md ("Dinero: enteros, nunca float").
+            $table->unsignedInteger('price');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cargo_job_types');
+    }
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1754,6 +1754,302 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 message: Too Many Attempts.
+  /admin/cargo-job-types:
+    get:
+      tags:
+        - Fares
+      operationId: listCargoJobTypes
+      summary: Listar el catálogo de tipos de acarreo
+      description: >-
+        Lista el catálogo de tipos de trabajo de Motocarga (ej. "Acarreo",
+        "Escombro") con su precio fijo, para que un administrador lo
+        gestione desde el panel (historia técnica #86). A diferencia del
+        precio de pasajero por sitio (#85), este precio depende de qué se
+        transporta y no de a dónde va.
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tipos de acarreo, ordenados por nombre.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CargoJobType"
+              example:
+                data:
+                  - id: 1
+                    name: Acarreo
+                    price: 20000
+                  - id: 2
+                    name: Escombro
+                    price: 40000
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+    post:
+      tags:
+        - Fares
+      operationId: createCargoJobType
+      summary: Crear un tipo de acarreo
+      description: >-
+        Crea un tipo de trabajo de Motocarga con su precio fijo (historia
+        técnica #86).
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - price
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                  example: Trasteo
+                price:
+                  type: integer
+                  minimum: 0
+                  example: 20000
+            example:
+              name: Trasteo
+              price: 20000
+      responses:
+        "201":
+          description: Tipo de acarreo creado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/CargoJobType"
+              example:
+                data:
+                  id: 3
+                  name: Trasteo
+                  price: 20000
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "422":
+          description: Falta un campo requerido, ya existe un tipo con ese nombre, o el precio es negativo.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The name has already been taken.
+                errors:
+                  name:
+                    - The name has already been taken.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+  /admin/cargo-job-types/{cargoJobType}:
+    patch:
+      tags:
+        - Fares
+      operationId: updateCargoJobType
+      summary: Ajustar el precio de un tipo de acarreo
+      description: >-
+        Ajusta el precio de un tipo de acarreo ya creado (historia técnica
+        #86). Solo el precio es editable: el nombre identifica el tipo de
+        trabajo.
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: cargoJobType
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - price
+              properties:
+                price:
+                  type: integer
+                  minimum: 0
+                  example: 25000
+            example:
+              price: 25000
+      responses:
+        "200":
+          description: Tipo de acarreo con el precio ya actualizado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/CargoJobType"
+              example:
+                data:
+                  id: 1
+                  name: Acarreo
+                  price: 25000
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe un tipo de acarreo con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No query results for model [App\\Models\\CargoJobType] 1
+        "422":
+          description: Falta el precio, o es negativo.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: The price field must be at least 0.
+                errors:
+                  price:
+                    - The price field must be at least 0.
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
+    delete:
+      tags:
+        - Fares
+      operationId: deleteCargoJobType
+      summary: Borrar un tipo de acarreo
+      description: >-
+        Borra un tipo de acarreo del catálogo (historia técnica #86).
+
+        Requiere un token vigente y rol `admin`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: cargoJobType
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "204":
+          description: Tipo de acarreo borrado. Sin cuerpo.
+        "401":
+          description: Falta el access token, es ilegible o ya venció.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Unauthenticated.
+        "403":
+          description: La cuenta autenticada no es administrador.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: This action is unauthorized.
+        "404":
+          description: No existe un tipo de acarreo con ese id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: No query results for model [App\\Models\\CargoJobType] 1
+        "429":
+          description: Se superó el límite general de la API para este usuario.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: Too Many Attempts.
   /me/availability:
     patch:
       tags:
@@ -3623,6 +3919,27 @@ components:
           type: string
           format: date-time
           example: "2026-09-04T15:00:00.000000Z"
+    CargoJobType:
+      type: object
+      description: >-
+        Un tipo de trabajo de Motocarga con precio fijo, ej. "Acarreo",
+        "Escombro" (historia técnica #86). A diferencia del precio de
+        pasajero por sitio (historia #85), este precio depende de qué se
+        transporta y no de a dónde va.
+      required:
+        - id
+        - name
+        - price
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Acarreo
+        price:
+          type: integer
+          example: 20000
     LoginRequest:
       type: object
       description: >-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,13 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Admin\ApproveDriverDocumentController;
+use App\Http\Controllers\Api\V1\Admin\CreateCargoJobTypeController;
+use App\Http\Controllers\Api\V1\Admin\DeleteCargoJobTypeController;
+use App\Http\Controllers\Api\V1\Admin\ListCargoJobTypesController;
 use App\Http\Controllers\Api\V1\Admin\ListDriverDocumentsController;
 use App\Http\Controllers\Api\V1\Admin\RejectDriverDocumentController;
 use App\Http\Controllers\Api\V1\Admin\ShowDriverDocumentFileController;
+use App\Http\Controllers\Api\V1\Admin\UpdateCargoJobTypeController;
 use App\Http\Controllers\Api\V1\Auth\ConfirmPasswordResetController;
 use App\Http\Controllers\Api\V1\Auth\ConfirmPhoneVerificationController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
@@ -210,6 +214,28 @@ Route::prefix('v1')->group(function () {
         Route::middleware('auth:api')
             ->post('documents/{document}/reject', RejectDriverDocumentController::class)
             ->name('documents.reject');
+
+        // Catálogo de tipos de acarreo de Motocarga (historia técnica #86):
+        // a diferencia del precio de pasajero por sitio, este precio
+        // depende de qué se transporta (ej. "Trasteo", "Escombro") y no de
+        // a dónde va — así lo describió el dueño del producto. Mismo
+        // criterio de autorización que sites (CargoJobTypePolicy, solo
+        // `admin`).
+        Route::middleware('auth:api')
+            ->get('cargo-job-types', ListCargoJobTypesController::class)
+            ->name('cargo-job-types.index');
+
+        Route::middleware('auth:api')
+            ->post('cargo-job-types', CreateCargoJobTypeController::class)
+            ->name('cargo-job-types.store');
+
+        Route::middleware('auth:api')
+            ->patch('cargo-job-types/{cargoJobType}', UpdateCargoJobTypeController::class)
+            ->name('cargo-job-types.update');
+
+        Route::middleware('auth:api')
+            ->delete('cargo-job-types/{cargoJobType}', DeleteCargoJobTypeController::class)
+            ->name('cargo-job-types.destroy');
     });
 
     // Historial de viajes de la cuenta autenticada: los que pidió, si es

--- a/tests/Feature/Admin/CreateCargoJobTypeTest.php
+++ b/tests/Feature/Admin/CreateCargoJobTypeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\CargoJobType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de POST /api/v1/admin/cargo-job-types — ver openapi.yaml.
+ */
+class CreateCargoJobTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crea_un_tipo_de_acarreo(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson('/api/v1/admin/cargo-job-types', ['name' => 'Trasteo', 'price' => 20000])
+            ->assertCreated()
+            ->assertJsonPath('data.name', 'Trasteo')
+            ->assertJsonPath('data.price', 20000);
+
+        $this->assertDatabaseHas('cargo_job_types', ['name' => 'Trasteo', 'price' => 20000]);
+    }
+
+    public function test_rechaza_un_nombre_repetido(): void
+    {
+        CargoJobType::factory()->create(['name' => 'Trasteo']);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson('/api/v1/admin/cargo-job-types', ['name' => 'Trasteo', 'price' => 20000])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('name');
+    }
+
+    public function test_rechaza_un_precio_negativo(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->postJson('/api/v1/admin/cargo-job-types', ['name' => 'Trasteo', 'price' => -1])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('price');
+    }
+
+    public function test_un_pasajero_no_puede_crear_tipos_de_acarreo(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->postJson('/api/v1/admin/cargo-job-types', ['name' => 'Trasteo', 'price' => 20000])
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_creacion_sin_token(): void
+    {
+        $this->postJson('/api/v1/admin/cargo-job-types', ['name' => 'Trasteo', 'price' => 20000])
+            ->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Admin/DeleteCargoJobTypeTest.php
+++ b/tests/Feature/Admin/DeleteCargoJobTypeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\CargoJobType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de DELETE /api/v1/admin/cargo-job-types/{cargoJobType} — ver
+ * openapi.yaml.
+ */
+class DeleteCargoJobTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_borra_un_tipo_de_acarreo(): void
+    {
+        $tipo = CargoJobType::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->deleteJson("/api/v1/admin/cargo-job-types/{$tipo->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('cargo_job_types', ['id' => $tipo->id]);
+    }
+
+    public function test_responde_404_si_el_tipo_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->deleteJson('/api/v1/admin/cargo-job-types/999999')
+            ->assertNotFound();
+    }
+
+    public function test_un_pasajero_no_puede_borrar_tipos_de_acarreo(): void
+    {
+        $tipo = CargoJobType::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->deleteJson("/api/v1/admin/cargo-job-types/{$tipo->id}")
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_el_borrado_sin_token(): void
+    {
+        $tipo = CargoJobType::factory()->create();
+
+        $this->deleteJson("/api/v1/admin/cargo-job-types/{$tipo->id}")->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Admin/ListCargoJobTypesTest.php
+++ b/tests/Feature/Admin/ListCargoJobTypesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\CargoJobType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de GET /api/v1/admin/cargo-job-types — ver openapi.yaml.
+ */
+class ListCargoJobTypesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lista_los_tipos_de_acarreo(): void
+    {
+        CargoJobType::factory()->create(['name' => 'Acarreo', 'price' => 20000]);
+        CargoJobType::factory()->create(['name' => 'Escombro', 'price' => 40000]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->getJson('/api/v1/admin/cargo-job-types')
+            ->assertOk()
+            ->assertJsonPath('data.0.name', 'Acarreo')
+            ->assertJsonPath('data.0.price', 20000)
+            ->assertJsonPath('data.1.name', 'Escombro')
+            ->assertJsonPath('data.1.price', 40000);
+    }
+
+    public function test_responde_lista_vacia_si_no_hay_tipos(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->getJson('/api/v1/admin/cargo-job-types')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_un_pasajero_no_puede_listar_tipos_de_acarreo(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->getJson('/api/v1/admin/cargo-job-types')
+            ->assertForbidden();
+    }
+
+    public function test_rechaza_la_lista_sin_token(): void
+    {
+        $this->getJson('/api/v1/admin/cargo-job-types')->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Admin/UpdateCargoJobTypeTest.php
+++ b/tests/Feature/Admin/UpdateCargoJobTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\CargoJobType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+/**
+ * Contrato de PATCH /api/v1/admin/cargo-job-types/{cargoJobType} — ver
+ * openapi.yaml.
+ */
+class UpdateCargoJobTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_actualiza_el_precio(): void
+    {
+        $tipo = CargoJobType::factory()->create(['name' => 'Acarreo', 'price' => 20000]);
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->patchJson("/api/v1/admin/cargo-job-types/{$tipo->id}", ['price' => 25000])
+            ->assertOk()
+            ->assertJsonPath('data.price', 25000)
+            ->assertJsonPath('data.name', 'Acarreo');
+
+        $this->assertDatabaseHas('cargo_job_types', ['id' => $tipo->id, 'price' => 25000]);
+    }
+
+    public function test_rechaza_un_precio_negativo(): void
+    {
+        $tipo = CargoJobType::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->patchJson("/api/v1/admin/cargo-job-types/{$tipo->id}", ['price' => -1])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('price');
+    }
+
+    public function test_responde_404_si_el_tipo_no_existe(): void
+    {
+        $this->withToken(JWTAuth::fromUser(User::factory()->admin()->create()))
+            ->patchJson('/api/v1/admin/cargo-job-types/999999', ['price' => 25000])
+            ->assertNotFound();
+    }
+
+    public function test_un_pasajero_no_puede_editar_tipos_de_acarreo(): void
+    {
+        $tipo = CargoJobType::factory()->create();
+
+        $this->withToken(JWTAuth::fromUser(User::factory()->create()))
+            ->patchJson("/api/v1/admin/cargo-job-types/{$tipo->id}", ['price' => 25000])
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Resumen
- Catalogo de tipos de trabajo de Motocarga (ej. "Acarreo" $20.000, "Escombro" $40.000) con precio fijo, administrable desde el panel admin. A diferencia del precio de pasajero por sitio (#85), este precio depende de que se transporta y no de a donde va, asi que es un catalogo independiente sin atarlo a un sitio.
- Endpoints nuevos bajo `/admin`, solo rol `admin` (`CargoJobTypePolicy`): `GET/POST /admin/cargo-job-types`, `PATCH/DELETE /admin/cargo-job-types/{cargoJobType}`.
- Contrato especificado primero en `openapi.yaml` (SDD).
- Segunda de tres historias relacionadas: #85 (sitios y precio de pasajero, PR #89) y #87 (usar estos precios al pedir/estimar un viaje real, todavia sin implementar).

Closes #86

## Test plan
- [x] `php artisan test` — 747/747 (730 de main + 17 nuevos)
- [x] `./vendor/bin/pint --test`
- [x] `./vendor/bin/phpstan analyse` (nivel 5, sin errores)
- [ ] `scripts/static_conformance.py` / `scripts/dynamic_conformance.py` — no pude correrlos en este entorno local (no hay Python instalado). Deberian correr en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)